### PR TITLE
feat: VBN provider (OTP + TRIAS) with new OTPBaseProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Code Quality](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/lint.yaml/badge.svg)](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/lint.yaml)
 [![Tests](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/tests.yaml/badge.svg)](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/tests.yaml)
 
-Real-time public transport departures for Home Assistant — 24 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
+Real-time public transport departures for Home Assistant — 25 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
 
 **Website**: [openpublictransport.net](https://openpublictransport.net) | **Docs**: [docs.openpublictransport.net](https://docs.openpublictransport.net/)
 
@@ -21,39 +21,40 @@ Real-time public transport departures for Home Assistant — 24 providers across
 > The domain changed from `vrr` to `openpublictransport` — entity IDs and services have new names.
 > See the [Migration Guide](https://docs.openpublictransport.net/migration/) for step-by-step instructions.
 
-## Supported Providers (24)
+## Supported Providers (25)
 
 | Provider | Region | API Key |
 |----------|--------|---------|
-| **VRR** | Rhein-Ruhr (NRW) | No |
-| **KVV** | Karlsruhe | No |
-| **HVV** | Hamburg | No |
-| **BVG** | Berlin / Brandenburg | No |
-| **MVV** | Munich | No |
-| **VVS** | Stuttgart | No |
-| **VGN** | Nuremberg | No |
-| **VAG** | Freiburg | No |
-| **RMV** | Frankfurt | Yes (free) |
-| **VBN** | Bremen / Niedersachsen | Yes (free) |
-| **VRN** | Rhein-Neckar | No |
-| **VVO** | Dresden | No |
-| **DING** | Ulm | No |
 | **AVV** | Augsburg | No |
-| **RVV** | Regensburg | No |
-| **BSVG** | Braunschweig | No |
-| **NWL** | Westfalen-Lippe | No |
-| **NVBW** | Baden-Württemberg | No |
 | **BEG** | Bavaria | No |
-| **SBB** | Switzerland (nationwide) | No |
-| **ÖBB** | Austria (nationwide) | No |
-| **Trafiklab** | Sweden (nationwide) | Yes (free) |
+| **BSVG** | Braunschweig | No |
+| **BVG** | Berlin / Brandenburg | No |
+| **DB** | Germany (nationwide, community API) | No |
+| **DING** | Ulm | No |
+| **HVV** | Hamburg | No |
+| **KVV** | Karlsruhe | No |
+| **MVV** | Munich | No |
 | **NTA** | Ireland (nationwide) | Yes (free) |
+| **NVBW** | Baden-Württemberg | No |
+| **NWL** | Westfalen-Lippe | No |
+| **ÖBB** | Austria (nationwide) | No |
+| **RMV** | Frankfurt / Rhein-Main | Yes (free) |
+| **RVV** | Regensburg | No |
+| **SBB** | Switzerland (nationwide) | No |
+| **Trafiklab** | Sweden (nationwide) | Yes (free) |
 | **Transitous** | Worldwide (community) | No |
+| **VAG** | Freiburg | No |
+| **VBN** | Bremen / Niedersachsen | Yes (free) |
+| **VGN** | Nuremberg | No |
+| **VRN** | Rhein-Neckar | No |
+| **VRR** | Rhein-Ruhr (NRW) | No |
+| **VVO** | Dresden | No |
+| **VVS** | Stuttgart | No |
 
 ## Features
 
 - **Real-time departures** with delay tracking, platform changes, and disruption notices
-- **24 transit providers** — most require no API key
+- **25 transit providers** — most require no API key
 - **Trip planner** — A-to-B routes with transfer risk assessment
 - **7 entity types** — sensor, binary sensor, calendar, event, camera, trip sensor, statistics
 - **4 services** — refresh_departures, plan_trip, check_delays, announce_departure (TTS)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Code Quality](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/lint.yaml/badge.svg)](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/lint.yaml)
 [![Tests](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/tests.yaml/badge.svg)](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/tests.yaml)
 
-Real-time public transport departures for Home Assistant — 23 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
+Real-time public transport departures for Home Assistant — 24 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
 
 **Website**: [openpublictransport.net](https://openpublictransport.net) | **Docs**: [docs.openpublictransport.net](https://docs.openpublictransport.net/)
 
@@ -21,7 +21,7 @@ Real-time public transport departures for Home Assistant — 23 providers across
 > The domain changed from `vrr` to `openpublictransport` — entity IDs and services have new names.
 > See the [Migration Guide](https://docs.openpublictransport.net/migration/) for step-by-step instructions.
 
-## Supported Providers (23)
+## Supported Providers (24)
 
 | Provider | Region | API Key |
 |----------|--------|---------|
@@ -34,6 +34,7 @@ Real-time public transport departures for Home Assistant — 23 providers across
 | **VGN** | Nuremberg | No |
 | **VAG** | Freiburg | No |
 | **RMV** | Frankfurt | Yes (free) |
+| **VBN** | Bremen / Niedersachsen | Yes (free) |
 | **VRN** | Rhein-Neckar | No |
 | **VVO** | Dresden | No |
 | **DING** | Ulm | No |
@@ -52,7 +53,7 @@ Real-time public transport departures for Home Assistant — 23 providers across
 ## Features
 
 - **Real-time departures** with delay tracking, platform changes, and disruption notices
-- **23 transit providers** — most require no API key
+- **24 transit providers** — most require no API key
 - **Trip planner** — A-to-B routes with transfer risk assessment
 - **7 entity types** — sensor, binary sensor, calendar, event, camera, trip sensor, statistics
 - **4 services** — refresh_departures, plan_trip, check_delays, announce_departure (TTS)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Code Quality](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/lint.yaml/badge.svg)](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/lint.yaml)
 [![Tests](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/tests.yaml/badge.svg)](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/tests.yaml)
 
-Real-time public transport departures for Home Assistant — 25 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
+Real-time public transport departures for Home Assistant — 26 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
 
 **Website**: [openpublictransport.net](https://openpublictransport.net) | **Docs**: [docs.openpublictransport.net](https://docs.openpublictransport.net/)
 
@@ -21,7 +21,7 @@ Real-time public transport departures for Home Assistant — 25 providers across
 > The domain changed from `vrr` to `openpublictransport` — entity IDs and services have new names.
 > See the [Migration Guide](https://docs.openpublictransport.net/migration/) for step-by-step instructions.
 
-## Supported Providers (25)
+## Supported Providers (26)
 
 | Provider | Region | API Key |
 |----------|--------|---------|
@@ -44,7 +44,8 @@ Real-time public transport departures for Home Assistant — 25 providers across
 | **Trafiklab** | Sweden (nationwide) | Yes (free) |
 | **Transitous** | Worldwide (community) | No |
 | **VAG** | Freiburg | No |
-| **VBN** | Bremen / Niedersachsen | Yes (free) |
+| **VBN (OTP)** | Bremen / Niedersachsen | Yes (free) |
+| **VBN (TRIAS)** | Bremen / Niedersachsen | Yes (free) |
 | **VGN** | Nuremberg | No |
 | **VRN** | Rhein-Neckar | No |
 | **VRR** | Rhein-Ruhr (NRW) | No |
@@ -54,7 +55,7 @@ Real-time public transport departures for Home Assistant — 25 providers across
 ## Features
 
 - **Real-time departures** with delay tracking, platform changes, and disruption notices
-- **25 transit providers** — most require no API key
+- **26 transit providers** — most require no API key
 - **Trip planner** — A-to-B routes with transfer risk assessment
 - **7 entity types** — sensor, binary sensor, calendar, event, camera, trip sensor, statistics
 - **4 services** — refresh_departures, plan_trip, check_delays, announce_departure (TTS)

--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -15,12 +15,15 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_STATION_ID,
     CONF_TRAFIKLAB_API_KEY,
+    CONF_VBN_API_KEY,
     DEFAULT_DEPARTURES,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     PROVIDER_NTA_IE,
     PROVIDER_RMV,
     PROVIDER_TRAFIKLAB_SE,
+    PROVIDER_VBN_OTP,
+    PROVIDER_VBN_TRIAS,
 )
 from .sensor import PublicTransportDataUpdateCoordinator
 from .trip import async_plan_trip
@@ -100,6 +103,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     trafiklab_api_key = entry.data.get(CONF_TRAFIKLAB_API_KEY)  # For Trafiklab
     nta_api_key = entry.data.get(CONF_NTA_API_KEY)  # For NTA
     rmv_api_key = entry.data.get(CONF_RMV_API_KEY)  # For RMV
+    vbn_api_key = entry.data.get(CONF_VBN_API_KEY)  # For VBN (OTP + TRIAS)
 
     # Use appropriate API key based on provider
     api_key = None
@@ -109,6 +113,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         api_key = nta_api_key
     elif provider == PROVIDER_RMV:
         api_key = rmv_api_key
+    elif provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
+        api_key = vbn_api_key
 
     departures = entry.options.get(CONF_DEPARTURES, entry.data.get(CONF_DEPARTURES, DEFAULT_DEPARTURES))
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -78,31 +78,31 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         """Return alphabetically sorted provider dropdown."""
         options = [
             {"value": "avv_augsburg", "label": "AVV — Augsburg"},
-            {"value": "beg",          "label": "BEG — Bayern"},
-            {"value": "bsvg",         "label": "BSVG — Braunschweig"},
-            {"value": "bvg",          "label": "BVG — Berlin / Brandenburg"},
-            {"value": "db",           "label": "DB — Deutsche Bahn (Community API)"},
-            {"value": "ding",         "label": "DING — Ulm / Donau-Iller"},
-            {"value": "hvv",          "label": "HVV — Hamburg"},
-            {"value": "kvv",          "label": "KVV — Karlsruhe"},
-            {"value": "mvv",          "label": "MVV — München"},
-            {"value": "nta_ie",       "label": "NTA — Irland (API Key)"},
-            {"value": "nvbw",         "label": "NVBW — Baden-Württemberg"},
-            {"value": "nwl",          "label": "NWL — Westfalen-Lippe"},
-            {"value": "oebb",         "label": "ÖBB — Österreich"},
-            {"value": "rmv",          "label": "RMV — Frankfurt / Rhein-Main (API Key)"},
-            {"value": "rvv",          "label": "RVV — Regensburg"},
-            {"value": "sbb",          "label": "SBB — Schweiz"},
+            {"value": "beg", "label": "BEG — Bayern"},
+            {"value": "bsvg", "label": "BSVG — Braunschweig"},
+            {"value": "bvg", "label": "BVG — Berlin / Brandenburg"},
+            {"value": "db", "label": "DB — Deutsche Bahn (Community API)"},
+            {"value": "ding", "label": "DING — Ulm / Donau-Iller"},
+            {"value": "hvv", "label": "HVV — Hamburg"},
+            {"value": "kvv", "label": "KVV — Karlsruhe"},
+            {"value": "mvv", "label": "MVV — München"},
+            {"value": "nta_ie", "label": "NTA — Irland (API Key)"},
+            {"value": "nvbw", "label": "NVBW — Baden-Württemberg"},
+            {"value": "nwl", "label": "NWL — Westfalen-Lippe"},
+            {"value": "oebb", "label": "ÖBB — Österreich"},
+            {"value": "rmv", "label": "RMV — Frankfurt / Rhein-Main (API Key)"},
+            {"value": "rvv", "label": "RVV — Regensburg"},
+            {"value": "sbb", "label": "SBB — Schweiz"},
             {"value": "trafiklab_se", "label": "Trafiklab — Schweden (API Key)"},
-            {"value": "transitous",   "label": "Transitous — Weltweit (Community, Beta)"},
-            {"value": "vagfr",        "label": "VAG — Freiburg"},
-            {"value": "vbn_otp",      "label": "VBN — Bremen / Niedersachsen — OTP (API Key)"},
-            {"value": "vbn_trias",    "label": "VBN — Bremen / Niedersachsen — TRIAS (API Key)"},
-            {"value": "vgn",          "label": "VGN — Nürnberg"},
-            {"value": "vrn",          "label": "VRN — Rhein-Neckar"},
-            {"value": "vrr",          "label": "VRR — Rhein-Ruhr (NRW)"},
-            {"value": "vvo",          "label": "VVO — Dresden"},
-            {"value": "vvs",          "label": "VVS — Stuttgart"},
+            {"value": "transitous", "label": "Transitous — Weltweit (Community, Beta)"},
+            {"value": "vagfr", "label": "VAG — Freiburg"},
+            {"value": "vbn_otp", "label": "VBN — Bremen / Niedersachsen — OTP (API Key)"},
+            {"value": "vbn_trias", "label": "VBN — Bremen / Niedersachsen — TRIAS (API Key)"},
+            {"value": "vgn", "label": "VGN — Nürnberg"},
+            {"value": "vrn", "label": "VRN — Rhein-Neckar"},
+            {"value": "vrr", "label": "VRR — Rhein-Ruhr (NRW)"},
+            {"value": "vvo", "label": "VVO — Dresden"},
+            {"value": "vvs", "label": "VVS — Stuttgart"},
         ]
         return SelectSelector(SelectSelectorConfig(options=options, mode=SelectSelectorMode.DROPDOWN))
 
@@ -235,7 +235,10 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         together with the search field so the user can refine or select.
         """
         # Validate API key for providers that need it
-        if self._provider in (PROVIDER_TRAFIKLAB_SE, PROVIDER_RMV, PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS) and not self._api_key:
+        if (
+            self._provider in (PROVIDER_TRAFIKLAB_SE, PROVIDER_RMV, PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS)
+            and not self._api_key
+        ):
             return await self.async_step_api_key()
         if self._provider == PROVIDER_NTA_IE and not self._api_key:
             return self.async_show_form(

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig, SelectSelectorMode
 
 from .const import (
     CONF_DELAY_THRESHOLD,
@@ -71,40 +72,37 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         self._search_cache: Dict[str, Dict[str, Any]] = {}
         self._cache_ttl: int = 300  # Cache TTL in seconds (5 minutes)
 
-    def _get_provider_schema(self) -> vol.Schema:
-        """Get the provider selection schema with descriptive names."""
-        provider_options = {
-            "vrr": "VRR — Rhein-Ruhr (NRW)",
-            "kvv": "KVV — Karlsruhe",
-            "hvv": "HVV — Hamburg",
-            "bvg": "BVG — Berlin / Brandenburg",
-            "mvv": "MVV — München",
-            "vvs": "VVS — Stuttgart",
-            "vgn": "VGN — Nürnberg",
-            "vagfr": "VAG — Freiburg",
-            "rmv": "RMV — Frankfurt / Rhein-Main (API Key)",
-            "trafiklab_se": "Trafiklab — Schweden (API Key)",
-            "nta_ie": "NTA — Irland (API Key)",
-            "sbb": "SBB — Schweiz",
-            "oebb": "ÖBB — Österreich",
-            "transitous": "Transitous — Weltweit (Community, Beta)",
-            "db": "DB — Deutsche Bahn (Community API)",
-            "vrn": "VRN — Rhein-Neckar",
-            "vvo": "VVO — Dresden",
-            "ding": "DING — Ulm / Donau-Iller",
-            "avv_augsburg": "AVV — Augsburg",
-            "rvv": "RVV — Regensburg",
-            "bsvg": "BSVG — Braunschweig",
-            "nwl": "NWL — Westfalen-Lippe",
-            "nvbw": "NVBW — Baden-Württemberg",
-            "beg": "BEG — Bayern",
-            "vbn": "VBN — Bremen / Niedersachsen (API Key)",
-        }
-        return vol.Schema(
-            {
-                vol.Required(CONF_PROVIDER, default=PROVIDER_VRR): vol.In(provider_options),
-            }
-        )
+    @staticmethod
+    def _provider_selector() -> SelectSelector:
+        """Return a searchable, alphabetically sorted provider dropdown."""
+        options = [
+            {"value": "avv_augsburg", "label": "AVV — Augsburg"},
+            {"value": "beg",          "label": "BEG — Bayern"},
+            {"value": "bsvg",         "label": "BSVG — Braunschweig"},
+            {"value": "bvg",          "label": "BVG — Berlin / Brandenburg"},
+            {"value": "db",           "label": "DB — Deutsche Bahn (Community API)"},
+            {"value": "ding",         "label": "DING — Ulm / Donau-Iller"},
+            {"value": "hvv",          "label": "HVV — Hamburg"},
+            {"value": "kvv",          "label": "KVV — Karlsruhe"},
+            {"value": "mvv",          "label": "MVV — München"},
+            {"value": "nta_ie",       "label": "NTA — Irland (API Key)"},
+            {"value": "nvbw",         "label": "NVBW — Baden-Württemberg"},
+            {"value": "nwl",          "label": "NWL — Westfalen-Lippe"},
+            {"value": "oebb",         "label": "ÖBB — Österreich"},
+            {"value": "rmv",          "label": "RMV — Frankfurt / Rhein-Main (API Key)"},
+            {"value": "rvv",          "label": "RVV — Regensburg"},
+            {"value": "sbb",          "label": "SBB — Schweiz"},
+            {"value": "trafiklab_se", "label": "Trafiklab — Schweden (API Key)"},
+            {"value": "transitous",   "label": "Transitous — Weltweit (Community, Beta)"},
+            {"value": "vagfr",        "label": "VAG — Freiburg"},
+            {"value": "vbn",          "label": "VBN — Bremen / Niedersachsen (API Key)"},
+            {"value": "vgn",          "label": "VGN — Nürnberg"},
+            {"value": "vrn",          "label": "VRN — Rhein-Neckar"},
+            {"value": "vrr",          "label": "VRR — Rhein-Ruhr (NRW)"},
+            {"value": "vvo",          "label": "VVO — Dresden"},
+            {"value": "vvs",          "label": "VVS — Stuttgart"},
+        ]
+        return SelectSelector(SelectSelectorConfig(options=options, mode=SelectSelectorMode.DROPDOWN))
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         """Handle the initial step - select entry type and provider."""
@@ -132,14 +130,11 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             "trip": "Verbindungssuche / Trip Planner (A → B)",
             "multi_stop": "Multi-Stop / Mehrere Haltestellen kombinieren",
         }
-        provider_options = (
-            self._get_provider_schema().schema[vol.Required(CONF_PROVIDER, default=PROVIDER_VRR)].container
-        )
 
         schema = vol.Schema(
             {
                 vol.Required("entry_type", default="departures"): vol.In(entry_type_options),
-                vol.Required(CONF_PROVIDER, default=PROVIDER_VRR): vol.In(provider_options),
+                vol.Required(CONF_PROVIDER, default=PROVIDER_VRR): self._provider_selector(),
             }
         )
 

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -42,7 +42,8 @@ from .const import (
     PROVIDER_NTA_IE,
     PROVIDER_RMV,
     PROVIDER_TRAFIKLAB_SE,
-    PROVIDER_VBN,
+    PROVIDER_VBN_OTP,
+    PROVIDER_VBN_TRIAS,
     PROVIDER_VRR,
     TRANSPORTATION_TYPES,
 )
@@ -95,7 +96,8 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             {"value": "trafiklab_se", "label": "Trafiklab — Schweden (API Key)"},
             {"value": "transitous",   "label": "Transitous — Weltweit (Community, Beta)"},
             {"value": "vagfr",        "label": "VAG — Freiburg"},
-            {"value": "vbn",          "label": "VBN — Bremen / Niedersachsen (API Key)"},
+            {"value": "vbn_otp",      "label": "VBN — Bremen / Niedersachsen — OTP (API Key)"},
+            {"value": "vbn_trias",    "label": "VBN — Bremen / Niedersachsen — TRIAS (API Key)"},
             {"value": "vgn",          "label": "VGN — Nürnberg"},
             {"value": "vrn",          "label": "VRN — Rhein-Neckar"},
             {"value": "vrr",          "label": "VRR — Rhein-Ruhr (NRW)"},
@@ -172,7 +174,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 else:
                     self._api_key = api_key
                     return await self.async_step_stop_search()
-            elif self._provider == PROVIDER_VBN:
+            elif self._provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
                 api_key = user_input.get(CONF_VBN_API_KEY, "").strip()
                 if not api_key:
                     errors[CONF_VBN_API_KEY] = "vbn_api_key_required"
@@ -196,7 +198,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 }
             )
             description = "RMV API key is required. Request one at opendata.rmv.de"
-        elif self._provider == PROVIDER_VBN:
+        elif self._provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
             schema = vol.Schema(
                 {
                     vol.Required(CONF_VBN_API_KEY): str,
@@ -226,7 +228,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         together with the search field so the user can refine or select.
         """
         # Validate API key for providers that need it
-        if self._provider in (PROVIDER_TRAFIKLAB_SE, PROVIDER_RMV, PROVIDER_VBN) and not self._api_key:
+        if self._provider in (PROVIDER_TRAFIKLAB_SE, PROVIDER_RMV, PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS) and not self._api_key:
             return await self.async_step_api_key()
         if self._provider == PROVIDER_NTA_IE and not self._api_key:
             return self.async_show_form(
@@ -408,7 +410,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                         errors={"base": "rmv_api_key_required"},
                     )
                 data[CONF_RMV_API_KEY] = self._api_key
-            elif self._provider == PROVIDER_VBN:
+            elif self._provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
                 if not self._api_key:
                     return self.async_show_form(
                         step_id="settings",

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_TRAFIKLAB_API_KEY,
     CONF_TRANSPORTATION_TYPES,
     CONF_USE_PROVIDER_LOGO,
+    CONF_VBN_API_KEY,
     CONF_WALKING_TIME,
     DEFAULT_DELAY_THRESHOLD,
     DEFAULT_DEPARTURES,
@@ -40,6 +41,7 @@ from .const import (
     PROVIDER_NTA_IE,
     PROVIDER_RMV,
     PROVIDER_TRAFIKLAB_SE,
+    PROVIDER_VBN,
     PROVIDER_VRR,
     TRANSPORTATION_TYPES,
 )
@@ -175,6 +177,13 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 else:
                     self._api_key = api_key
                     return await self.async_step_stop_search()
+            elif self._provider == PROVIDER_VBN:
+                api_key = user_input.get(CONF_VBN_API_KEY, "").strip()
+                if not api_key:
+                    errors[CONF_VBN_API_KEY] = "vbn_api_key_required"
+                else:
+                    self._api_key = api_key
+                    return await self.async_step_stop_search()
 
         # Show appropriate schema based on provider
         provider_instance = get_provider(self._provider, self.hass)
@@ -192,6 +201,13 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 }
             )
             description = "RMV API key is required. Request one at opendata.rmv.de"
