### PR TITLE
fix: Trip Planner with API key providers shows wrong config steps

### DIFF
--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -158,7 +158,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     errors[CONF_TRAFIKLAB_API_KEY] = "trafiklab_api_key_required"
                 else:
                     self._api_key = api_key
-                    return await self.async_step_stop_search()
+                    return await self._async_next_step_after_api_key()
             elif self._provider == PROVIDER_NTA_IE:
                 api_key = user_input.get(CONF_NTA_API_KEY, "").strip()
                 api_key_secondary = user_input.get(CONF_NTA_API_KEY_SECONDARY, "").strip()
@@ -167,14 +167,14 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 else:
                     self._api_key = api_key
                     self._api_key_secondary = api_key_secondary if api_key_secondary else None
-                    return await self.async_step_stop_search()
+                    return await self._async_next_step_after_api_key()
             elif self._provider == PROVIDER_RMV:
                 api_key = user_input.get(CONF_RMV_API_KEY, "").strip()
                 if not api_key:
                     errors[CONF_RMV_API_KEY] = "rmv_api_key_required"
                 else:
                     self._api_key = api_key
-                    return await self.async_step_stop_search()
+                    return await self._async_next_step_after_api_key()
 
         # Show appropriate schema based on provider
         provider_instance = get_provider(self._provider, self.hass)
@@ -207,6 +207,13 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             errors=errors,
             description_placeholders={"info": description},
         )
+
+    async def _async_next_step_after_api_key(self) -> FlowResult:
+        """Route to trip search or stop search depending on entry_type."""
+        if self._entry_type == "trip":
+            self._trip_search_phase = "origin"
+            return await self.async_step_trip_search()
+        return await self.async_step_stop_search()
 
     async def async_step_stop_search(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         """Handle combined stop search and selection step.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,9 +10,11 @@ from homeassistant.data_entry_flow import FlowResultType
 from custom_components.openpublictransport.const import (
     CONF_DEPARTURES,
     CONF_PROVIDER,
+    CONF_RMV_API_KEY,
     CONF_SCAN_INTERVAL,
     CONF_TRANSPORTATION_TYPES,
     DOMAIN,
+    PROVIDER_RMV,
     PROVIDER_VRR,
 )
 
@@ -208,6 +210,52 @@ async def test_options_flow(hass: HomeAssistant, mock_config_entry):
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_DEPARTURES] == 15
     assert result["data"][CONF_SCAN_INTERVAL] == 120
+
+
+async def test_api_key_provider_trip_routes_to_trip_search(hass: HomeAssistant):
+    """After entering an API key with entry_type=trip, flow must go to trip_search (origin phase)."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+
+    # Select Trip Planner + RMV
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"entry_type": "trip", CONF_PROVIDER: PROVIDER_RMV},
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "api_key"
+
+    # Submit a valid RMV API key
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_RMV_API_KEY: "test-api-key-123"},
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "trip_search"
+
+
+async def test_api_key_provider_departures_routes_to_stop_search(hass: HomeAssistant):
+    """After entering an API key with entry_type=departures, flow must still go to stop_search."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+
+    # Select Departure Monitor + RMV
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"entry_type": "departures", CONF_PROVIDER: PROVIDER_RMV},
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "api_key"
+
+    # Submit a valid RMV API key
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_RMV_API_KEY: "test-api-key-123"},
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "stop_search"
 
 
 def test_parse_stopfinder_response():


### PR DESCRIPTION
## Problem

When configuring **Trip Planner + RMV** (or any other API-key-required provider), the flow incorrectly shows the Departure Monitor configuration steps (single stop search) instead of the Trip Planner steps (origin → destination search).

**Root cause:** In `async_step_api_key`, after a valid API key is entered, the flow always redirects to `async_step_stop_search()` — completely ignoring whether the user selected *Trip Planner* or *Departure Monitor* as the entry type.

## Fix

Added a private helper `_async_next_step_after_api_key()` that checks `self._entry_type` and routes to:
- `async_step_trip_search()` (with `_trip_search_phase = "origin"`) when entry type is `"trip"`
- `async_step_stop_search()` otherwise

All three API-key providers (Trafiklab, NTA, RMV) now use this helper instead of hardcoding the stop-search redirect.

Fixes #1