+        elif self._provider == PROVIDER_VBN:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_VBN_API_KEY): str,
+                }
+            )
+            description = "VBN API key is required. Request a free key at api@vbn.de"
         else:  # NTA
             schema = vol.Schema(
                 {
@@ -215,7 +231,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         together with the search field so the user can refine or select.
         """
         # Validate API key for providers that need it
-        if self._provider in (PROVIDER_TRAFIKLAB_SE, PROVIDER_RMV) and not self._api_key:
+        if self._provider in (PROVIDER_TRAFIKLAB_SE, PROVIDER_RMV, PROVIDER_VBN) and not self._api_key:
             return await self.async_step_api_key()
         if self._provider == PROVIDER_NTA_IE and not self._api_key:
             return self.async_show_form(
@@ -397,6 +413,14 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                         errors={"base": "rmv_api_key_required"},
                     )
                 data[CONF_RMV_API_KEY] = self._api_key
+            elif self._provider == PROVIDER_VBN:
+                if not self._api_key:
+                    return self.async_show_form(
+                        step_id="settings",
+                        data_schema=schema,
+                        errors={"base": "vbn_api_key_required"},
+                    )
+                data[CONF_VBN_API_KEY] = self._api_key
 
             # Create unique ID (self._selected_stop validated above)
             unique_id = f"{self._provider}_{self._selected_stop['id']}"

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -98,6 +98,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             "nwl": "NWL — Westfalen-Lippe",
             "nvbw": "NVBW — Baden-Württemberg",
             "beg": "BEG — Bayern",
+            "vbn": "VBN — Bremen / Niedersachsen (API Key)",
         }
         return vol.Schema(
             {

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -60,6 +60,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         """Initialize the config flow."""
         self._entry_type: str = "departures"  # "departures" or "trip"
         self._provider: Optional[str] = None
+        self._provider_search: str = ""
         self._selected_stop: Optional[Dict[str, Any]] = None
         self._api_key: Optional[str] = None  # For Trafiklab or NTA (Primary)
         self._api_key_secondary: Optional[str] = None  # For NTA (Secondary, optional)
@@ -73,9 +74,9 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         self._cache_ttl: int = 300  # Cache TTL in seconds (5 minutes)
 
     @staticmethod
-    def _provider_selector() -> SelectSelector:
-        """Return a searchable, alphabetically sorted provider dropdown."""
-        options = [
+    def _all_provider_options() -> List[Dict[str, str]]:
+        """Return all providers alphabetically sorted."""
+        return [
             {"value": "avv_augsburg", "label": "AVV — Augsburg"},
             {"value": "beg",          "label": "BEG — Bayern"},
             {"value": "bsvg",         "label": "BSVG — Braunschweig"},
@@ -102,28 +103,32 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             {"value": "vvo",          "label": "VVO — Dresden"},
             {"value": "vvs",          "label": "VVS — Stuttgart"},
         ]
+
+    @staticmethod
+    def _filter_providers(search: str) -> List[Dict[str, str]]:
+        """Filter provider list by search term (matches value and label)."""
+        if not search:
+            return PublicTransportConfigFlow._all_provider_options()
+        term = search.lower()
+        return [
+            opt for opt in PublicTransportConfigFlow._all_provider_options()
+            if term in opt["value"].lower() or term in opt["label"].lower()
+        ]
+
+    @staticmethod
+    def _make_provider_selector(options: List[Dict[str, str]]) -> SelectSelector:
         return SelectSelector(SelectSelectorConfig(options=options, mode=SelectSelectorMode.DROPDOWN))
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
-        """Handle the initial step - select entry type and provider."""
+        """Handle the initial step — entry type + provider search text."""
         if user_input is not None:
             self._entry_type = user_input.get("entry_type", "departures")
 
             if self._entry_type == "multi_stop":
                 return await self.async_step_multi_stop()
 
-            self._provider = user_input[CONF_PROVIDER]
-
-            # Check if provider requires API key
-            provider_instance = get_provider(self._provider, self.hass)
-            if provider_instance and provider_instance.requires_api_key:
-                return await self.async_step_api_key()
-
-            if self._entry_type == "trip":
-                self._trip_search_phase = "origin"
-                return await self.async_step_trip_search()
-
-            return await self.async_step_stop_search()
+            self._provider_search = user_input.get("provider_search", "").strip()
+            return await self.async_step_provider_select()
 
         entry_type_options = {
             "departures": "Abfahrtsanzeige / Departure Monitor",
@@ -134,11 +139,51 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         schema = vol.Schema(
             {
                 vol.Required("entry_type", default="departures"): vol.In(entry_type_options),
-                vol.Required(CONF_PROVIDER, default=PROVIDER_VRR): self._provider_selector(),
+                vol.Optional("provider_search"): str,
             }
         )
 
         return self.async_show_form(step_id="user", data_schema=schema)
+
+    async def async_step_provider_select(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
+        """Show filtered provider list and let user pick one."""
+        if user_input is not None:
+            self._provider = user_input[CONF_PROVIDER]
+
+            provider_instance = get_provider(self._provider, self.hass)
+            if provider_instance and provider_instance.requires_api_key:
+                return await self.async_step_api_key()
+
+            if self._entry_type == "trip":
+                self._trip_search_phase = "origin"
+                return await self.async_step_trip_search()
+
+            return await self.async_step_stop_search()
+
+        filtered = self._filter_providers(self._provider_search)
+        errors = {}
+
+        if not filtered:
+            errors["base"] = "no_providers_found"
+            filtered = self._all_provider_options()
+
+        default = filtered[0]["value"] if len(filtered) == 1 else PROVIDER_VRR
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_PROVIDER, default=default): self._make_provider_selector(filtered),
+            }
+        )
+
+        count = len(filtered)
+        search_display = self._provider_search or "–"
+
+        return self.async_show_form(
+            step_id="provider_select",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"count": str(count), "search": search_display},
+        )
 
     async def async_step_api_key(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         """Handle API key input for providers that require it."""

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -60,7 +60,6 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         """Initialize the config flow."""
         self._entry_type: str = "departures"  # "departures" or "trip"
         self._provider: Optional[str] = None
-        self._provider_search: str = ""
         self._selected_stop: Optional[Dict[str, Any]] = None
         self._api_key: Optional[str] = None  # For Trafiklab or NTA (Primary)
         self._api_key_secondary: Optional[str] = None  # For NTA (Secondary, optional)
@@ -74,9 +73,9 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         self._cache_ttl: int = 300  # Cache TTL in seconds (5 minutes)
 
     @staticmethod
-    def _all_provider_options() -> List[Dict[str, str]]:
-        """Return all providers alphabetically sorted."""
-        return [
+    def _provider_selector() -> SelectSelector:
+        """Return alphabetically sorted provider dropdown."""
+        options = [
             {"value": "avv_augsburg", "label": "AVV — Augsburg"},
             {"value": "beg",          "label": "BEG — Bayern"},
             {"value": "bsvg",         "label": "BSVG — Braunschweig"},
@@ -103,51 +102,16 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             {"value": "vvo",          "label": "VVO — Dresden"},
             {"value": "vvs",          "label": "VVS — Stuttgart"},
         ]
-
-    @staticmethod
-    def _filter_providers(search: str) -> List[Dict[str, str]]:
-        """Filter provider list by search term (matches value and label)."""
-        if not search:
-            return PublicTransportConfigFlow._all_provider_options()
-        term = search.lower()
-        return [
-            opt for opt in PublicTransportConfigFlow._all_provider_options()
-            if term in opt["value"].lower() or term in opt["label"].lower()
-        ]
-
-    @staticmethod
-    def _make_provider_selector(options: List[Dict[str, str]]) -> SelectSelector:
         return SelectSelector(SelectSelectorConfig(options=options, mode=SelectSelectorMode.DROPDOWN))
 
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
-        """Handle the initial step — entry type + provider search text."""
+        """Handle the initial step - select entry type and provider."""
         if user_input is not None:
             self._entry_type = user_input.get("entry_type", "departures")
 
             if self._entry_type == "multi_stop":
                 return await self.async_step_multi_stop()
 
-            self._provider_search = user_input.get("provider_search", "").strip()
-            return await self.async_step_provider_select()
-
-        entry_type_options = {
-            "departures": "Abfahrtsanzeige / Departure Monitor",
-            "trip": "Verbindungssuche / Trip Planner (A → B)",
-            "multi_stop": "Multi-Stop / Mehrere Haltestellen kombinieren",
-        }
-
-        schema = vol.Schema(
-            {
-                vol.Required("entry_type", default="departures"): vol.In(entry_type_options),
-                vol.Optional("provider_search"): str,
-            }
-        )
-
-        return self.async_show_form(step_id="user", data_schema=schema)
-
-    async def async_step_provider_select(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
-        """Show filtered provider list and let user pick one."""
-        if user_input is not None:
             self._provider = user_input[CONF_PROVIDER]
 
             provider_instance = get_provider(self._provider, self.hass)
@@ -160,30 +124,20 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
 
             return await self.async_step_stop_search()
 
-        filtered = self._filter_providers(self._provider_search)
-        errors = {}
-
-        if not filtered:
-            errors["base"] = "no_providers_found"
-            filtered = self._all_provider_options()
-
-        default = filtered[0]["value"] if len(filtered) == 1 else PROVIDER_VRR
+        entry_type_options = {
+            "departures": "Abfahrtsanzeige / Departure Monitor",
+            "trip": "Verbindungssuche / Trip Planner (A → B)",
+            "multi_stop": "Multi-Stop / Mehrere Haltestellen kombinieren",
+        }
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_PROVIDER, default=default): self._make_provider_selector(filtered),
+                vol.Required("entry_type", default="departures"): vol.In(entry_type_options),
+                vol.Required(CONF_PROVIDER, default=PROVIDER_VRR): self._provider_selector(),
             }
         )
 
-        count = len(filtered)
-        search_display = self._provider_search or "–"
-
-        return self.async_show_form(
-            step_id="provider_select",
-            data_schema=schema,
-            errors=errors,
-            description_placeholders={"count": str(count), "search": search_display},
-        )
+        return self.async_show_form(step_id="user", data_schema=schema)
 
     async def async_step_api_key(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         """Handle API key input for providers that require it."""

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -47,6 +47,8 @@ PROVIDER_SBB = "sbb"
 PROVIDER_OEBB = "oebb"
 PROVIDER_TRANSITOUS = "transitous"
 PROVIDER_DB = "db"
+PROVIDER_VBN = "vbn"
+CONF_VBN_API_KEY = "vbn_api_key"  # For VBN TRIAS API
 PROVIDERS = [
     PROVIDER_VRR,
     PROVIDER_KVV,
@@ -72,6 +74,7 @@ PROVIDERS = [
     PROVIDER_OEBB,
     PROVIDER_TRANSITOUS,
     PROVIDER_DB,
+    PROVIDER_VBN,
 ]
 
 # Transportation types mapping
@@ -153,6 +156,7 @@ PROVIDER_ICONS = {
     "nwl": "mdi:train",
     "nvbw": "mdi:train",
     "beg": "mdi:train",
+    "vbn": "mdi:bus-clock",
 }
 
 # Provider-specific entity pictures (logos)
@@ -183,4 +187,5 @@ PROVIDER_ENTITY_PICTURES = {
     "nvbw": "https://www.efa-bw.de/favicon.ico",
     "beg": "https://www.bahnland-bayern.de/favicon.ico",
     "db": "https://www.bahn.de/favicon.ico",
+    "vbn": "https://www.vbn.de/favicon.ico",
 }

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -47,8 +47,9 @@ PROVIDER_SBB = "sbb"
 PROVIDER_OEBB = "oebb"
 PROVIDER_TRANSITOUS = "transitous"
 PROVIDER_DB = "db"
-PROVIDER_VBN = "vbn"
-CONF_VBN_API_KEY = "vbn_api_key"  # For VBN TRIAS API
+PROVIDER_VBN_OTP = "vbn_otp"
+PROVIDER_VBN_TRIAS = "vbn_trias"
+CONF_VBN_API_KEY = "vbn_api_key"
 PROVIDERS = [
     PROVIDER_VRR,
     PROVIDER_KVV,
@@ -74,7 +75,8 @@ PROVIDERS = [
     PROVIDER_OEBB,
     PROVIDER_TRANSITOUS,
     PROVIDER_DB,
-    PROVIDER_VBN,
+    PROVIDER_VBN_OTP,
+    PROVIDER_VBN_TRIAS,
 ]
 
 # Transportation types mapping
@@ -156,7 +158,8 @@ PROVIDER_ICONS = {
     "nwl": "mdi:train",
     "nvbw": "mdi:train",
     "beg": "mdi:train",
-    "vbn": "mdi:bus-clock",
+    "vbn_otp": "mdi:bus-clock",
+    "vbn_trias": "mdi:bus-clock",
 }
 
 # Provider-specific entity pictures (logos)
@@ -187,5 +190,6 @@ PROVIDER_ENTITY_PICTURES = {
     "nvbw": "https://www.efa-bw.de/favicon.ico",
     "beg": "https://www.bahnland-bayern.de/favicon.ico",
     "db": "https://www.bahn.de/favicon.ico",
-    "vbn": "https://www.vbn.de/favicon.ico",
+    "vbn_otp": "https://www.vbn.de/favicon.ico",
+    "vbn_trias": "https://www.vbn.de/favicon.ico",
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b5"
+  "version": "2026.5.2b6"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b9"
+  "version": "2026.5.2b10"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2"
+  "version": "2026.5.2b1"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b2"
+  "version": "2026.5.2b3"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b3"
+  "version": "2026.5.2b4"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b10"
+  "version": "2026.5.2b11"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b11"
+  "version": "2026.5.2b12"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b7"
+  "version": "2026.5.2b8"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b8"
+  "version": "2026.5.2b9"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b4"
+  "version": "2026.5.2b5"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b6"
+  "version": "2026.5.2b7"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b12"
+  "version": "2026.5.2"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.4.16"
+  "version": "2026.5.2"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2b1"
+  "version": "2026.5.2b2"
 }

--- a/custom_components/openpublictransport/providers/__init__.py
+++ b/custom_components/openpublictransport/providers/__init__.py
@@ -25,7 +25,8 @@ from ..const import (
     PROVIDER_TRANSITOUS,
     PROVIDER_VAGFR,
     PROVIDER_VGN,
-    PROVIDER_VBN,
+    PROVIDER_VBN_OTP,
+    PROVIDER_VBN_TRIAS,
     PROVIDER_VRN,
     PROVIDER_VRR,
     PROVIDER_VVO,
@@ -54,7 +55,7 @@ from .vagfr import VAGFRProvider
 from .vgn import VGNProvider
 from .vrn import VRNProvider
 from .vrr import VRRProvider
-from .vbn import VBNProvider
+from .vbn import VBNOTPProvider, VBNTriasProvider
 from .vvo import VVOProvider
 from .vvs import VVSProvider
 
@@ -111,4 +112,5 @@ register_provider(PROVIDER_SBB, SBBProvider)
 register_provider(PROVIDER_OEBB, OeBBProvider)
 register_provider(PROVIDER_TRANSITOUS, TransitousProvider)
 register_provider(PROVIDER_DB, DBProvider)
-register_provider(PROVIDER_VBN, VBNProvider)
+register_provider(PROVIDER_VBN_OTP, VBNOTPProvider)
+register_provider(PROVIDER_VBN_TRIAS, VBNTriasProvider)

--- a/custom_components/openpublictransport/providers/__init__.py
+++ b/custom_components/openpublictransport/providers/__init__.py
@@ -25,6 +25,7 @@ from ..const import (
     PROVIDER_TRANSITOUS,
     PROVIDER_VAGFR,
     PROVIDER_VGN,
+    PROVIDER_VBN,
     PROVIDER_VRN,
     PROVIDER_VRR,
     PROVIDER_VVO,
@@ -53,6 +54,7 @@ from .vagfr import VAGFRProvider
 from .vgn import VGNProvider
 from .vrn import VRNProvider
 from .vrr import VRRProvider
+from .vbn import VBNProvider
 from .vvo import VVOProvider
 from .vvs import VVSProvider
 
@@ -109,3 +111,4 @@ register_provider(PROVIDER_SBB, SBBProvider)
 register_provider(PROVIDER_OEBB, OeBBProvider)
 register_provider(PROVIDER_TRANSITOUS, TransitousProvider)
 register_provider(PROVIDER_DB, DBProvider)
+register_provider(PROVIDER_VBN, VBNProvider)

--- a/custom_components/openpublictransport/providers/__init__.py
+++ b/custom_components/openpublictransport/providers/__init__.py
@@ -24,9 +24,9 @@ from ..const import (
     PROVIDER_TRAFIKLAB_SE,
     PROVIDER_TRANSITOUS,
     PROVIDER_VAGFR,
-    PROVIDER_VGN,
     PROVIDER_VBN_OTP,
     PROVIDER_VBN_TRIAS,
+    PROVIDER_VGN,
     PROVIDER_VRN,
     PROVIDER_VRR,
     PROVIDER_VVO,
@@ -52,10 +52,10 @@ from .sbb import SBBProvider
 from .trafiklab import TrafiklabProvider
 from .transitous import TransitousProvider
 from .vagfr import VAGFRProvider
+from .vbn import VBNOTPProvider, VBNTriasProvider
 from .vgn import VGNProvider
 from .vrn import VRNProvider
 from .vrr import VRRProvider
-from .vbn import VBNOTPProvider, VBNTriasProvider
 from .vvo import VVOProvider
 from .vvs import VVSProvider
 

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -168,9 +168,7 @@ class OTPBaseProvider(BaseProvider):
         if routes_data:
             for r in routes_data:
                 if isinstance(r, dict) and "id" in r and r["id"] not in route_map:
-                    agency = r.get("agencyName") or (
-                        r["agency"]["name"] if isinstance(r.get("agency"), dict) else None
-                    )
+                    agency = r.get("agencyName") or (r["agency"]["name"] if isinstance(r.get("agency"), dict) else None)
                     route_map[r["id"]] = {
                         "shortName": r.get("shortName") or r.get("longName", ""),
                         "mode": mode_mapping.get(r.get("mode", ""), "unknown"),
@@ -215,19 +213,21 @@ class OTPBaseProvider(BaseProvider):
             for t in group.get("times", []):
                 if not isinstance(t, dict):
                     continue
-                stop_events.append({
-                    "routeName": route_info.get("shortName") or pattern.get("desc", ""),
-                    "transportType": route_info.get("mode", "unknown"),
-                    "agency": route_info.get("agency", ""),
-                    "notices": stop_notices or None,
-                    "serviceDay": t.get("serviceDay", 0),
-                    "scheduledDeparture": t.get("scheduledDeparture", 0),
-                    "realtimeDeparture": t.get("realtimeDeparture", 0),
-                    "departureDelay": t.get("departureDelay", 0),
-                    "realtime": t.get("realtime", False),
-                    # headsign is directly on the time entry (not in a trip sub-object)
-                    "headsign": t.get("headsign", ""),
-                })
+                stop_events.append(
+                    {
+                        "routeName": route_info.get("shortName") or pattern.get("desc", ""),
+                        "transportType": route_info.get("mode", "unknown"),
+                        "agency": route_info.get("agency", ""),
+                        "notices": stop_notices or None,
+                        "serviceDay": t.get("serviceDay", 0),
+                        "scheduledDeparture": t.get("scheduledDeparture", 0),
+                        "realtimeDeparture": t.get("realtimeDeparture", 0),
+                        "departureDelay": t.get("departureDelay", 0),
+                        "realtime": t.get("realtime", False),
+                        # headsign is directly on the time entry (not in a trip sub-object)
+                        "headsign": t.get("headsign", ""),
+                    }
+                )
 
         stop_events.sort(key=lambda x: x["serviceDay"] + x["realtimeDeparture"])
         return {"stopEvents": stop_events[:departures_limit]}
@@ -240,12 +240,8 @@ class OTPBaseProvider(BaseProvider):
     ) -> Optional[UnifiedDeparture]:
         try:
             service_day: int = stop["serviceDay"]
-            planned = datetime.fromtimestamp(
-                service_day + stop["scheduledDeparture"], tz=timezone.utc
-            ).astimezone(tz)
-            actual = datetime.fromtimestamp(
-                service_day + stop["realtimeDeparture"], tz=timezone.utc
-            ).astimezone(tz)
+            planned = datetime.fromtimestamp(service_day + stop["scheduledDeparture"], tz=timezone.utc).astimezone(tz)
+            actual = datetime.fromtimestamp(service_day + stop["realtimeDeparture"], tz=timezone.utc).astimezone(tz)
 
             delay_min = max(0, int(stop.get("departureDelay", 0) / 60))
             minutes_until = max(0, int((actual - now).total_seconds() / 60))

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -1,0 +1,197 @@
+"""Base provider for OpenTripPlanner (OTP) REST API.
+
+Subclasses only need to define:
+- provider_id, provider_name
+- otp_base_url: router base URL, e.g. 'http://gtfsr.vbn.de/api/otp/routers/default'
+
+Override _auth_headers() to add an API key.
+Override get_timezone() if not Europe/Berlin.
+Override get_mode_mapping() for custom GTFS mode conversions.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
+
+import aiohttp
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from ..data_models import UnifiedDeparture
+from .base import BaseProvider
+
+_LOGGER = logging.getLogger(__name__)
+
+OTP_MODE_MAP: Dict[str, str] = {
+    "BUS": "bus",
+    "COACH": "bus",
+    "RAIL": "train",
+    "TRAM": "tram",
+    "SUBWAY": "subway",
+    "FERRY": "ferry",
+    "GONDOLA": "tram",
+    "FUNICULAR": "train",
+    "CABLE_CAR": "tram",
+}
+
+
+class OTPBaseProvider(BaseProvider):
+    """Base class for OpenTripPlanner REST API providers."""
+
+    otp_base_url: str = ""
+
+    def get_timezone(self) -> str:
+        return "Europe/Berlin"
+
+    def get_mode_mapping(self) -> Dict[str, str]:
+        return OTP_MODE_MAP
+
+    def _auth_headers(self) -> Dict[str, str]:
+        """Request headers. Override in subclasses to add API key auth."""
+        return {"Accept": "application/json"}
+
+    def _index_url(self, path: str) -> str:
+        return f"{self.otp_base_url}/index/{path}"
+
+    async def _get(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        params: Optional[Dict] = None,
+    ) -> Optional[Any]:
+        try:
+            async with session.get(
+                url,
+                params=params or {},
+                headers=self._auth_headers(),
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+                _LOGGER.warning("%s OTP %s → HTTP %s", self.provider_name, url, resp.status)
+        except aiohttp.ClientError as exc:
+            _LOGGER.warning("%s OTP request failed: %s", self.provider_name, exc)
+        except Exception as exc:
+            _LOGGER.warning("%s OTP error: %s", self.provider_name, exc)
+        return None
+
+    async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:
+        """Search stops by name via OTP /index/stops?name=..."""
+        session = async_get_clientsession(self.hass)
+        data = await self._get(session, self._index_url("stops"), {"name": search_term})
+        if not data:
+            return []
+        return [
+            {
+                "id": s["id"],
+                "name": s.get("name", ""),
+                "place": s.get("name", ""),
+                "area_type": "stop",
+            }
+            for s in data
+            if isinstance(s, dict) and "id" in s
+        ]
+
+    async def fetch_departures(
+        self,
+        station_id: Optional[str],
+        place_dm: str,
+        name_dm: str,
+        departures_limit: int,
+    ) -> Optional[Dict[str, Any]]:
+        if not station_id:
+            return None
+
+        encoded_id = quote(station_id, safe="")
+        session = async_get_clientsession(self.hass)
+        mode_mapping = self.get_mode_mapping()
+
+        # 1. Routes at stop → line shortName + transport mode
+        routes_data = await self._get(session, self._index_url(f"stops/{encoded_id}/routes"))
+        route_map: Dict[str, Dict[str, str]] = {}
+        if routes_data:
+            for r in routes_data:
+                if isinstance(r, dict) and "id" in r:
+                    route_map[r["id"]] = {
+                        "shortName": r.get("shortName") or r.get("longName", ""),
+                        "mode": mode_mapping.get(r.get("mode", ""), "unknown"),
+                    }
+
+        # 2. Stoptimes (numberOfDepartures = per pattern, not total)
+        stoptimes = await self._get(
+            session,
+            self._index_url(f"stops/{encoded_id}/stoptimes"),
+            {
+                "timeRange": 7200,
+                "numberOfDepartures": max(departures_limit, 5),
+                "omitNonPickups": True,
+            },
+        )
+        if stoptimes is None:
+            return None
+
+        stop_events = []
+        for group in stoptimes:
+            if not isinstance(group, dict):
+                continue
+            pattern = group.get("pattern", {})
+            for t in group.get("times", []):
+                if not isinstance(t, dict):
+                    continue
+                trip = t.get("trip", {})
+                route_id = trip.get("routeId", "")
+                route_info = route_map.get(route_id, {})
+
+                stop_events.append({
+                    "routeName": route_info.get("shortName") or pattern.get("desc", ""),
+                    "transportType": route_info.get("mode", "unknown"),
+                    "serviceDay": t.get("serviceDay", 0),
+                    "scheduledDeparture": t.get("scheduledDeparture", 0),
+                    "realtimeDeparture": t.get("realtimeDeparture", 0),
+                    "departureDelay": t.get("departureDelay", 0),
+                    "realtime": t.get("realtime", False),
+                    "headsign": t.get("headsign") or trip.get("tripHeadsign", ""),
+                })
+
+        stop_events.sort(key=lambda x: x["serviceDay"] + x["realtimeDeparture"])
+        return {"stopEvents": stop_events[:departures_limit]}
+
+    def parse_departure(
+        self,
+        stop: Dict[str, Any],
+        tz: Union[ZoneInfo, Any],
+        now: datetime,
+    ) -> Optional[UnifiedDeparture]:
+        try:
+            service_day: int = stop["serviceDay"]
+            planned = datetime.fromtimestamp(
+                service_day + stop["scheduledDeparture"], tz=timezone.utc
+            ).astimezone(tz)
+            actual = datetime.fromtimestamp(
+                service_day + stop["realtimeDeparture"], tz=timezone.utc
+            ).astimezone(tz)
+
+            delay_min = max(0, int(stop.get("departureDelay", 0) / 60))
+            minutes_until = max(0, int((actual - now).total_seconds() / 60))
+
+            return UnifiedDeparture(
+                line=stop.get("routeName", ""),
+                destination=stop.get("headsign", "Unknown"),
+                departure_time=actual.strftime("%H:%M"),
+                planned_time=planned.strftime("%H:%M"),
+                delay=delay_min,
+                platform="",
+                transportation_type=stop.get("transportType", "unknown"),
+                is_realtime=stop.get("realtime", False),
+                minutes_until_departure=minutes_until,
+                departure_time_obj=actual,
+                description=None,
+                agency=None,
+                notices=None,
+                planned_platform=None,
+                platform_changed=False,
+            )
+        except Exception as exc:
+            _LOGGER.debug("%s OTP parse_departure error: %s", self.provider_name, exc)
+            return None

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -2,16 +2,22 @@
 
 Subclasses only need to define:
 - provider_id, provider_name
-- otp_base_url: router base URL, e.g. 'http://gtfsr.vbn.de/api/otp/routers/default'
+- otp_base_url: router base URL up to and including the router ID,
+  e.g. 'http://gtfsr.vbn.de/api/routers/default'
+  NOTE: no /otp/ prefix needed when the base path already includes /api/
 
 Override _auth_headers() to add an API key.
 Override get_timezone() if not Europe/Berlin.
-Override get_mode_mapping() for custom GTFS mode conversions.
+Override stop_search_radius if 500 m is not appropriate.
+
+Stop search uses Nominatim geocoding (OSM) to resolve the stop name to
+coordinates, then OTP /index/stops?lat=&lon=&radius= to find nearby stops.
+OTP 2.3.0 REST does not support name-based stop search natively.
 """
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
@@ -22,6 +28,9 @@ from ..data_models import UnifiedDeparture
 from .base import BaseProvider
 
 _LOGGER = logging.getLogger(__name__)
+
+_NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+_NOMINATIM_UA = "openpublictransport-homeassistant/1.0 (github.com/NerdySoftPaw/openpublictransport)"
 
 OTP_MODE_MAP: Dict[str, str] = {
     "BUS": "bus",
@@ -39,7 +48,12 @@ OTP_MODE_MAP: Dict[str, str] = {
 class OTPBaseProvider(BaseProvider):
     """Base class for OpenTripPlanner REST API providers."""
 
+    # Subclasses set this to the OTP router base URL (without trailing slash)
+    # e.g. 'http://gtfsr.vbn.de/api/routers/default'
     otp_base_url: str = ""
+
+    # Search radius in metres for stop lookup after geocoding
+    stop_search_radius: int = 500
 
     def get_timezone(self) -> str:
         return "Europe/Berlin"
@@ -48,7 +62,7 @@ class OTPBaseProvider(BaseProvider):
         return OTP_MODE_MAP
 
     def _auth_headers(self) -> Dict[str, str]:
-        """Request headers. Override in subclasses to add API key auth."""
+        """Request headers — override in subclasses to add API key auth."""
         return {"Accept": "application/json"}
 
     def _index_url(self, path: str) -> str:
@@ -76,12 +90,53 @@ class OTPBaseProvider(BaseProvider):
             _LOGGER.warning("%s OTP error: %s", self.provider_name, exc)
         return None
 
-    async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:
-        """Search stops by name via OTP /index/stops?name=..."""
+    async def _geocode(self, search_term: str) -> Optional[Tuple[float, float]]:
+        """Resolve a stop name to (lat, lon) via Nominatim / OpenStreetMap.
+
+        OTP 2.x REST API has no name-based stop search; we geocode first,
+        then use the coordinate-based /index/stops?lat=&lon=&radius= endpoint.
+        """
         session = async_get_clientsession(self.hass)
-        data = await self._get(session, self._index_url("stops"), {"name": search_term})
+        try:
+            async with session.get(
+                _NOMINATIM_URL,
+                params={"q": search_term, "format": "json", "limit": 1},
+                headers={"User-Agent": _NOMINATIM_UA, "Accept": "application/json"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                if resp.status == 200:
+                    results = await resp.json(content_type=None)
+                    if results:
+                        return float(results[0]["lat"]), float(results[0]["lon"])
+                    _LOGGER.debug("%s: Nominatim returned no results for '%s'", self.provider_name, search_term)
+        except Exception as exc:
+            _LOGGER.debug("%s: Nominatim geocode error: %s", self.provider_name, exc)
+        return None
+
+    async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:
+        """Search stops by geocoding the term, then finding nearby OTP stops.
+
+        Returns stops sorted by distance from the geocoded coordinates.
+        """
+        coords = await self._geocode(search_term)
+        if coords is None:
+            _LOGGER.warning(
+                "%s: could not geocode '%s' — check your search term",
+                self.provider_name,
+                search_term,
+            )
+            return []
+
+        lat, lon = coords
+        session = async_get_clientsession(self.hass)
+        data = await self._get(
+            session,
+            self._index_url("stops"),
+            {"lat": lat, "lon": lon, "radius": self.stop_search_radius},
+        )
         if not data:
             return []
+
         return [
             {
                 "id": s["id"],
@@ -89,7 +144,7 @@ class OTPBaseProvider(BaseProvider):
                 "place": s.get("name", ""),
                 "area_type": "stop",
             }
-            for s in data
+            for s in sorted(data, key=lambda x: x.get("dist", 0))
             if isinstance(s, dict) and "id" in s
         ]
 
@@ -107,18 +162,18 @@ class OTPBaseProvider(BaseProvider):
         session = async_get_clientsession(self.hass)
         mode_mapping = self.get_mode_mapping()
 
-        # 1. Routes at stop → line shortName + transport mode
+        # Routes at stop → line shortName + transport mode (deduplicate by ID)
         routes_data = await self._get(session, self._index_url(f"stops/{encoded_id}/routes"))
         route_map: Dict[str, Dict[str, str]] = {}
         if routes_data:
             for r in routes_data:
-                if isinstance(r, dict) and "id" in r:
+                if isinstance(r, dict) and "id" in r and r["id"] not in route_map:
                     route_map[r["id"]] = {
                         "shortName": r.get("shortName") or r.get("longName", ""),
                         "mode": mode_mapping.get(r.get("mode", ""), "unknown"),
                     }
 
-        # 2. Stoptimes (numberOfDepartures = per pattern, not total)
+        # Stoptimes — numberOfDepartures is per pattern, not total
         stoptimes = await self._get(
             session,
             self._index_url(f"stops/{encoded_id}/stoptimes"),
@@ -135,14 +190,14 @@ class OTPBaseProvider(BaseProvider):
         for group in stoptimes:
             if not isinstance(group, dict):
                 continue
+            # routeId lives on the pattern, not on individual time entries
             pattern = group.get("pattern", {})
+            route_id = pattern.get("routeId", "")
+            route_info = route_map.get(route_id, {})
+
             for t in group.get("times", []):
                 if not isinstance(t, dict):
                     continue
-                trip = t.get("trip", {})
-                route_id = trip.get("routeId", "")
-                route_info = route_map.get(route_id, {})
-
                 stop_events.append({
                     "routeName": route_info.get("shortName") or pattern.get("desc", ""),
                     "transportType": route_info.get("mode", "unknown"),
@@ -151,7 +206,8 @@ class OTPBaseProvider(BaseProvider):
                     "realtimeDeparture": t.get("realtimeDeparture", 0),
                     "departureDelay": t.get("departureDelay", 0),
                     "realtime": t.get("realtime", False),
-                    "headsign": t.get("headsign") or trip.get("tripHeadsign", ""),
+                    # headsign is directly on the time entry (not in a trip sub-object)
+                    "headsign": t.get("headsign", ""),
                 })
 
         stop_events.sort(key=lambda x: x["serviceDay"] + x["realtimeDeparture"])

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -162,16 +162,33 @@ class OTPBaseProvider(BaseProvider):
         session = async_get_clientsession(self.hass)
         mode_mapping = self.get_mode_mapping()
 
-        # Routes at stop → line shortName + transport mode (deduplicate by ID)
+        # Routes at stop → line shortName + transport mode + agency (deduplicate by ID)
         routes_data = await self._get(session, self._index_url(f"stops/{encoded_id}/routes"))
         route_map: Dict[str, Dict[str, str]] = {}
         if routes_data:
             for r in routes_data:
                 if isinstance(r, dict) and "id" in r and r["id"] not in route_map:
+                    agency = r.get("agencyName") or (
+                        r["agency"]["name"] if isinstance(r.get("agency"), dict) else None
+                    )
                     route_map[r["id"]] = {
                         "shortName": r.get("shortName") or r.get("longName", ""),
                         "mode": mode_mapping.get(r.get("mode", ""), "unknown"),
+                        "agency": agency or "",
                     }
+
+        # Active alerts for this stop
+        alerts_data = await self._get(session, self._index_url(f"stops/{encoded_id}/alerts"))
+        stop_notices: List[str] = []
+        if alerts_data:
+            seen: set = set()
+            for alert in alerts_data:
+                if not isinstance(alert, dict):
+                    continue
+                text = alert.get("alertHeaderText") or alert.get("alertDescriptionText") or ""
+                if text and text not in seen:
+                    stop_notices.append(text)
+                    seen.add(text)
 
         # Stoptimes — numberOfDepartures is per pattern, not total
         stoptimes = await self._get(
@@ -201,6 +218,8 @@ class OTPBaseProvider(BaseProvider):
                 stop_events.append({
                     "routeName": route_info.get("shortName") or pattern.get("desc", ""),
                     "transportType": route_info.get("mode", "unknown"),
+                    "agency": route_info.get("agency", ""),
+                    "notices": stop_notices or None,
                     "serviceDay": t.get("serviceDay", 0),
                     "scheduledDeparture": t.get("scheduledDeparture", 0),
                     "realtimeDeparture": t.get("realtimeDeparture", 0),
@@ -231,6 +250,9 @@ class OTPBaseProvider(BaseProvider):
             delay_min = max(0, int(stop.get("departureDelay", 0) / 60))
             minutes_until = max(0, int((actual - now).total_seconds() / 60))
 
+            agency = stop.get("agency") or None
+            notices = stop.get("notices") or None
+
             return UnifiedDeparture(
                 line=stop.get("routeName", ""),
                 destination=stop.get("headsign", "Unknown"),
@@ -243,8 +265,8 @@ class OTPBaseProvider(BaseProvider):
                 minutes_until_departure=minutes_until,
                 departure_time_obj=actual,
                 description=None,
-                agency=None,
-                notices=None,
+                agency=agency,
+                notices=notices,
                 planned_platform=None,
                 platform_changed=False,
             )

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -180,7 +180,7 @@ class OTPBaseProvider(BaseProvider):
             {
                 "timeRange": 7200,
                 "numberOfDepartures": max(departures_limit, 5),
-                "omitNonPickups": True,
+                "omitNonPickups": "true",
             },
         )
         if stoptimes is None:

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -15,6 +15,7 @@ coordinates, then OTP /index/stops?lat=&lon=&radius= to find nearby stops.
 OTP 2.3.0 REST does not support name-based stop search natively.
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -162,8 +163,22 @@ class OTPBaseProvider(BaseProvider):
         session = async_get_clientsession(self.hass)
         mode_mapping = self.get_mode_mapping()
 
-        # Routes at stop → line shortName + transport mode + agency (deduplicate by ID)
-        routes_data = await self._get(session, self._index_url(f"stops/{encoded_id}/routes"))
+        # Fetch routes, alerts, and stoptimes concurrently
+        routes_data, alerts_data, stoptimes = await asyncio.gather(
+            self._get(session, self._index_url(f"stops/{encoded_id}/routes")),
+            self._get(session, self._index_url(f"stops/{encoded_id}/alerts")),
+            self._get(
+                session,
+                self._index_url(f"stops/{encoded_id}/stoptimes"),
+                {
+                    "timeRange": 7200,
+                    "numberOfDepartures": max(departures_limit, 5),
+                    "omitNonPickups": "true",
+                },
+            ),
+        )
+
+        # Routes → line shortName + transport mode + agency (deduplicate by ID)
         route_map: Dict[str, Dict[str, str]] = {}
         if routes_data:
             for r in routes_data:
@@ -176,7 +191,6 @@ class OTPBaseProvider(BaseProvider):
                     }
 
         # Active alerts for this stop
-        alerts_data = await self._get(session, self._index_url(f"stops/{encoded_id}/alerts"))
         stop_notices: List[str] = []
         if alerts_data:
             seen: set = set()
@@ -187,17 +201,6 @@ class OTPBaseProvider(BaseProvider):
                 if text and text not in seen:
                     stop_notices.append(text)
                     seen.add(text)
-
-        # Stoptimes — numberOfDepartures is per pattern, not total
-        stoptimes = await self._get(
-            session,
-            self._index_url(f"stops/{encoded_id}/stoptimes"),
-            {
-                "timeRange": 7200,
-                "numberOfDepartures": max(departures_limit, 5),
-                "omitNonPickups": "true",
-            },
-        )
         if stoptimes is None:
             return None
 

--- a/custom_components/openpublictransport/providers/trias_base.py
+++ b/custom_components/openpublictransport/providers/trias_base.py
@@ -136,10 +136,14 @@ class TRIASBaseProvider(BaseProvider):
   </ServiceRequest>
 </Trias>"""
 
+    def _extra_headers(self) -> Dict[str, str]:
+        """Additional HTTP headers for TRIAS requests. Override in subclasses for auth."""
+        return {}
+
     async def _post_trias(self, xml_body: str) -> Optional[ET.Element]:
         """Send POST request to TRIAS endpoint and parse XML response."""
         session = async_get_clientsession(self.hass)
-        headers = {"Content-Type": "text/xml; charset=utf-8"}
+        headers = {"Content-Type": "text/xml; charset=utf-8", **self._extra_headers()}
 
         try:
             async with session.post(

--- a/custom_components/openpublictransport/providers/trias_base.py
+++ b/custom_components/openpublictransport/providers/trias_base.py
@@ -156,7 +156,7 @@ class TRIASBaseProvider(BaseProvider):
                     text = await response.text()
                     return ET.fromstring(text)
                 else:
-                    _LOGGER.debug("%s TRIAS API returned status %s", self.provider_name, response.status)
+                    _LOGGER.warning("%s TRIAS API returned status %s", self.provider_name, response.status)
         except aiohttp.ClientError as e:
             _LOGGER.warning("%s TRIAS API request failed: %s", self.provider_name, e)
         except ET.ParseError as e:

--- a/custom_components/openpublictransport/providers/trias_base.py
+++ b/custom_components/openpublictransport/providers/trias_base.py
@@ -156,7 +156,7 @@ class TRIASBaseProvider(BaseProvider):
                     text = await response.text()
                     return ET.fromstring(text)
                 else:
-                    _LOGGER.warning("%s TRIAS API returned status %s", self.provider_name, response.status)
+                    _LOGGER.debug("%s TRIAS API returned status %s", self.provider_name, response.status)
         except aiohttp.ClientError as e:
             _LOGGER.warning("%s TRIAS API request failed: %s", self.provider_name, e)
         except ET.ParseError as e:

--- a/custom_components/openpublictransport/providers/vbn.py
+++ b/custom_components/openpublictransport/providers/vbn.py
@@ -1,0 +1,35 @@
+"""VBN (Verkehrsverbund Bremen/Niedersachsen) provider — TRIAS interface."""
+
+from typing import Optional
+
+from homeassistant.core import HomeAssistant
+
+from ..const import PROVIDER_VBN
+from .trias_base import TRIASBaseProvider
+
+
+class VBNProvider(TRIASBaseProvider):
+    """VBN provider using TRIAS API (https://fahrplaner.vbn.de/triasproxy/).
+
+    API key is passed as RequestorRef in every TRIAS XML request.
+    Request a free key at api@vbn.de (3,000 transactions/day for hobbyists).
+    """
+
+    trias_base_url = "https://fahrplaner.vbn.de/triasproxy/"
+
+    def __init__(self, hass: HomeAssistant, api_key: Optional[str] = None, api_key_secondary: Optional[str] = None):
+        super().__init__(hass, api_key, api_key_secondary)
+        if api_key:
+            self.requestor_ref = api_key
+
+    @property
+    def provider_id(self) -> str:
+        return PROVIDER_VBN
+
+    @property
+    def provider_name(self) -> str:
+        return "VBN (Bremen/Niedersachsen)"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return True

--- a/custom_components/openpublictransport/providers/vbn.py
+++ b/custom_components/openpublictransport/providers/vbn.py
@@ -1,26 +1,64 @@
-"""VBN (Verkehrsverbund Bremen/Niedersachsen) provider — TRIAS interface."""
+"""VBN (Verkehrsverbund Bremen/Niedersachsen) provider.
 
-from typing import Optional
+Tries TRIAS first (https://fahrplaner.vbn.de/triasproxy/), falls back to
+OpenTripPlanner REST API (http://gtfsr.vbn.de/api/).
 
+Both APIs share the same API key, passed as 'Authorization: Bearer <key>'.
+Request a free key at api@vbn.de — 3,000 transactions/day for non-commercial use.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
+
+import aiohttp
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from ..const import PROVIDER_VBN
-from .trias_base import TRIASBaseProvider
+from .trias_base import DEFAULT_MODE_MAPPING, TRIASBaseProvider
+
+_LOGGER = logging.getLogger(__name__)
+
+_OTP_BASE = "http://gtfsr.vbn.de/api/otp/routers/default/index"
+
+# Map OTP GTFS route modes → TRIAS PtMode strings (so parse_departure works for both)
+_OTP_TO_TRIAS_MODE: Dict[str, str] = {
+    "BUS": "bus",
+    "RAIL": "rail",
+    "TRAM": "tram",
+    "SUBWAY": "metro",
+    "FERRY": "water",
+    "GONDOLA": "tram",
+    "FUNICULAR": "funicular",
+    "CABLE_CAR": "telecabin",
+    "COACH": "coach",
+}
+
+# Prefix used on stop IDs returned by OTP search so fetch_departures knows which API to use
+_OTP_PREFIX = "OTP:"
 
 
 class VBNProvider(TRIASBaseProvider):
-    """VBN provider using TRIAS API (https://fahrplaner.vbn.de/triasproxy/).
+    """VBN provider — TRIAS with Bearer auth, automatic OTP fallback.
 
-    API key is passed as RequestorRef in every TRIAS XML request.
-    Request a free key at api@vbn.de (3,000 transactions/day for hobbyists).
+    Stop IDs from OTP search are prefixed with 'OTP:' so the provider always
+    calls the correct backend without requiring user interaction.
     """
 
     trias_base_url = "https://fahrplaner.vbn.de/triasproxy/"
 
-    def __init__(self, hass: HomeAssistant, api_key: Optional[str] = None, api_key_secondary: Optional[str] = None):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_key: Optional[str] = None,
+        api_key_secondary: Optional[str] = None,
+    ) -> None:
         super().__init__(hass, api_key, api_key_secondary)
-        if api_key:
-            self.requestor_ref = api_key
+        # Cached API preference: None = not yet determined, True = TRIAS, False = OTP
+        self._use_trias: Optional[bool] = None
 
     @property
     def provider_id(self) -> str:
@@ -33,3 +71,193 @@ class VBNProvider(TRIASBaseProvider):
     @property
     def requires_api_key(self) -> bool:
         return True
+
+    # ── Auth ────────────────────────────────────────────────────────────────
+
+    def _extra_headers(self) -> Dict[str, str]:
+        """Add Bearer token to all TRIAS requests."""
+        if self.api_key:
+            return {"Authorization": f"Bearer {self.api_key}"}
+        return {}
+
+    def get_mode_mapping(self) -> Dict[str, str]:
+        """TRIAS PtMode + OTP GTFS mode → unified transport types."""
+        return {
+            **DEFAULT_MODE_MAPPING,
+            # OTP GTFS modes (uppercase) — used when OTP fallback is active
+            "BUS": "bus",
+            "RAIL": "train",
+            "TRAM": "tram",
+            "SUBWAY": "subway",
+            "FERRY": "ferry",
+            "GONDOLA": "tram",
+            "FUNICULAR": "train",
+            "CABLE_CAR": "tram",
+            "COACH": "bus",
+        }
+
+    # ── OTP helpers ─────────────────────────────────────────────────────────
+
+    def _otp_headers(self) -> Dict[str, str]:
+        h = {"Accept": "application/json"}
+        if self.api_key:
+            h["Authorization"] = f"Bearer {self.api_key}"
+        return h
+
+    async def _otp_get(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        params: Optional[Dict] = None,
+    ) -> Optional[Any]:
+        try:
+            async with session.get(
+                url,
+                params=params or {},
+                headers=self._otp_headers(),
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+                _LOGGER.debug("VBN OTP %s → HTTP %s", url, resp.status)
+        except aiohttp.ClientError as exc:
+            _LOGGER.debug("VBN OTP request failed: %s", exc)
+        except Exception as exc:
+            _LOGGER.debug("VBN OTP error: %s", exc)
+        return None
+
+    async def _otp_search_stops(self, search_term: str) -> List[Dict[str, Any]]:
+        session = async_get_clientsession(self.hass)
+        data = await self._otp_get(session, f"{_OTP_BASE}/stops", {"name": search_term})
+        if not data:
+            return []
+        return [
+            {
+                "id": f"{_OTP_PREFIX}{s['id']}",
+                "name": s.get("name", ""),
+                "place": s.get("name", ""),
+                "area_type": "stop",
+            }
+            for s in data
+            if isinstance(s, dict) and "id" in s
+        ]
+
+    async def _otp_fetch_departures(
+        self,
+        station_id: str,
+        limit: int,
+    ) -> Optional[Dict[str, Any]]:
+        otp_id = station_id.removeprefix(_OTP_PREFIX)
+        encoded_id = quote(otp_id, safe="")
+        session = async_get_clientsession(self.hass)
+
+        # Fetch routes at stop to get line shortName + GTFS mode
+        routes_data = await self._otp_get(session, f"{_OTP_BASE}/stops/{encoded_id}/routes")
+        route_map: Dict[str, Dict[str, str]] = {}
+        if routes_data:
+            for r in routes_data:
+                if isinstance(r, dict) and "id" in r:
+                    route_map[r["id"]] = {
+                        "shortName": r.get("shortName") or r.get("longName", ""),
+                        "mode": _OTP_TO_TRIAS_MODE.get(r.get("mode", ""), "bus"),
+                    }
+
+        # Fetch stoptimes (numberOfDepartures is per-pattern, not total)
+        stoptimes = await self._otp_get(
+            session,
+            f"{_OTP_BASE}/stops/{encoded_id}/stoptimes",
+            {
+                "timeRange": 7200,
+                "numberOfDepartures": max(limit, 5),
+                "omitNonPickups": True,
+            },
+        )
+        if stoptimes is None:
+            return None
+
+        stop_events = []
+        for group in stoptimes:
+            if not isinstance(group, dict):
+                continue
+            pattern = group.get("pattern", {})
+            for t in group.get("times", []):
+                if not isinstance(t, dict):
+                    continue
+                trip = t.get("trip", {})
+                route_id = trip.get("routeId", "")
+                route_info = route_map.get(route_id, {})
+
+                service_day: int = t.get("serviceDay", 0)
+                scheduled: int = t.get("scheduledDeparture", 0)
+                realtime_dep: int = t.get("realtimeDeparture", 0)
+                is_realtime: bool = t.get("realtime", False)
+
+                # Convert OTP timestamps to ISO strings so TRIASBaseProvider.parse_departure works
+                planned_iso = datetime.fromtimestamp(
+                    service_day + scheduled, tz=timezone.utc
+                ).isoformat()
+                estimated_iso = (
+                    datetime.fromtimestamp(
+                        service_day + realtime_dep, tz=timezone.utc
+                    ).isoformat()
+                    if is_realtime
+                    else ""
+                )
+
+                stop_events.append({
+                    "timetabledTime": planned_iso,
+                    "estimatedTime": estimated_iso,
+                    "platform": "",
+                    "plannedPlatform": "",
+                    "lineName": route_info.get("shortName") or pattern.get("desc", ""),
+                    "mode": route_info.get("mode", "bus"),
+                    "submode": "",
+                    "destination": t.get("headsign") or trip.get("tripHeadsign", "Unknown"),
+                    "operator": "",
+                    "isRealtime": is_realtime,
+                })
+
+        stop_events.sort(key=lambda x: x["timetabledTime"])
+        return {"stopEvents": stop_events[:limit]}
+
+    # ── Public overrides ─────────────────────────────────────────────────────
+
+    async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:
+        """Try TRIAS, fall back to OTP if TRIAS is unavailable."""
+        if self._use_trias is not False:
+            results = await super().search_stops(search_term)
+            if results:
+                self._use_trias = True
+                return results
+            _LOGGER.info("VBN TRIAS search returned no results — switching to OTP")
+
+        self._use_trias = False
+        return await self._otp_search_stops(search_term)
+
+    async def fetch_departures(
+        self,
+        station_id: Optional[str],
+        place_dm: str,
+        name_dm: str,
+        departures_limit: int,
+    ) -> Optional[Dict[str, Any]]:
+        """Try TRIAS or OTP based on stop ID prefix and cached preference."""
+        if not station_id:
+            return None
+
+        # OTP IDs are tagged with prefix — always route to OTP
+        if station_id.startswith(_OTP_PREFIX):
+            return await self._otp_fetch_departures(station_id, departures_limit)
+
+        # TRIAS IDs: try TRIAS, fall back to OTP on failure
+        if self._use_trias is not False:
+            result = await super().fetch_departures(
+                station_id, place_dm, name_dm, departures_limit
+            )
+            if result is not None:
+                self._use_trias = True
+                return result
+            _LOGGER.info("VBN TRIAS fetch failed — switching to OTP")
+
+        self._use_trias = False
+        return await self._otp_fetch_departures(station_id, departures_limit)

--- a/custom_components/openpublictransport/providers/vbn.py
+++ b/custom_components/openpublictransport/providers/vbn.py
@@ -1,52 +1,57 @@
-"""VBN (Verkehrsverbund Bremen/Niedersachsen) provider.
+"""VBN (Verkehrsverbund Bremen/Niedersachsen) providers.
 
-Tries TRIAS first (https://fahrplaner.vbn.de/triasproxy/), falls back to
-OpenTripPlanner REST API (http://gtfsr.vbn.de/api/).
+Two separate variants — same API key, different protocol:
 
-Both APIs share the same API key, passed as 'Authorization: Bearer <key>'.
-Request a free key at api@vbn.de — 3,000 transactions/day for non-commercial use.
+  VBNOTPProvider   — OpenTripPlanner REST API (http://gtfsr.vbn.de/api/)
+  VBNTriasProvider — TRIAS XML API            (https://fahrplaner.vbn.de/triasproxy/)
+
+API key: free, request at api@vbn.de — 3,000 transactions/day for non-commercial use.
+Auth: Authorization: <key>  (plain header, no Bearer prefix)
 """
 
-import logging
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Union
-from urllib.parse import quote
-from zoneinfo import ZoneInfo
+from typing import Dict, Optional
 
-import aiohttp
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from ..const import PROVIDER_VBN
-from .trias_base import DEFAULT_MODE_MAPPING, TRIASBaseProvider
-
-_LOGGER = logging.getLogger(__name__)
-
-_OTP_BASE = "http://gtfsr.vbn.de/api/otp/routers/default/index"
-
-# Map OTP GTFS route modes → TRIAS PtMode strings (so parse_departure works for both)
-_OTP_TO_TRIAS_MODE: Dict[str, str] = {
-    "BUS": "bus",
-    "RAIL": "rail",
-    "TRAM": "tram",
-    "SUBWAY": "metro",
-    "FERRY": "water",
-    "GONDOLA": "tram",
-    "FUNICULAR": "funicular",
-    "CABLE_CAR": "telecabin",
-    "COACH": "coach",
-}
-
-# Prefix used on stop IDs returned by OTP search so fetch_departures knows which API to use
-_OTP_PREFIX = "OTP:"
+from ..const import PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS
+from .otp_base import OTPBaseProvider
+from .trias_base import TRIASBaseProvider
 
 
-class VBNProvider(TRIASBaseProvider):
-    """VBN provider — TRIAS with Bearer auth, automatic OTP fallback.
+class VBNOTPProvider(OTPBaseProvider):
+    """VBN via OpenTripPlanner REST API (http://gtfsr.vbn.de/api/)."""
 
-    Stop IDs from OTP search are prefixed with 'OTP:' so the provider always
-    calls the correct backend without requiring user interaction.
-    """
+    otp_base_url = "http://gtfsr.vbn.de/api/otp/routers/default"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_key: Optional[str] = None,
+        api_key_secondary: Optional[str] = None,
+    ) -> None:
+        super().__init__(hass, api_key, api_key_secondary)
+
+    @property
+    def provider_id(self) -> str:
+        return PROVIDER_VBN_OTP
+
+    @property
+    def provider_name(self) -> str:
+        return "VBN OTP (Bremen/Niedersachsen)"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return True
+
+    def _auth_headers(self) -> Dict[str, str]:
+        h = super()._auth_headers()
+        if self.api_key:
+            h["Authorization"] = self.api_key
+        return h
+
+
+class VBNTriasProvider(TRIASBaseProvider):
+    """VBN via TRIAS XML API (https://fahrplaner.vbn.de/triasproxy/)."""
 
     trias_base_url = "https://fahrplaner.vbn.de/triasproxy/"
 
@@ -57,207 +62,20 @@ class VBNProvider(TRIASBaseProvider):
         api_key_secondary: Optional[str] = None,
     ) -> None:
         super().__init__(hass, api_key, api_key_secondary)
-        # Cached API preference: None = not yet determined, True = TRIAS, False = OTP
-        self._use_trias: Optional[bool] = None
 
     @property
     def provider_id(self) -> str:
-        return PROVIDER_VBN
+        return PROVIDER_VBN_TRIAS
 
     @property
     def provider_name(self) -> str:
-        return "VBN (Bremen/Niedersachsen)"
+        return "VBN TRIAS (Bremen/Niedersachsen)"
 
     @property
     def requires_api_key(self) -> bool:
         return True
 
-    # ── Auth ────────────────────────────────────────────────────────────────
-
     def _extra_headers(self) -> Dict[str, str]:
-        """Add API key to all TRIAS requests. VBN uses plain Authorization (no Bearer)."""
         if self.api_key:
             return {"Authorization": self.api_key}
         return {}
-
-    def get_mode_mapping(self) -> Dict[str, str]:
-        """TRIAS PtMode + OTP GTFS mode → unified transport types."""
-        return {
-            **DEFAULT_MODE_MAPPING,
-            # OTP GTFS modes (uppercase) — used when OTP fallback is active
-            "BUS": "bus",
-            "RAIL": "train",
-            "TRAM": "tram",
-            "SUBWAY": "subway",
-            "FERRY": "ferry",
-            "GONDOLA": "tram",
-            "FUNICULAR": "train",
-            "CABLE_CAR": "tram",
-            "COACH": "bus",
-        }
-
-    # ── OTP helpers ─────────────────────────────────────────────────────────
-
-    def _otp_headers(self) -> Dict[str, str]:
-        h = {"Accept": "application/json"}
-        if self.api_key:
-            h["Authorization"] = self.api_key
-        return h
-
-    async def _otp_get(
-        self,
-        session: aiohttp.ClientSession,
-        url: str,
-        params: Optional[Dict] = None,
-    ) -> Optional[Any]:
-        try:
-            async with session.get(
-                url,
-                params=params or {},
-                headers=self._otp_headers(),
-                timeout=aiohttp.ClientTimeout(total=15),
-            ) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                _LOGGER.debug("VBN OTP %s → HTTP %s", url, resp.status)
-        except aiohttp.ClientError as exc:
-            _LOGGER.debug("VBN OTP request failed: %s", exc)
-        except Exception as exc:
-            _LOGGER.debug("VBN OTP error: %s", exc)
-        return None
-
-    async def _otp_search_stops(self, search_term: str) -> List[Dict[str, Any]]:
-        session = async_get_clientsession(self.hass)
-        data = await self._otp_get(session, f"{_OTP_BASE}/stops", {"name": search_term})
-        if not data:
-            return []
-        return [
-            {
-                "id": f"{_OTP_PREFIX}{s['id']}",
-                "name": s.get("name", ""),
-                "place": s.get("name", ""),
-                "area_type": "stop",
-            }
-            for s in data
-            if isinstance(s, dict) and "id" in s
-        ]
-
-    async def _otp_fetch_departures(
-        self,
-        station_id: str,
-        limit: int,
-    ) -> Optional[Dict[str, Any]]:
-        otp_id = station_id.removeprefix(_OTP_PREFIX)
-        encoded_id = quote(otp_id, safe="")
-        session = async_get_clientsession(self.hass)
-
-        # Fetch routes at stop to get line shortName + GTFS mode
-        routes_data = await self._otp_get(session, f"{_OTP_BASE}/stops/{encoded_id}/routes")
-        route_map: Dict[str, Dict[str, str]] = {}
-        if routes_data:
-            for r in routes_data:
-                if isinstance(r, dict) and "id" in r:
-                    route_map[r["id"]] = {
-                        "shortName": r.get("shortName") or r.get("longName", ""),
-                        "mode": _OTP_TO_TRIAS_MODE.get(r.get("mode", ""), "bus"),
-                    }
-
-        # Fetch stoptimes (numberOfDepartures is per-pattern, not total)
-        stoptimes = await self._otp_get(
-            session,
-            f"{_OTP_BASE}/stops/{encoded_id}/stoptimes",
-            {
-                "timeRange": 7200,
-                "numberOfDepartures": max(limit, 5),
-                "omitNonPickups": True,
-            },
-        )
-        if stoptimes is None:
-            return None
-
-        stop_events = []
-        for group in stoptimes:
-            if not isinstance(group, dict):
-                continue
-            pattern = group.get("pattern", {})
-            for t in group.get("times", []):
-                if not isinstance(t, dict):
-                    continue
-                trip = t.get("trip", {})
-                route_id = trip.get("routeId", "")
-                route_info = route_map.get(route_id, {})
-
-                service_day: int = t.get("serviceDay", 0)
-                scheduled: int = t.get("scheduledDeparture", 0)
-                realtime_dep: int = t.get("realtimeDeparture", 0)
-                is_realtime: bool = t.get("realtime", False)
-
-                # Convert OTP timestamps to ISO strings so TRIASBaseProvider.parse_departure works
-                planned_iso = datetime.fromtimestamp(
-                    service_day + scheduled, tz=timezone.utc
-                ).isoformat()
-                estimated_iso = (
-                    datetime.fromtimestamp(
-                        service_day + realtime_dep, tz=timezone.utc
-                    ).isoformat()
-                    if is_realtime
-                    else ""
-                )
-
-                stop_events.append({
-                    "timetabledTime": planned_iso,
-                    "estimatedTime": estimated_iso,
-                    "platform": "",
-                    "plannedPlatform": "",
-                    "lineName": route_info.get("shortName") or pattern.get("desc", ""),
-                    "mode": route_info.get("mode", "bus"),
-                    "submode": "",
-                    "destination": t.get("headsign") or trip.get("tripHeadsign", "Unknown"),
-                    "operator": "",
-                    "isRealtime": is_realtime,
-                })
-
-        stop_events.sort(key=lambda x: x["timetabledTime"])
-        return {"stopEvents": stop_events[:limit]}
-
-    # ── Public overrides ─────────────────────────────────────────────────────
-
-    async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:
-        """Try TRIAS, fall back to OTP if TRIAS is unavailable."""
-        if self._use_trias is not False:
-            results = await super().search_stops(search_term)
-            if results:
-                self._use_trias = True
-                return results
-            _LOGGER.info("VBN TRIAS search returned no results — switching to OTP")
-
-        self._use_trias = False
-        return await self._otp_search_stops(search_term)
-
-    async def fetch_departures(
-        self,
-        station_id: Optional[str],
-        place_dm: str,
-        name_dm: str,
-        departures_limit: int,
-    ) -> Optional[Dict[str, Any]]:
-        """Try TRIAS or OTP based on stop ID prefix and cached preference."""
-        if not station_id:
-            return None
-
-        # OTP IDs are tagged with prefix — always route to OTP
-        if station_id.startswith(_OTP_PREFIX):
-            return await self._otp_fetch_departures(station_id, departures_limit)
-
-        # TRIAS IDs: try TRIAS, fall back to OTP on failure
-        if self._use_trias is not False:
-            result = await super().fetch_departures(
-                station_id, place_dm, name_dm, departures_limit
-            )
-            if result is not None:
-                self._use_trias = True
-                return result
-            _LOGGER.info("VBN TRIAS fetch failed — switching to OTP")
-
-        self._use_trias = False
-        return await self._otp_fetch_departures(station_id, departures_limit)

--- a/custom_components/openpublictransport/providers/vbn.py
+++ b/custom_components/openpublictransport/providers/vbn.py
@@ -21,7 +21,7 @@ from .trias_base import TRIASBaseProvider
 class VBNOTPProvider(OTPBaseProvider):
     """VBN via OpenTripPlanner REST API (http://gtfsr.vbn.de/api/)."""
 
-    otp_base_url = "http://gtfsr.vbn.de/api/otp/routers/default"
+    otp_base_url = "http://gtfsr.vbn.de/api/routers/default"
 
     def __init__(
         self,

--- a/custom_components/openpublictransport/providers/vbn.py
+++ b/custom_components/openpublictransport/providers/vbn.py
@@ -75,9 +75,9 @@ class VBNProvider(TRIASBaseProvider):
     # ── Auth ────────────────────────────────────────────────────────────────
 
     def _extra_headers(self) -> Dict[str, str]:
-        """Add Bearer token to all TRIAS requests."""
+        """Add API key to all TRIAS requests. VBN uses plain Authorization (no Bearer)."""
         if self.api_key:
-            return {"Authorization": f"Bearer {self.api_key}"}
+            return {"Authorization": self.api_key}
         return {}
 
     def get_mode_mapping(self) -> Dict[str, str]:
@@ -101,7 +101,7 @@ class VBNProvider(TRIASBaseProvider):
     def _otp_headers(self) -> Dict[str, str]:
         h = {"Accept": "application/json"}
         if self.api_key:
-            h["Authorization"] = f"Bearer {self.api_key}"
+            h["Authorization"] = self.api_key
         return h
 
     async def _otp_get(

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_TRAFIKLAB_API_KEY,
     CONF_TRANSPORTATION_TYPES,
     CONF_USE_PROVIDER_LOGO,
+    CONF_VBN_API_KEY,
     CONF_WALKING_TIME,
     DEFAULT_DEPARTURES,
     DEFAULT_NAME,
@@ -36,6 +37,8 @@ from .const import (
     PROVIDER_ENTITY_PICTURES,
     PROVIDER_NTA_IE,
     PROVIDER_TRAFIKLAB_SE,
+    PROVIDER_VBN_OTP,
+    PROVIDER_VBN_TRIAS,
     PROVIDER_VRR,
     TRANSPORTATION_TYPES,
 )
@@ -261,6 +264,7 @@ async def async_setup_entry(
         station_id = config_entry.data.get(CONF_STATION_ID)
         trafiklab_api_key = config_entry.data.get(CONF_TRAFIKLAB_API_KEY)
         nta_api_key = config_entry.data.get(CONF_NTA_API_KEY)
+        vbn_api_key = config_entry.data.get(CONF_VBN_API_KEY)
 
         # Use appropriate API key based on provider
         api_key = None
@@ -268,6 +272,8 @@ async def async_setup_entry(
             api_key = trafiklab_api_key
         elif provider == PROVIDER_NTA_IE:
             api_key = nta_api_key
+        elif provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
+            api_key = vbn_api_key
 
         departures = config_entry.options.get(
             CONF_DEPARTURES, config_entry.data.get(CONF_DEPARTURES, DEFAULT_DEPARTURES)

--- a/custom_components/openpublictransport/translations/de.json
+++ b/custom_components/openpublictransport/translations/de.json
@@ -9,7 +9,7 @@
           "entry_type": "Typ"
         },
         "data_description": {
-          "provider": "VRR, KVV, HVV, BVG, MVV, VVS, VAG, VRN, VVO, DING, AVV, RVV, RMV, SBB, ÖBB, Transitous, Trafiklab oder NTA"
+          "provider": "VRR, KVV, HVV, BVG, MVV, VVS, VAG, VRN, VVO, DING, AVV, RVV, RMV, VBN, SBB, ÖBB, Transitous, Trafiklab oder NTA"
         }
       },
       "stop_search": {
@@ -33,13 +33,15 @@
           "trafiklab_api_key": "Trafiklab API-Schlüssel",
           "nta_api_key": "NTA Primary API-Schlüssel",
           "nta_api_key_secondary": "NTA Secondary API-Schlüssel (optional)",
-          "rmv_api_key": "RMV API-Schlüssel"
+          "rmv_api_key": "RMV API-Schlüssel",
+          "vbn_api_key": "VBN API-Schlüssel"
         },
         "data_description": {
           "trafiklab_api_key": "Trafiklab API-Schlüssel (erhältlich auf trafiklab.se)",
           "nta_api_key": "NTA Primary API-Schlüssel (erforderlich, erhältlich auf developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA Secondary API-Schlüssel (optional, als Fallback)",
-          "rmv_api_key": "RMV API-Schlüssel (erhältlich auf opendata.rmv.de)"
+          "rmv_api_key": "RMV API-Schlüssel (erhältlich auf opendata.rmv.de)",
+          "vbn_api_key": "VBN API-Schlüssel — kostenlos für private Nutzung, per E-Mail anfragen bei api@vbn.de"
         }
       },
       "settings": {
@@ -104,6 +106,7 @@
       "trafiklab_api_key_required": "Trafiklab API-Schlüssel ist erforderlich",
       "nta_api_key_required": "NTA API-Schlüssel ist erforderlich",
       "rmv_api_key_required": "RMV API-Schlüssel ist erforderlich",
+      "vbn_api_key_required": "VBN API-Schlüssel ist erforderlich",
       "min_two_entities": "Bitte mindestens 2 Entity-IDs angeben"
     }
   },

--- a/custom_components/openpublictransport/translations/de.json
+++ b/custom_components/openpublictransport/translations/de.json
@@ -3,20 +3,10 @@
     "step": {
       "user": {
         "title": "ÖPNV Anbieter wählen",
-        "description": "Wähle den Eintragstyp und suche nach deinem Anbieter.",
+        "description": "Wähle deinen ÖPNV-Anbieter aus",
         "data": {
-          "entry_type": "Typ",
-          "provider_search": "Anbietersuche"
-        },
-        "data_description": {
-          "provider_search": "Region oder Anbieterkürzel eingeben, um zu filtern — z.B. \"Hamburg\", \"VBN\", \"Bremen\""
-        }
-      },
-      "provider_select": {
-        "title": "Anbieter auswählen",
-        "description": "{count} Ergebnis(se) für \"{search}\" — Anbieter auswählen:",
-        "data": {
-          "provider": "Anbieter"
+          "provider": "Anbieter",
+          "entry_type": "Typ"
         }
       },
       "stop_search": {
@@ -109,7 +99,6 @@
       "missing_location": "Bitte geben Sie entweder eine Stations-ID oder Ort und Haltestelle an",
       "empty_search": "Bitte geben Sie einen Suchbegriff ein",
       "no_results": "Keine Ergebnisse gefunden. Bitte versuchen Sie einen anderen Suchbegriff.",
-      "no_providers_found": "Kein Anbieter für diesen Suchbegriff gefunden. Alle Anbieter werden angezeigt.",
       "api_key_required": "API-Schlüssel ist erforderlich",
       "trafiklab_api_key_required": "Trafiklab API-Schlüssel ist erforderlich",
       "nta_api_key_required": "NTA API-Schlüssel ist erforderlich",

--- a/custom_components/openpublictransport/translations/de.json
+++ b/custom_components/openpublictransport/translations/de.json
@@ -3,13 +3,20 @@
     "step": {
       "user": {
         "title": "ÖPNV Anbieter wählen",
-        "description": "Wähle deinen ÖPNV-Anbieter aus",
+        "description": "Wähle den Eintragstyp und suche nach deinem Anbieter.",
         "data": {
-          "provider": "Anbieter",
-          "entry_type": "Typ"
+          "entry_type": "Typ",
+          "provider_search": "Anbietersuche"
         },
         "data_description": {
-          "provider": "VRR, KVV, HVV, BVG, MVV, VVS, VAG, VRN, VVO, DING, AVV, RVV, RMV, VBN, SBB, ÖBB, Transitous, Trafiklab oder NTA"
+          "provider_search": "Region oder Anbieterkürzel eingeben, um zu filtern — z.B. \"Hamburg\", \"VBN\", \"Bremen\""
+        }
+      },
+      "provider_select": {
+        "title": "Anbieter auswählen",
+        "description": "{count} Ergebnis(se) für \"{search}\" — Anbieter auswählen:",
+        "data": {
+          "provider": "Anbieter"
         }
       },
       "stop_search": {
@@ -102,6 +109,7 @@
       "missing_location": "Bitte geben Sie entweder eine Stations-ID oder Ort und Haltestelle an",
       "empty_search": "Bitte geben Sie einen Suchbegriff ein",
       "no_results": "Keine Ergebnisse gefunden. Bitte versuchen Sie einen anderen Suchbegriff.",
+      "no_providers_found": "Kein Anbieter für diesen Suchbegriff gefunden. Alle Anbieter werden angezeigt.",
       "api_key_required": "API-Schlüssel ist erforderlich",
       "trafiklab_api_key_required": "Trafiklab API-Schlüssel ist erforderlich",
       "nta_api_key_required": "NTA API-Schlüssel ist erforderlich",

--- a/custom_components/openpublictransport/translations/de.json
+++ b/custom_components/openpublictransport/translations/de.json
@@ -38,7 +38,7 @@
           "nta_api_key": "NTA Primary API-Schlüssel (erforderlich, erhältlich auf developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA Secondary API-Schlüssel (optional, als Fallback)",
           "rmv_api_key": "RMV API-Schlüssel (erhältlich auf opendata.rmv.de)",
-          "vbn_api_key": "VBN API-Schlüssel — kostenlos für private Nutzung, per E-Mail anfragen bei api@vbn.de"
+          "vbn_api_key": "VBN API-Schlüssel — gilt für OTP und TRIAS. Kostenlos für private Nutzung, per E-Mail anfragen bei api@vbn.de"
         }
       },
       "settings": {

--- a/custom_components/openpublictransport/translations/en.json
+++ b/custom_components/openpublictransport/translations/en.json
@@ -3,13 +3,20 @@
     "step": {
       "user": {
         "title": "Select Public Transport Provider",
-        "description": "Choose your public transport provider",
+        "description": "Choose your entry type and search for a provider.",
         "data": {
-          "provider": "Provider",
-          "entry_type": "Type"
+          "entry_type": "Type",
+          "provider_search": "Provider search"
         },
         "data_description": {
-          "provider": "VRR, KVV, HVV, BVG, MVV, VVS, VAG, VRN, VVO, DING, AVV, RVV, RMV, VBN, SBB, ÖBB, Transitous, Trafiklab or NTA"
+          "provider_search": "Type a region or provider name to filter — e.g. \"Hamburg\", \"VBN\", \"Bremen\""
+        }
+      },
+      "provider_select": {
+        "title": "Select Provider",
+        "description": "{count} result(s) for \"{search}\" — select your provider:",
+        "data": {
+          "provider": "Provider"
         }
       },
       "stop_search": {
@@ -102,6 +109,7 @@
       "missing_location": "Please provide either a station ID or location and stop name",
       "empty_search": "Please enter a search term",
       "no_results": "No results found. Please try a different search term.",
+      "no_providers_found": "No providers found for this search term. Showing all providers.",
       "api_key_required": "API key is required",
       "trafiklab_api_key_required": "Trafiklab API key is required",
       "nta_api_key_required": "NTA API key is required",

--- a/custom_components/openpublictransport/translations/en.json
+++ b/custom_components/openpublictransport/translations/en.json
@@ -38,7 +38,7 @@
           "nta_api_key": "NTA Primary API key (required, available at developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA Secondary API key (optional, used as fallback)",
           "rmv_api_key": "RMV API key (request at opendata.rmv.de)",
-          "vbn_api_key": "VBN API key — free for non-commercial use, request by e-mail at api@vbn.de"
+          "vbn_api_key": "VBN API key — works for both OTP and TRIAS. Free for non-commercial use, request by e-mail at api@vbn.de"
         }
       },
       "settings": {

--- a/custom_components/openpublictransport/translations/en.json
+++ b/custom_components/openpublictransport/translations/en.json
@@ -3,20 +3,10 @@
     "step": {
       "user": {
         "title": "Select Public Transport Provider",
-        "description": "Choose your entry type and search for a provider.",
+        "description": "Choose your public transport provider",
         "data": {
-          "entry_type": "Type",
-          "provider_search": "Provider search"
-        },
-        "data_description": {
-          "provider_search": "Type a region or provider name to filter — e.g. \"Hamburg\", \"VBN\", \"Bremen\""
-        }
-      },
-      "provider_select": {
-        "title": "Select Provider",
-        "description": "{count} result(s) for \"{search}\" — select your provider:",
-        "data": {
-          "provider": "Provider"
+          "provider": "Provider",
+          "entry_type": "Type"
         }
       },
       "stop_search": {
@@ -109,7 +99,6 @@
       "missing_location": "Please provide either a station ID or location and stop name",
       "empty_search": "Please enter a search term",
       "no_results": "No results found. Please try a different search term.",
-      "no_providers_found": "No providers found for this search term. Showing all providers.",
       "api_key_required": "API key is required",
       "trafiklab_api_key_required": "Trafiklab API key is required",
       "nta_api_key_required": "NTA API key is required",

--- a/custom_components/openpublictransport/translations/en.json
+++ b/custom_components/openpublictransport/translations/en.json
@@ -9,7 +9,7 @@
           "entry_type": "Type"
         },
         "data_description": {
-          "provider": "VRR, KVV, HVV, BVG, MVV, VVS, VAG, VRN, VVO, DING, AVV, RVV, RMV, SBB, ÖBB, Transitous, Trafiklab or NTA"
+          "provider": "VRR, KVV, HVV, BVG, MVV, VVS, VAG, VRN, VVO, DING, AVV, RVV, RMV, VBN, SBB, ÖBB, Transitous, Trafiklab or NTA"
         }
       },
       "stop_search": {
@@ -33,13 +33,15 @@
           "trafiklab_api_key": "Trafiklab API Key",
           "nta_api_key": "NTA Primary API Key",
           "nta_api_key_secondary": "NTA Secondary API Key (optional)",
-          "rmv_api_key": "RMV API Key"
+          "rmv_api_key": "RMV API Key",
+          "vbn_api_key": "VBN API Key"
         },
         "data_description": {
           "trafiklab_api_key": "Trafiklab API key (available at trafiklab.se)",
           "nta_api_key": "NTA Primary API key (required, available at developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA Secondary API key (optional, used as fallback)",
-          "rmv_api_key": "RMV API key (request at opendata.rmv.de)"
+          "rmv_api_key": "RMV API key (request at opendata.rmv.de)",
+          "vbn_api_key": "VBN API key — free for non-commercial use, request by e-mail at api@vbn.de"
         }
       },
       "settings": {
@@ -104,6 +106,7 @@
       "trafiklab_api_key_required": "Trafiklab API key is required",
       "nta_api_key_required": "NTA API key is required",
       "rmv_api_key_required": "RMV API key is required",
+      "vbn_api_key_required": "VBN API key is required",
       "min_two_entities": "Please provide at least 2 entity IDs"
     }
   },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,23 +1,29 @@
 # Changelog
 
-## v2026.5.2 - VBN Provider & Searchable Provider Dropdown
+## v2026.5.2 - VBN Provider & Alphabetical Provider Dropdown
 
 ### New Provider
 
-- **VBN (Verkehrsverbund Bremen/Niedersachsen)** - Bremen, Bremerhaven, and surrounding Lower Saxony counties via TRIAS (VDV 431-2) XML API. API key required (free, request at api@vbn.de, 3,000 transactions/day for hobbyists).
+- **VBN (Verkehrsverbund Bremen/Niedersachsen)** - Bremen, Bremerhaven, and surrounding Lower Saxony counties. API key required (free, request at api@vbn.de, 3,000 transactions/day for hobbyists).
+
+  VBN supports two APIs, both using `Authorization: Bearer <key>`:
+  - **TRIAS** (`https://fahrplaner.vbn.de/triasproxy/`) — primary
+  - **OTP REST** (`http://gtfsr.vbn.de/api/`) — automatic fallback if TRIAS is unavailable
+
+  The integration detects which API works and switches automatically — no configuration needed.
 
 ### Improvements
 
-- **Searchable provider dropdown** - The provider selector is now a native HA searchable dropdown (`SelectSelector`). Type to filter — no more scrolling through 25 entries.
-- **Alphabetical provider order** - All 25 providers sorted A–Z in both the dropdown and documentation.
+- **Alphabetical provider order** - All 25 providers sorted A–Z in the dropdown and documentation.
+- **TRIAS auth header support** - Added `_extra_headers()` hook to `TRIASBaseProvider` so providers that require HTTP-level authentication (like VBN) can inject `Authorization` headers without touching the base class.
 
 ### Documentation
 
-- Provider docs: new page `docs/providers/vbn.md` with API key instructions, quota info, and troubleshooting.
+- Provider docs: new page `docs/providers/vbn.md` with API key instructions, quota info, both API endpoints, and troubleshooting.
 - All provider counts updated to 25 across README and docs.
 
 !!! info "Total providers: 25"
-    VBN joins as the 25th provider via the existing TRIAS base class — zero new parsing code required.
+    VBN joins as the 25th provider. Both TRIAS and OTP REST are supported with automatic fallback.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,39 +1,32 @@
 # Changelog
 
-## v2026.5.2 - VBN Provider (OTP + TRIAS), OTPBaseProvider, Agency & Alerts
-
-### Improvements
-
-- **VBN OTP: agency/operator** — Operator name (e.g. "Bremer Straßenbahn AG") extracted from the OTP routes endpoint and exposed as `agency` on every departure.
-- **VBN OTP: stop alerts** — Active service alerts fetched from `/index/stops/{id}/alerts` and attached as `notices` to all departures at the stop.
-- **VBN OTP: auth fix** — `CONF_VBN_API_KEY` is now correctly extracted from the config entry and passed to the provider in both `__init__.py` and the `sensor.py` fallback coordinator.
-- **VBN OTP: omitNonPickups fix** — Query parameter changed from Python `True` to string `"true"` (aiohttp requirement).
-- **Provider comparison table** — Added Agency/Operator and Alerts/Notices rows; footnote explaining VBN OTP's geocoded stop search.
-- **VBN docs rewritten** — Corrected auth header format, removed incorrect auto-fallback description, added per-variant feature table.
-
----
-
 ## v2026.5.2 - VBN Provider (OTP + TRIAS) & New OTPBaseProvider
 
 ### New Providers
 
 - **VBN OTP** (`vbn_otp`) — Bremen, Bremerhaven, and surrounding Lower Saxony counties via OpenTripPlanner REST API (`http://gtfsr.vbn.de/api/`). API key required (free, request at api@vbn.de).
-- **VBN TRIAS** (`vbn_trias`) — Same region via TRIAS XML API (`https://fahrplaner.vbn.de/triasproxy/`). Same API key.
+- **VBN TRIAS** (`vbn_trias`) — Same region via TRIAS XML API (`https://fahrplaner.vbn.de/triasproxy/`). Same API key (or a separate TRIAS key from VBN).
 
-Both providers use `Authorization: <key>` HTTP header. Choose based on which API key VBN issued you.
+Both providers use `Authorization: <key>` (plain header, no Bearer prefix). Choose the variant that matches the key VBN issued you.
 
 ### New Architecture
 
-- **OTPBaseProvider** (`otp_base.py`) — Base class for OpenTripPlanner REST API providers, analogous to `TRIASBaseProvider`. Handles stop search, stoptimes + routes fetch, and `parse_departure`. Subclasses only define `otp_base_url`, `provider_id`, `provider_name`, and optional `_auth_headers()`.
+- **OTPBaseProvider** (`otp_base.py`) — Base class for OpenTripPlanner REST API providers, analogous to `TRIASBaseProvider`. Handles Nominatim geocoding for stop search, stoptimes + routes fetch, alerts, and `parse_departure`. Subclasses only define `otp_base_url`, `provider_id`, `provider_name`, and optional `_auth_headers()`.
 - **`_extra_headers()` hook** in `TRIASBaseProvider` — lets subclasses inject HTTP auth headers without modifying the base class.
+
+### New Features (VBN OTP)
+
+- **Agency/Operator** — Operator name (e.g. "Bremer Straßenbahn AG") extracted from the OTP routes endpoint and exposed as `agency` on every departure.
+- **Stop alerts** — Active service alerts fetched from `/index/stops/{id}/alerts` and attached as `notices` to all departures at the stop.
 
 ### Improvements
 
 - **Alphabetical provider order** — All 26 providers sorted A–Z in the dropdown and documentation.
+- **Provider comparison table** — Added Agency/Operator and Alerts/Notices rows across all providers.
 
 ### Documentation
 
-- Provider docs: `docs/providers/vbn.md` — both API endpoints, auth header format, quotas, troubleshooting.
+- Provider docs: `docs/providers/vbn.md` — both API variants, correct `Authorization: <key>` header format, per-variant feature table, quotas, troubleshooting.
 - Provider count updated to 26 across README and docs.
 
 !!! info "Total providers: 26"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v2026.5.2 - VBN Provider & Searchable Provider Dropdown
+
+### New Provider
+
+- **VBN (Verkehrsverbund Bremen/Niedersachsen)** - Bremen, Bremerhaven, and surrounding Lower Saxony counties via TRIAS (VDV 431-2) XML API. API key required (free, request at api@vbn.de, 3,000 transactions/day for hobbyists).
+
+### Improvements
+
+- **Searchable provider dropdown** - The provider selector is now a native HA searchable dropdown (`SelectSelector`). Type to filter — no more scrolling through 25 entries.
+- **Alphabetical provider order** - All 25 providers sorted A–Z in both the dropdown and documentation.
+
+### Documentation
+
+- Provider docs: new page `docs/providers/vbn.md` with API key instructions, quota info, and troubleshooting.
+- All provider counts updated to 25 across README and docs.
+
+!!! info "Total providers: 25"
+    VBN joins as the 25th provider via the existing TRIAS base class — zero new parsing code required.
+
+---
+
 ## v2026.4.16 - Deutsche Bahn, TRIAS Protocol, New Logo & Website
 
 ### New Provider

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v2026.5.2 - VBN Provider (OTP + TRIAS), OTPBaseProvider, Agency & Alerts
+
+### Improvements
+
+- **VBN OTP: agency/operator** — Operator name (e.g. "Bremer Straßenbahn AG") extracted from the OTP routes endpoint and exposed as `agency` on every departure.
+- **VBN OTP: stop alerts** — Active service alerts fetched from `/index/stops/{id}/alerts` and attached as `notices` to all departures at the stop.
+- **VBN OTP: auth fix** — `CONF_VBN_API_KEY` is now correctly extracted from the config entry and passed to the provider in both `__init__.py` and the `sensor.py` fallback coordinator.
+- **VBN OTP: omitNonPickups fix** — Query parameter changed from Python `True` to string `"true"` (aiohttp requirement).
+- **Provider comparison table** — Added Agency/Operator and Alerts/Notices rows; footnote explaining VBN OTP's geocoded stop search.
+- **VBN docs rewritten** — Corrected auth header format, removed incorrect auto-fallback description, added per-variant feature table.
+
+---
+
 ## v2026.5.2 - VBN Provider (OTP + TRIAS) & New OTPBaseProvider
 
 ### New Providers

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,29 +1,30 @@
 # Changelog
 
-## v2026.5.2 - VBN Provider & Alphabetical Provider Dropdown
+## v2026.5.2 - VBN Provider (OTP + TRIAS) & New OTPBaseProvider
 
-### New Provider
+### New Providers
 
-- **VBN (Verkehrsverbund Bremen/Niedersachsen)** - Bremen, Bremerhaven, and surrounding Lower Saxony counties. API key required (free, request at api@vbn.de, 3,000 transactions/day for hobbyists).
+- **VBN OTP** (`vbn_otp`) — Bremen, Bremerhaven, and surrounding Lower Saxony counties via OpenTripPlanner REST API (`http://gtfsr.vbn.de/api/`). API key required (free, request at api@vbn.de).
+- **VBN TRIAS** (`vbn_trias`) — Same region via TRIAS XML API (`https://fahrplaner.vbn.de/triasproxy/`). Same API key.
 
-  VBN supports two APIs, both using `Authorization: Bearer <key>`:
-  - **TRIAS** (`https://fahrplaner.vbn.de/triasproxy/`) — primary
-  - **OTP REST** (`http://gtfsr.vbn.de/api/`) — automatic fallback if TRIAS is unavailable
+Both providers use `Authorization: <key>` HTTP header. Choose based on which API key VBN issued you.
 
-  The integration detects which API works and switches automatically — no configuration needed.
+### New Architecture
+
+- **OTPBaseProvider** (`otp_base.py`) — Base class for OpenTripPlanner REST API providers, analogous to `TRIASBaseProvider`. Handles stop search, stoptimes + routes fetch, and `parse_departure`. Subclasses only define `otp_base_url`, `provider_id`, `provider_name`, and optional `_auth_headers()`.
+- **`_extra_headers()` hook** in `TRIASBaseProvider` — lets subclasses inject HTTP auth headers without modifying the base class.
 
 ### Improvements
 
-- **Alphabetical provider order** - All 25 providers sorted A–Z in the dropdown and documentation.
-- **TRIAS auth header support** - Added `_extra_headers()` hook to `TRIASBaseProvider` so providers that require HTTP-level authentication (like VBN) can inject `Authorization` headers without touching the base class.
+- **Alphabetical provider order** — All 26 providers sorted A–Z in the dropdown and documentation.
 
 ### Documentation
 
-- Provider docs: new page `docs/providers/vbn.md` with API key instructions, quota info, both API endpoints, and troubleshooting.
-- All provider counts updated to 25 across README and docs.
+- Provider docs: `docs/providers/vbn.md` — both API endpoints, auth header format, quotas, troubleshooting.
+- Provider count updated to 26 across README and docs.
 
-!!! info "Total providers: 25"
-    VBN joins as the 25th provider. Both TRIAS and OTP REST are supported with automatic fallback.
+!!! info "Total providers: 26"
+    VBN joins as two separate selectable variants (OTP + TRIAS) for a total of 26 provider options.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Real-time public transport departures for Home Assistant — 25 providers across
 | **Trafiklab** | Sweden (nationwide) | REST | Yes (free) |
 | **Transitous** | Worldwide (community) | MOTIS2 | No |
 | **VAG** | Freiburg | EFA | No |
-| **VBN** | Bremen / Niedersachsen | TRIAS | Yes (free) |
+| **VBN** | Bremen / Niedersachsen | TRIAS / OTP | Yes (free) |
 | **VGN** | Nuremberg | EFA | No |
 | **VRN** | Rhein-Neckar | EFA | No |
 | **VRR** | Rhein-Ruhr (NRW) | EFA | No |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,39 +1,41 @@
 # openpublictransport
 
-Real-time public transport departures for Home Assistant — 23 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
+Real-time public transport departures for Home Assistant — 25 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
 
 !!! tip "Coming from VRRAPI-HACS or hacs-publictransport?"
     This is the new official repository! The domain changed from `vrr` to `openpublictransport` — entity IDs and services have new names.
     
     **[→ Migration Guide](migration.md)** — Step-by-step instructions for both migrations.
 
-## Supported Providers (23)
+## Supported Providers (25)
 
 | Provider | Region | API Type | API Key |
 |----------|--------|----------|---------|
-| **VRR** | Rhein-Ruhr (NRW) | EFA | No |
-| **KVV** | Karlsruhe | EFA | No |
-| **HVV** | Hamburg | REST | No |
-| **BVG** | Berlin / Brandenburg | REST | No |
-| **MVV** | Munich | EFA | No |
-| **VVS** | Stuttgart | EFA | No |
-| **VGN** | Nuremberg | EFA | No |
-| **VAG** | Freiburg | EFA | No |
-| **RMV** | Frankfurt / Rhein-Main | HAFAS | Yes (free) |
-| **VRN** | Rhein-Neckar | EFA | No |
-| **VVO** | Dresden | EFA | No |
-| **DING** | Ulm / Donau-Iller | EFA | No |
 | **AVV** | Augsburg | EFA | No |
-| **RVV** | Regensburg | EFA | No |
-| **BSVG** | Braunschweig | EFA | No |
-| **NWL** | Westfalen-Lippe | EFA | No |
-| **NVBW** | Baden-Württemberg | EFA | No |
 | **BEG** | Bavaria | EFA | No |
-| **SBB** | Switzerland (nationwide) | EFA | No |
-| **ÖBB** | Austria (nationwide) | EFA | No |
-| **Trafiklab** | Sweden (nationwide) | REST | Yes (free) |
+| **BSVG** | Braunschweig | EFA | No |
+| **BVG** | Berlin / Brandenburg | FPTF REST | No |
+| **DB** | Germany (nationwide, community API) | FPTF REST | No |
+| **DING** | Ulm / Donau-Iller | EFA | No |
+| **HVV** | Hamburg | EFA | No |
+| **KVV** | Karlsruhe | EFA | No |
+| **MVV** | Munich | EFA | No |
 | **NTA** | Ireland (nationwide) | GTFS-RT | Yes (free) |
+| **NVBW** | Baden-Württemberg | EFA | No |
+| **NWL** | Westfalen-Lippe | EFA | No |
+| **ÖBB** | Austria (nationwide) | FPTF REST | No |
+| **RMV** | Frankfurt / Rhein-Main | HAFAS | Yes (free) |
+| **RVV** | Regensburg | EFA | No |
+| **SBB** | Switzerland (nationwide) | REST | No |
+| **Trafiklab** | Sweden (nationwide) | REST | Yes (free) |
 | **Transitous** | Worldwide (community) | MOTIS2 | No |
+| **VAG** | Freiburg | EFA | No |
+| **VBN** | Bremen / Niedersachsen | TRIAS | Yes (free) |
+| **VGN** | Nuremberg | EFA | No |
+| **VRN** | Rhein-Neckar | EFA | No |
+| **VRR** | Rhein-Ruhr (NRW) | EFA | No |
+| **VVO** | Dresden | EFA | No |
+| **VVS** | Stuttgart | EFA | No |
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 # openpublictransport
 
-Real-time public transport departures for Home Assistant — 25 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
+Real-time public transport departures for Home Assistant — 26 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
 
 !!! tip "Coming from VRRAPI-HACS or hacs-publictransport?"
     This is the new official repository! The domain changed from `vrr` to `openpublictransport` — entity IDs and services have new names.
     
     **[→ Migration Guide](migration.md)** — Step-by-step instructions for both migrations.
 
-## Supported Providers (25)
+## Supported Providers (26)
 
 | Provider | Region | API Type | API Key |
 |----------|--------|----------|---------|
@@ -30,7 +30,8 @@ Real-time public transport departures for Home Assistant — 25 providers across
 | **Trafiklab** | Sweden (nationwide) | REST | Yes (free) |
 | **Transitous** | Worldwide (community) | MOTIS2 | No |
 | **VAG** | Freiburg | EFA | No |
-| **VBN** | Bremen / Niedersachsen | TRIAS / OTP | Yes (free) |
+| **VBN (OTP)** | Bremen / Niedersachsen | OTP REST | Yes (free) |
+| **VBN (TRIAS)** | Bremen / Niedersachsen | TRIAS XML | Yes (free) |
 | **VGN** | Nuremberg | EFA | No |
 | **VRN** | Rhein-Neckar | EFA | No |
 | **VRR** | Rhein-Ruhr (NRW) | EFA | No |

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -12,7 +12,11 @@ The Public Transport Integration supports multiple transit providers across Euro
 | **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
 | **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
 | **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available |
-| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete |
+| **Agency/Operator** | No | No | No | No | No | No | No | Yes | Yes | Yes | No | No | No | No | No | No | No | No | No | No | No | Yes | Yes | No | When available |
+| **Alerts/Notices** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | No | Yes | When available |
+| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Geocoded¹ | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete |
+
+¹ VBN OTP has no native name-based stop search. The integration geocodes your search term via Nominatim (OpenStreetMap) and finds stops within 500 m of the resolved coordinates.
 
 ## Timezone Handling
 
@@ -110,11 +114,11 @@ Different providers use different internal classification systems. The integrati
 | Tram | tram | Tram/Straßenbahn |
 | Bus | bus | Bus services |
 
-### VBN Transport Modes (TRIAS + OTP fallback)
+### VBN Transport Modes
 
-VBN uses TRIAS as the primary API. If TRIAS is unavailable, the integration automatically falls back to VBN's OpenTripPlanner REST API. Both APIs use the same API key (`Authorization: Bearer <key>`).
+VBN is available as two separate provider variants. Both use `Authorization: <key>` (no Bearer prefix).
 
-**TRIAS PtMode strings:**
+**VBN TRIAS — PtMode strings:**
 
 | PtMode | Type | Description |
 |--------|------|-------------|
@@ -126,7 +130,7 @@ VBN uses TRIAS as the primary API. If TRIAS is unavailable, the integration auto
 | coach | bus | Coach/Express bus |
 | water | ferry | Ferry |
 
-**OTP GTFS route modes (fallback):**
+**VBN OTP — GTFS route modes:**
 
 | Mode | Type | Description |
 |------|------|-------------|

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -7,7 +7,7 @@ The Public Transport Integration supports multiple transit providers across Euro
 | Feature | VRR | KVV | HVV | MVV | VVS | VGN | VAG Freiburg | BVG | RMV | VBN | VRN | VVO | DING | AVV | RVV | BSVG | NWL | NVBW | BEG | SBB | ÖBB | Trafiklab | NTA | Transitous |
 |---------|-----|-----|-----|-----|-----|-----|--------------|-----|-----|-----|-----|-----|------|-----|-----|------|-----|------|-----|-----|-----|-----------|-----|-----------|
 | **Region** | NRW | Karlsruhe | Hamburg | Munich | Stuttgart | Nuremberg | Freiburg | Berlin | Frankfurt | Bremen/Niedersachsen | Rhein-Neckar | Dresden | Ulm | Augsburg | Regensburg | Braunschweig | Westfalen-Lippe | Baden-Württemberg | Bayern | Switzerland | Austria | Sweden | Ireland | Worldwide |
-| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | TRIAS XML | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | FPTF REST | REST | GTFS-RT | MOTIS2 |
+| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | TRIAS / OTP | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | FPTF REST | REST | GTFS-RT | MOTIS2 |
 | **API Key** | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No | No | No | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No |
 | **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
 | **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
@@ -109,7 +109,11 @@ Different providers use different internal classification systems. The integrati
 | Tram | tram | Tram/Straßenbahn |
 | Bus | bus | Bus services |
 
-### VBN PtMode Strings (TRIAS)
+### VBN Transport Modes (TRIAS + OTP fallback)
+
+VBN uses TRIAS as the primary API. If TRIAS is unavailable, the integration automatically falls back to VBN's OpenTripPlanner REST API. Both APIs use the same API key (`Authorization: Bearer <key>`).
+
+**TRIAS PtMode strings:**
 
 | PtMode | Type | Description |
 |--------|------|-------------|
@@ -120,6 +124,17 @@ Different providers use different internal classification systems. The integrati
 | bus | bus | City and regional bus |
 | coach | bus | Coach/Express bus |
 | water | ferry | Ferry |
+
+**OTP GTFS route modes (fallback):**
+
+| Mode | Type | Description |
+|------|------|-------------|
+| RAIL | train | Regional trains |
+| TRAM | tram | Tram/Straßenbahn |
+| BUS | bus | City and regional bus |
+| COACH | bus | Express/regional bus |
+| SUBWAY | subway | Metro/U-Bahn |
+| FERRY | ferry | Ferry |
 
 ### Trafiklab Transport Modes
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -4,15 +4,15 @@ The Public Transport Integration supports multiple transit providers across Euro
 
 ## Provider Comparison
 
-| Feature | VRR | KVV | HVV | MVV | VVS | VGN | VAG Freiburg | BVG | RMV | VRN | VVO | DING | AVV | RVV | BSVG | NWL | NVBW | BEG | SBB | ÖBB | Trafiklab | NTA | Transitous |
-|---------|-----|-----|-----|-----|-----|-----|--------------|-----|-----|-----|-----|------|-----|-----|------|-----|------|-----|-----|-----|-----------|-----|-----------|
-| **Region** | NRW | Karlsruhe | Hamburg | Munich | Stuttgart | Nuremberg | Freiburg | Berlin | Frankfurt | Rhein-Neckar | Dresden | Ulm | Augsburg | Regensburg | Braunschweig | Westfalen-Lippe | Baden-Württemberg | Bayern | Switzerland | Austria | Sweden | Ireland | Worldwide |
-| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | FPTF REST | REST | GTFS-RT | MOTIS2 |
-| **API Key** | No | No | No | No | No | No | No | No | Yes (free) | No | No | No | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No |
-| **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
-| **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
-| **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available |
-| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete |
+| Feature | VRR | KVV | HVV | MVV | VVS | VGN | VAG Freiburg | BVG | RMV | VBN | VRN | VVO | DING | AVV | RVV | BSVG | NWL | NVBW | BEG | SBB | ÖBB | Trafiklab | NTA | Transitous |
+|---------|-----|-----|-----|-----|-----|-----|--------------|-----|-----|-----|-----|-----|------|-----|-----|------|-----|------|-----|-----|-----|-----------|-----|-----------|
+| **Region** | NRW | Karlsruhe | Hamburg | Munich | Stuttgart | Nuremberg | Freiburg | Berlin | Frankfurt | Bremen/Niedersachsen | Rhein-Neckar | Dresden | Ulm | Augsburg | Regensburg | Braunschweig | Westfalen-Lippe | Baden-Württemberg | Bayern | Switzerland | Austria | Sweden | Ireland | Worldwide |
+| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | TRIAS XML | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | FPTF REST | REST | GTFS-RT | MOTIS2 |
+| **API Key** | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No | No | No | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No |
+| **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
+| **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
+| **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available |
+| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete |
 
 ## Timezone Handling
 
@@ -29,6 +29,7 @@ Each provider uses its local timezone for departure times:
 | VAG Freiburg | Europe/Berlin |
 | BVG | Europe/Berlin |
 | RMV | Europe/Berlin |
+| VBN | Europe/Berlin |
 | VRN | Europe/Berlin |
 | VVO | Europe/Berlin |
 | DING | Europe/Berlin |
@@ -107,6 +108,18 @@ Different providers use different internal classification systems. The integrati
 | U | subway | U-Bahn |
 | Tram | tram | Tram/Straßenbahn |
 | Bus | bus | Bus services |
+
+### VBN PtMode Strings (TRIAS)
+
+| PtMode | Type | Description |
+|--------|------|-------------|
+| rail | train | Regional and long-distance trains |
+| urbanRail | train | S-Bahn |
+| metro | subway | Metro/U-Bahn |
+| tram | tram | Tram/Straßenbahn |
+| bus | bus | City and regional bus |
+| coach | bus | Coach/Express bus |
+| water | ferry | Ferry |
 
 ### Trafiklab Transport Modes
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -4,15 +4,15 @@ The Public Transport Integration supports multiple transit providers across Euro
 
 ## Provider Comparison
 
-| Feature | VRR | KVV | HVV | MVV | VVS | VGN | VAG Freiburg | BVG | RMV | VBN | VRN | VVO | DING | AVV | RVV | BSVG | NWL | NVBW | BEG | SBB | ÖBB | Trafiklab | NTA | Transitous |
-|---------|-----|-----|-----|-----|-----|-----|--------------|-----|-----|-----|-----|-----|------|-----|-----|------|-----|------|-----|-----|-----|-----------|-----|-----------|
-| **Region** | NRW | Karlsruhe | Hamburg | Munich | Stuttgart | Nuremberg | Freiburg | Berlin | Frankfurt | Bremen/Niedersachsen | Rhein-Neckar | Dresden | Ulm | Augsburg | Regensburg | Braunschweig | Westfalen-Lippe | Baden-Württemberg | Bayern | Switzerland | Austria | Sweden | Ireland | Worldwide |
-| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | TRIAS / OTP | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | FPTF REST | REST | GTFS-RT | MOTIS2 |
-| **API Key** | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No | No | No | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No |
-| **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
-| **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
-| **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available |
-| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete |
+| Feature | VRR | KVV | HVV | MVV | VVS | VGN | VAG Freiburg | BVG | RMV | VBN OTP | VBN TRIAS | VRN | VVO | DING | AVV | RVV | BSVG | NWL | NVBW | BEG | SBB | ÖBB | Trafiklab | NTA | Transitous |
+|---------|-----|-----|-----|-----|-----|-----|--------------|-----|-----|---------|-----------|-----|-----|------|-----|-----|------|-----|------|-----|-----|-----|-----------|-----|-----------|
+| **Region** | NRW | Karlsruhe | Hamburg | Munich | Stuttgart | Nuremberg | Freiburg | Berlin | Frankfurt | Bremen/Niedersachsen | Bremen/Niedersachsen | Rhein-Neckar | Dresden | Ulm | Augsburg | Regensburg | Braunschweig | Westfalen-Lippe | Baden-Württemberg | Bayern | Switzerland | Austria | Sweden | Ireland | Worldwide |
+| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | OTP REST | TRIAS XML | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | FPTF REST | REST | GTFS-RT | MOTIS2 |
+| **API Key** | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | Yes (free) | No | No | No | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No |
+| **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
+| **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
+| **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available |
+| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete |
 
 ## Timezone Handling
 
@@ -29,7 +29,8 @@ Each provider uses its local timezone for departure times:
 | VAG Freiburg | Europe/Berlin |
 | BVG | Europe/Berlin |
 | RMV | Europe/Berlin |
-| VBN | Europe/Berlin |
+| VBN OTP | Europe/Berlin |
+| VBN TRIAS | Europe/Berlin |
 | VRN | Europe/Berlin |
 | VVO | Europe/Berlin |
 | DING | Europe/Berlin |

--- a/docs/providers/vbn.md
+++ b/docs/providers/vbn.md
@@ -10,13 +10,21 @@ VBN is the transit authority for the Bremen/Niedersachsen region in northern Ger
 
 ## API Details
 
+VBN offers three APIs, all protected by the same API key sent as `Authorization: Bearer <key>`:
+
+| API | Endpoint | Used for |
+|-----|----------|---------|
+| **TRIAS** (primary) | `https://fahrplaner.vbn.de/triasproxy/` | Stop search, departure boards |
+| **OTP** (fallback) | `http://gtfsr.vbn.de/api/` | Stop search, departure boards |
+| **HAFAS REST** | `https://fahrplaner.vbn.de/restproxy/2/` | Trip planning (not used by this integration) |
+
 | Property | Value |
 |----------|-------|
-| **Endpoint** | `https://fahrplaner.vbn.de/triasproxy/` |
-| **API Type** | TRIAS (VDV 431-2) XML |
 | **API Key** | Required (free for non-commercial/hobbyist use) |
 | **Timezone** | Europe/Berlin |
-| **Quota** | 3,000 transactions/day (12,000/month) for hobbyists |
+| **Quota** | 3,000 transactions/day, 12,000/month |
+
+The integration automatically tries TRIAS first. If TRIAS is unavailable, it falls back to the OTP REST API — no configuration required.
 
 ## API Key
 
@@ -33,23 +41,27 @@ VBN is the transit authority for the Bremen/Niedersachsen region in northern Ger
 !!! tip
     Activation may take a few business days after your e-mail request.
 
-### API Key in Configuration
+### API Key Authentication
 
-The API key is passed as the `RequestorRef` field in every TRIAS XML request sent to the VBN endpoint.
+The API key is sent as an HTTP `Authorization` header on every request:
+
+```
+Authorization: Bearer <your-api-key>
+```
 
 ## Transport Types
 
-VBN uses standard TRIAS `PtMode` strings which are mapped to the integration's unified transport types:
-
-| PtMode | Unified Type | Description |
-|--------|-------------|-------------|
-| `rail` | train | Regional and long-distance trains (RE, IC, ICE) |
-| `urbanRail` | train | S-Bahn |
-| `metro` | subway | Metro/U-Bahn |
-| `tram` | tram | Tram/Straßenbahn (e.g. Bremen Straßenbahn) |
-| `bus` | bus | City and regional bus |
-| `coach` | bus | Coach/Express bus |
-| `water` | ferry | Ferry (e.g. Weser-Fähre in Bremen) |
+| Source | Mode | Unified Type | Description |
+|--------|------|-------------|-------------|
+| TRIAS | `rail` / `urbanRail` | train | Regional trains, S-Bahn |
+| TRIAS | `metro` | subway | Metro/U-Bahn |
+| TRIAS | `tram` | tram | Tram/Straßenbahn (Bremen) |
+| TRIAS | `bus` / `coach` | bus | City and regional bus |
+| TRIAS | `water` | ferry | Ferry (Weser-Fähre) |
+| OTP | `RAIL` | train | Regional trains |
+| OTP | `TRAM` | tram | Tram |
+| OTP | `BUS` | bus | Bus |
+| OTP | `FERRY` | ferry | Ferry |
 
 ## Configuration
 
@@ -66,26 +78,30 @@ VBN uses standard TRIAS `PtMode` strings which are mapped to the integration's u
 - Bremen Hauptbahnhof
 - Bremerhaven Hauptbahnhof
 - Bremen Domsheide
-- Bremen Hbf (Regionalbahn-Bereich)
 - Osnabrück Hauptbahnhof
 
 ## Troubleshooting
 
-### API Key Issues
+### HTTP 403 / API Key Issues
 
-If the integration returns no data or shows connection errors:
+If the integration returns no data or shows a 403 error:
 
 1. Verify the API key was entered correctly (copy-paste from the e-mail)
 2. Check that your daily quota hasn't been exceeded (3,000 transactions/day)
-3. Confirm the key has been activated by VBN — this can take a few business days after your initial e-mail
+3. Confirm the key has been activated by VBN — this can take a few business days
+
+### TRIAS vs. OTP Fallback
+
+The integration logs which API is active at `INFO` level. Enable debug logging to see detailed request/response information:
+
+```yaml
+logger:
+  logs:
+    custom_components.openpublictransport: debug
+```
 
 ### No Departures Found
 
 1. Re-run the stop search to verify the stop ID is correct
 2. Check that the stop has active services at this time of day
-3. Enable debug logging in Home Assistant to inspect the raw TRIAS XML responses:
-   ```yaml
-   logger:
-     logs:
-       custom_components.openpublictransport: debug
-   ```
+3. Enable debug logging to inspect raw API responses

--- a/docs/providers/vbn.md
+++ b/docs/providers/vbn.md
@@ -6,25 +6,33 @@ VBN is the transit authority for the Bremen/Niedersachsen region in northern Ger
 
 - Bremen (city and suburbs)
 - Bremerhaven
-- Surrounding Lower Saxony (Niedersachsen) counties
+- Surrounding Lower Saxony (Niedersachsen) counties (e.g. Delmenhorst, Verden, Rotenburg)
+
+## Two Provider Variants
+
+VBN is available as **two separate selectable providers**, both using the same API key:
+
+| Provider | Endpoint | Protocol |
+|----------|----------|---------|
+| **VBN OTP** | `http://gtfsr.vbn.de/api/` | OpenTripPlanner REST |
+| **VBN TRIAS** | `https://fahrplaner.vbn.de/triasproxy/` | TRIAS XML (VDV 431-2) |
+
+Choose the variant that matches your API key:
+
+- **OTP key** (labelled "OTP-API-Key" in the VBN welcome e-mail) → select **VBN OTP**
+- **TRIAS key** → select **VBN TRIAS**
 
 ## API Details
 
-VBN offers three APIs, all protected by the same API key sent as `Authorization: Bearer <key>`:
-
-| API | Endpoint | Used for |
-|-----|----------|---------|
-| **TRIAS** (primary) | `https://fahrplaner.vbn.de/triasproxy/` | Stop search, departure boards |
-| **OTP** (fallback) | `http://gtfsr.vbn.de/api/` | Stop search, departure boards |
-| **HAFAS REST** | `https://fahrplaner.vbn.de/restproxy/2/` | Trip planning (not used by this integration) |
-
-| Property | Value |
-|----------|-------|
-| **API Key** | Required (free for non-commercial/hobbyist use) |
-| **Timezone** | Europe/Berlin |
-| **Quota** | 3,000 transactions/day, 12,000/month |
-
-The integration automatically tries TRIAS first. If TRIAS is unavailable, it falls back to the OTP REST API — no configuration required.
+| Property | VBN OTP | VBN TRIAS |
+|----------|---------|-----------|
+| **API Key** | Required (free) | Required (free) |
+| **Timezone** | Europe/Berlin | Europe/Berlin |
+| **Quota** | 3,000 transactions/day | 3,000 transactions/day |
+| **Real-time** | Yes | Yes |
+| **Platform info** | No | Yes |
+| **Agency/Operator** | Yes | No |
+| **Stop alerts** | Yes | No |
 
 ## API Key
 
@@ -32,43 +40,65 @@ The integration automatically tries TRIAS first. If TRIAS is unavailable, it fal
 
 1. Send an e-mail to **api@vbn.de**
 2. Briefly describe your use case (e.g. "Home Assistant integration for personal use")
-3. You will receive an API key by e-mail
-4. Enter the key during integration setup in Home Assistant
+3. You will receive an API key by e-mail — VBN may issue separate OTP and TRIAS keys
+4. Enter the key during integration setup
 
 !!! note
-    The API key is free for non-commercial use. Departure board queries count as 1/5 of a transaction each, so the daily quota of 3,000 transactions effectively covers up to ~15,000 departure lookups per day — more than sufficient for home automation use.
+    The API key is free for non-commercial use. Departure board queries count as 1/5 of a transaction each, so the daily quota of 3,000 transactions effectively covers ~15,000 departure lookups per day.
 
 !!! tip
     Activation may take a few business days after your e-mail request.
 
-### API Key Authentication
+### Authentication
 
-The API key is sent as an HTTP `Authorization` header on every request:
+The API key is sent as a plain HTTP `Authorization` header (no `Bearer` prefix):
 
 ```
-Authorization: Bearer <your-api-key>
+Authorization: <your-api-key>
 ```
 
 ## Transport Types
 
-| Source | Mode | Unified Type | Description |
-|--------|------|-------------|-------------|
-| TRIAS | `rail` / `urbanRail` | train | Regional trains, S-Bahn |
-| TRIAS | `metro` | subway | Metro/U-Bahn |
-| TRIAS | `tram` | tram | Tram/Straßenbahn (Bremen) |
-| TRIAS | `bus` / `coach` | bus | City and regional bus |
-| TRIAS | `water` | ferry | Ferry (Weser-Fähre) |
-| OTP | `RAIL` | train | Regional trains |
-| OTP | `TRAM` | tram | Tram |
-| OTP | `BUS` | bus | Bus |
-| OTP | `FERRY` | ferry | Ferry |
+### VBN OTP (OpenTripPlanner GTFS modes)
+
+| OTP Mode | Unified Type | Description |
+|----------|-------------|-------------|
+| `RAIL` | train | Regional trains |
+| `TRAM` | tram | Tram/Straßenbahn (Bremen) |
+| `BUS` | bus | City and regional bus |
+| `COACH` | bus | Express/regional bus |
+| `SUBWAY` | subway | Metro/U-Bahn |
+| `FERRY` | ferry | Ferry (Weser-Fähre) |
+
+### VBN TRIAS (TRIAS PtMode strings)
+
+| PtMode | Unified Type | Description |
+|--------|-------------|-------------|
+| `rail` / `urbanRail` | train | Regional trains, S-Bahn |
+| `metro` | subway | Metro/U-Bahn |
+| `tram` | tram | Tram/Straßenbahn (Bremen) |
+| `bus` / `coach` | bus | City and regional bus |
+| `water` | ferry | Ferry (Weser-Fähre) |
+
+## Features by Variant
+
+### VBN OTP
+
+- **Stop search**: Geocodes your search term via Nominatim (OpenStreetMap), then finds nearby OTP stops within 500 m
+- **Agency/Operator**: Shown in the `agency` departure attribute (e.g. "Bremer Straßenbahn AG")
+- **Stop alerts**: Active service alerts for the stop are attached as `notices` to all departures
+
+### VBN TRIAS
+
+- **Stop search**: Native TRIAS `LocationInformationRequest` — returns direct name matches
+- **Platform info**: Platform/track numbers included when provided by VBN
 
 ## Configuration
 
 ### Setup Steps
 
-1. Select **VBN** as provider
-2. Enter your API key (received via e-mail from api@vbn.de)
+1. Select **VBN OTP** or **VBN TRIAS** as provider
+2. Enter your API key (from your VBN welcome e-mail)
 3. Search for your stop (e.g. "Bremen Hauptbahnhof")
 4. Select the stop from the results list
 5. Configure the number of departures and transport type filters
@@ -78,21 +108,25 @@ Authorization: Bearer <your-api-key>
 - Bremen Hauptbahnhof
 - Bremerhaven Hauptbahnhof
 - Bremen Domsheide
+- Bremen Hauptbahnhof/ZOB
 - Osnabrück Hauptbahnhof
 
 ## Troubleshooting
 
-### HTTP 403 / API Key Issues
+### HTTP 401 / API Key Issues
 
-If the integration returns no data or shows a 403 error:
+If the integration shows a 401 error after stop selection:
 
-1. Verify the API key was entered correctly (copy-paste from the e-mail)
-2. Check that your daily quota hasn't been exceeded (3,000 transactions/day)
-3. Confirm the key has been activated by VBN — this can take a few business days
+1. Verify the API key was entered correctly (copy-paste from the VBN e-mail)
+2. Confirm you selected the correct variant (OTP key → VBN OTP, TRIAS key → VBN TRIAS)
+3. Check that your daily quota has not been exceeded (3,000 transactions/day)
+4. Confirm the key has been activated by VBN — this can take a few business days
 
-### TRIAS vs. OTP Fallback
+### No Departures Found
 
-The integration logs which API is active at `INFO` level. Enable debug logging to see detailed request/response information:
+1. Re-run the stop search to verify the stop ID is correct
+2. Check that the stop has active services at this time of day
+3. Enable debug logging to inspect raw API responses:
 
 ```yaml
 logger:
@@ -100,8 +134,9 @@ logger:
     custom_components.openpublictransport: debug
 ```
 
-### No Departures Found
+### VBN OTP: Stop Search Returns No Results
 
-1. Re-run the stop search to verify the stop ID is correct
-2. Check that the stop has active services at this time of day
-3. Enable debug logging to inspect raw API responses
+OTP has no native name-based stop search. The integration geocodes your search term via Nominatim (OpenStreetMap) and finds stops within 500 m. If no results appear:
+
+- Use a more specific address (e.g. "Bremen Hauptbahnhof, Bremen" instead of just "Hauptbahnhof")
+- The stop may be outside the 500 m search radius — try a more precise location name

--- a/docs/providers/vbn.md
+++ b/docs/providers/vbn.md
@@ -1,0 +1,91 @@
+# VBN (Verkehrsverbund Bremen/Niedersachsen)
+
+VBN is the transit authority for the Bremen/Niedersachsen region in northern Germany.
+
+## Coverage Area
+
+- Bremen (city and suburbs)
+- Bremerhaven
+- Surrounding Lower Saxony (Niedersachsen) counties
+
+## API Details
+
+| Property | Value |
+|----------|-------|
+| **Endpoint** | `https://fahrplaner.vbn.de/triasproxy/` |
+| **API Type** | TRIAS (VDV 431-2) XML |
+| **API Key** | Required (free for non-commercial/hobbyist use) |
+| **Timezone** | Europe/Berlin |
+| **Quota** | 3,000 transactions/day (12,000/month) for hobbyists |
+
+## API Key
+
+### Getting an API Key
+
+1. Send an e-mail to **api@vbn.de**
+2. Briefly describe your use case (e.g. "Home Assistant integration for personal use")
+3. You will receive an API key by e-mail
+4. Enter the key during integration setup in Home Assistant
+
+!!! note
+    The API key is free for non-commercial use. Departure board queries count as 1/5 of a transaction each, so the daily quota of 3,000 transactions effectively covers up to ~15,000 departure lookups per day — more than sufficient for home automation use.
+
+!!! tip
+    Activation may take a few business days after your e-mail request.
+
+### API Key in Configuration
+
+The API key is passed as the `RequestorRef` field in every TRIAS XML request sent to the VBN endpoint.
+
+## Transport Types
+
+VBN uses standard TRIAS `PtMode` strings which are mapped to the integration's unified transport types:
+
+| PtMode | Unified Type | Description |
+|--------|-------------|-------------|
+| `rail` | train | Regional and long-distance trains (RE, IC, ICE) |
+| `urbanRail` | train | S-Bahn |
+| `metro` | subway | Metro/U-Bahn |
+| `tram` | tram | Tram/Straßenbahn (e.g. Bremen Straßenbahn) |
+| `bus` | bus | City and regional bus |
+| `coach` | bus | Coach/Express bus |
+| `water` | ferry | Ferry (e.g. Weser-Fähre in Bremen) |
+
+## Configuration
+
+### Setup Steps
+
+1. Select **VBN** as provider
+2. Enter your API key (received via e-mail from api@vbn.de)
+3. Search for your stop (e.g. "Bremen Hauptbahnhof")
+4. Select the stop from the results list
+5. Configure the number of departures and transport type filters
+
+### Example Stops
+
+- Bremen Hauptbahnhof
+- Bremerhaven Hauptbahnhof
+- Bremen Domsheide
+- Bremen Hbf (Regionalbahn-Bereich)
+- Osnabrück Hauptbahnhof
+
+## Troubleshooting
+
+### API Key Issues
+
+If the integration returns no data or shows connection errors:
+
+1. Verify the API key was entered correctly (copy-paste from the e-mail)
+2. Check that your daily quota hasn't been exceeded (3,000 transactions/day)
+3. Confirm the key has been activated by VBN — this can take a few business days after your initial e-mail
+
+### No Departures Found
+
+1. Re-run the stop search to verify the stop ID is correct
+2. Check that the stop has active services at this time of day
+3. Enable debug logging in Home Assistant to inspect the raw TRIAS XML responses:
+   ```yaml
+   logger:
+     logs:
+       custom_components.openpublictransport: debug
+   ```


### PR DESCRIPTION
## Summary

Adds VBN (Verkehrsverbund Bremen/Niedersachsen) as two selectable provider variants, introduces a new `OTPBaseProvider` base class for OpenTripPlanner REST APIs, and extends `TRIASBaseProvider` with an HTTP auth hook.

## New Providers

- **VBN OTP** (`vbn_otp`) — Bremen, Bremerhaven, and surrounding Lower Saxony counties via OpenTripPlanner REST API (`http://gtfsr.vbn.de/api/`). API key required (free, request at api@vbn.de).
- **VBN TRIAS** (`vbn_trias`) — Same region via TRIAS XML API (`https://fahrplaner.vbn.de/triasproxy/`). API key required (same source, may be a separate key).

Both use `Authorization: <key>` (plain header, no Bearer prefix). Total provider count: **26**.

## Architecture

### New: `OTPBaseProvider` (`providers/otp_base.py`)

Base class for OpenTripPlanner 2.x REST API providers, analogous to `TRIASBaseProvider`. Subclasses only define `otp_base_url`, `provider_id`, `provider_name`, and optionally `_auth_headers()`.

Key implementation details:
- **Stop search**: OTP 2.x REST has no name-based stop search. The base class geocodes the search term via Nominatim (OpenStreetMap), then queries `/index/stops?lat=&lon=&radius=500` for nearby stops.
- **Departures**: Fetches `/index/stops/{id}/routes` (line names, transport modes, agency) and `/index/stops/{id}/stoptimes` in parallel concept, then joins by `pattern.routeId`.
- **Alerts**: Fetches `/index/stops/{id}/alerts` and attaches active alert header texts as `notices` to all departures at the stop.
- **Agency**: Extracted from the routes endpoint (`agencyName` or nested `agency.name`) and exposed as the `agency` departure attribute.
- **Auth hook**: `_auth_headers()` override point — default returns `{"Accept": "application/json"}`.

### Extended: `TRIASBaseProvider` (`providers/trias_base.py`)

Added `_extra_headers()` hook (returns `{}` by default). Subclasses override it to inject HTTP auth headers without touching the base class. Used by `VBNTriasProvider`.

## Files Changed

| File | Change |
|------|--------|
| `providers/otp_base.py` | **New** — OTPBaseProvider base class |
| `providers/vbn.py` | **New** — VBNOTPProvider + VBNTriasProvider |
| `providers/__init__.py` | Register both VBN providers |
| `providers/trias_base.py` | Add `_extra_headers()` hook |
| `const.py` | `PROVIDER_VBN_OTP`, `PROVIDER_VBN_TRIAS`, `CONF_VBN_API_KEY`, icons, entity pictures |
| `config_flow.py` | Two VBN entries in dropdown, API key step, stop search key check |
| `__init__.py` | Extract `CONF_VBN_API_KEY` and pass to coordinator |
| `sensor.py` | Extract `CONF_VBN_API_KEY` in fallback coordinator path |
| `translations/en.json` | VBN API key field label and description |
| `translations/de.json` | VBN API key field label and description (German) |
| `docs/providers/vbn.md` | **New** — full provider docs (both variants, auth, transport types, troubleshooting) |
| `docs/providers/index.md` | Added Agency/Operator + Alerts/Notices rows; VBN OTP geocoded search footnote |
| `docs/changelog.md` | v2026.5.2 entry |
| `docs/index.md` | Provider count + VBN entries |
| `README.md` | Provider count + VBN table rows |

## Bugs Fixed During Development

- **HTTP 401 on routes**: `CONF_VBN_API_KEY` was not extracted from config entry in `__init__.py` / `sensor.py` — key was never passed to the provider instance
- **`omitNonPickups=True` type error**: aiohttp rejects Python booleans as query params — changed to string `"true"`
- **Wrong OTP URL**: initial `/api/otp/routers/default` returned 404 — correct path is `/api/routers/default`
- **OTP stop search `?name=` returns 400**: OTP 2.x REST has no name-based search — replaced with Nominatim geocoding
- **Wrong `routeId` source**: `routeId` lives on `pattern.routeId` (group level), not on individual time entries or a `trip` sub-object

## Test Plan

- [ ] Install via HACS from beta branch
- [ ] Add integration → select **VBN OTP** → enter API key → search "Bremen Hauptbahnhof" → stop results appear
- [ ] Select stop → sensor created → departures visible with correct line names, destinations, real-time times
- [ ] `agency` attribute populated (e.g. "Bremer Straßenbahn AG")
- [ ] `notices` attribute populated when VBN has active alerts
- [ ] Add integration → select **VBN TRIAS** → same API key → stop search + departures work
- [ ] VBN TRIAS departures include platform info
- [ ] No regressions on existing providers (VRR, BVG, RMV spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)