### PR TITLE
feat: VBN OTP trip planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,34 +23,34 @@ Real-time public transport departures for Home Assistant — 26 providers across
 
 ## Supported Providers (26)
 
-| Provider | Region | API Key |
-|----------|--------|---------|
-| **AVV** | Augsburg | No |
-| **BEG** | Bavaria | No |
-| **BSVG** | Braunschweig | No |
-| **BVG** | Berlin / Brandenburg | No |
-| **DB** | Germany (nationwide, community API) | No |
-| **DING** | Ulm | No |
-| **HVV** | Hamburg | No |
-| **KVV** | Karlsruhe | No |
-| **MVV** | Munich | No |
-| **NTA** | Ireland (nationwide) | Yes (free) |
-| **NVBW** | Baden-Württemberg | No |
-| **NWL** | Westfalen-Lippe | No |
-| **ÖBB** | Austria (nationwide) | No |
-| **RMV** | Frankfurt / Rhein-Main | Yes (free) |
-| **RVV** | Regensburg | No |
-| **SBB** | Switzerland (nationwide) | No |
-| **Trafiklab** | Sweden (nationwide) | Yes (free) |
-| **Transitous** | Worldwide (community) | No |
-| **VAG** | Freiburg | No |
-| **VBN (OTP)** | Bremen / Niedersachsen | Yes (free) |
-| **VBN (TRIAS)** | Bremen / Niedersachsen | Yes (free) |
-| **VGN** | Nuremberg | No |
-| **VRN** | Rhein-Neckar | No |
-| **VRR** | Rhein-Ruhr (NRW) | No |
-| **VVO** | Dresden | No |
-| **VVS** | Stuttgart | No |
+| Provider | Region | API Key | Trip Planner |
+|----------|--------|---------|--------------|
+| **AVV** | Augsburg | No | Yes |
+| **BEG** | Bavaria | No | Yes |
+| **BSVG** | Braunschweig | No | No |
+| **BVG** | Berlin / Brandenburg | No | No |
+| **DB** | Germany (nationwide, community API) | No | No |
+| **DING** | Ulm | No | Yes |
+| **HVV** | Hamburg | No | Yes |
+| **KVV** | Karlsruhe | No | Yes |
+| **MVV** | Munich | No | Yes |
+| **NTA** | Ireland (nationwide) | Yes (free) | No |
+| **NVBW** | Baden-Württemberg | No | No |
+| **NWL** | Westfalen-Lippe | No | No |
+| **ÖBB** | Austria (nationwide) | No | No |
+| **RMV** | Frankfurt / Rhein-Main | Yes (free) | No |
+| **RVV** | Regensburg | No | No |
+| **SBB** | Switzerland (nationwide) | No | No |
+| **Trafiklab** | Sweden (nationwide) | Yes (free) | No |
+| **Transitous** | Worldwide (community) | No | No |
+| **VAG** | Freiburg | No | Yes |
+| **VBN (OTP)** | Bremen / Niedersachsen | Yes (free) | Yes |
+| **VBN (TRIAS)** | Bremen / Niedersachsen | Yes (free) | No |
+| **VGN** | Nuremberg | No | Yes |
+| **VRN** | Rhein-Neckar | No | No |
+| **VRR** | Rhein-Ruhr (NRW) | No | Yes |
+| **VVO** | Dresden | No | No |
+| **VVS** | Stuttgart | No | Yes |
 
 ## Features
 

--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -198,7 +198,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         destination = call.data["destination"]
         destination_city = call.data["destination_city"]
 
-        journeys = await async_plan_trip(hass, provider, origin, origin_city, destination, destination_city)
+        # For API-key providers, look up the key from an existing config entry
+        api_key = None
+        if provider == PROVIDER_VBN_OTP:
+            for existing in hass.config_entries.async_entries(DOMAIN):
+                if existing.data.get(CONF_PROVIDER) == PROVIDER_VBN_OTP:
+                    api_key = existing.data.get(CONF_VBN_API_KEY)
+                    break
+
+        journeys = await async_plan_trip(
+            hass, provider, origin, origin_city, destination, destination_city, api_key=api_key
+        )
 
         return {"journeys": journeys or []}
 

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -1219,6 +1219,10 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, 120),
             }
 
+            # Persist API key for providers that require one
+            if self._api_key and self._provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
+                data[CONF_VBN_API_KEY] = self._api_key
+
             unique_id = f"{self._provider}_trip_{origin.get('id', '')}_{dest.get('id', '')}"
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.3b1"
+  "version": "2026.5.3b2"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.2"
+  "version": "2026.5.3b1"
 }

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -84,6 +84,8 @@ class OTPBaseProvider(BaseProvider):
             ) as resp:
                 if resp.status == 200:
                     return await resp.json()
+                if resp.status == 204:
+                    return None  # No content — normal for empty alerts
                 _LOGGER.warning("%s OTP %s → HTTP %s", self.provider_name, url, resp.status)
         except aiohttp.ClientError as exc:
             _LOGGER.warning("%s OTP request failed: %s", self.provider_name, exc)

--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -4,8 +4,9 @@ Provides both a service (on-demand) and a sensor (polling) for
 route planning from A to B with connections and transfers.
 """
 
+import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -27,6 +28,20 @@ EFA_TRIP_ENDPOINTS = {
     "vagfr": "https://efa.vagfr.de/vagfr3/XML_TRIP_REQUEST2",
 }
 
+# OTP GTFS mode → unified product name
+_OTP_MODE_TO_PRODUCT = {
+    "BUS": "bus",
+    "COACH": "bus",
+    "RAIL": "train",
+    "TRAM": "tram",
+    "SUBWAY": "subway",
+    "FERRY": "ferry",
+    "GONDOLA": "tram",
+    "FUNICULAR": "train",
+    "CABLE_CAR": "tram",
+    "WALK": "walk",
+}
+
 
 async def async_plan_trip(
     hass: HomeAssistant,
@@ -38,12 +53,25 @@ async def async_plan_trip(
     departure_time: Optional[datetime] = None,
     origin_id: Optional[str] = None,
     dest_id: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> Optional[List[Dict[str, Any]]]:
-    """Plan a trip from origin to destination using EFA API.
+    """Plan a trip from origin to destination.
 
+    Dispatches to OTP REST for vbn_otp, EFA for all other supported providers.
     Uses stop IDs when available (more reliable), falls back to name+place search.
     Returns a list of journey options, each with legs and transfer info.
     """
+    # OTP providers
+    if provider == "vbn_otp":
+        if not origin_id or not dest_id:
+            _LOGGER.warning("VBN OTP trip planning requires stop IDs — search for stops first")
+            return None
+        from .providers import get_provider
+
+        provider_instance = get_provider(provider, hass, api_key=api_key)
+        return await _async_plan_trip_otp(hass, origin_id, dest_id, departure_time, provider_instance)
+
+    # EFA providers
     base_url = EFA_TRIP_ENDPOINTS.get(provider)
     if not base_url:
         _LOGGER.warning("Trip planning not supported for provider: %s", provider)
@@ -91,6 +119,166 @@ async def async_plan_trip(
     except Exception as e:
         _LOGGER.warning("Trip planning failed: %s", e)
         return None
+
+
+async def _async_plan_trip_otp(
+    hass: HomeAssistant,
+    origin_id: str,
+    dest_id: str,
+    departure_time: Optional[datetime],
+    provider_instance,
+) -> Optional[List[Dict[str, Any]]]:
+    """Plan a trip using the OTP 2.x REST /plan endpoint."""
+    now = departure_time or dt_util.now()
+    session = async_get_clientsession(hass)
+    base_url = provider_instance.otp_base_url
+
+    # Resolve stop coordinates concurrently — OTP /plan needs lat,lon not stop IDs
+    origin_stop, dest_stop = await asyncio.gather(
+        provider_instance._get(session, f"{base_url}/index/stops/{quote(origin_id, safe='')}"),
+        provider_instance._get(session, f"{base_url}/index/stops/{quote(dest_id, safe='')}"),
+    )
+    if not origin_stop or not dest_stop:
+        _LOGGER.warning("VBN OTP trip: could not resolve stop coordinates for %s / %s", origin_id, dest_id)
+        return None
+
+    from_place = f"{origin_stop['lat']},{origin_stop['lon']}"
+    to_place = f"{dest_stop['lat']},{dest_stop['lon']}"
+
+    data = await provider_instance._get(
+        session,
+        f"{base_url}/plan",
+        {
+            "fromPlace": from_place,
+            "toPlace": to_place,
+            "date": now.strftime("%Y-%m-%d"),
+            "time": now.strftime("%H:%M:%S"),
+            "numItineraries": "3",
+            "mode": "TRANSIT,WALK",
+        },
+    )
+    if not data:
+        return None
+
+    itineraries = data.get("plan", {}).get("itineraries", [])
+    if not itineraries:
+        _LOGGER.debug("VBN OTP trip: no itineraries returned")
+        return None
+
+    return _parse_otp_itineraries(itineraries)
+
+
+def _parse_otp_itineraries(itineraries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Parse OTP 2.x plan itineraries into the unified journey dict format."""
+    results = []
+
+    for itin in itineraries:
+        transit_legs = []
+        # ms timestamps for transfer gap calculation
+        leg_arrival_ms: List[int] = []
+        leg_departure_ms: List[int] = []
+
+        for leg in itin.get("legs", []):
+            if not leg.get("transitLeg", False):
+                # Walking/transfer leg — capture its times for gap calc but skip display
+                if transit_legs:
+                    # The walk connects the previous transit leg to the next one
+                    leg_arrival_ms.append(leg.get("endTime", 0))
+                continue
+
+            start_ms: int = leg.get("startTime", 0)
+            end_ms: int = leg.get("endTime", 0)
+            dep_delay_s: int = leg.get("departureDelay", 0)
+            arr_delay_s: int = leg.get("arrivalDelay", 0)
+
+            # planned = actual minus delay
+            planned_start_ms = start_ms - dep_delay_s * 1000
+            planned_end_ms = end_ms - arr_delay_s * 1000
+
+            dep_estimated = _ms_to_hhmm(start_ms)
+            dep_planned = _ms_to_hhmm(planned_start_ms)
+            arr_estimated = _ms_to_hhmm(end_ms)
+            arr_planned = _ms_to_hhmm(planned_end_ms)
+
+            delay_min = dep_delay_s // 60
+
+            transit_legs.append(
+                {
+                    "origin": leg.get("from", {}).get("name", ""),
+                    "destination": leg.get("to", {}).get("name", ""),
+                    "line": leg.get("routeShortName") or leg.get("route", ""),
+                    "product": _OTP_MODE_TO_PRODUCT.get(leg.get("mode", ""), leg.get("mode", "").lower()),
+                    "departure_planned": dep_planned,
+                    "departure_estimated": dep_estimated,
+                    "arrival_planned": arr_planned,
+                    "arrival_estimated": arr_estimated,
+                    "delay": delay_min,
+                    "duration_minutes": round(leg.get("duration", 0) / 60),
+                    "platform": "",
+                    # Internal ms values for transfer gap calculation
+                    "_arrival_ms": end_ms,
+                    "_departure_ms": start_ms,
+                }
+            )
+            leg_departure_ms.append(start_ms)
+            leg_arrival_ms.append(end_ms)
+
+        if not transit_legs:
+            continue
+
+        # Transfer risk from arrival of leg N to departure of leg N+1
+        connection_feasible = True
+        transfer_risk = "low"
+        min_transfer_time: Optional[int] = None
+
+        for i in range(len(transit_legs) - 1):
+            arr_ms = transit_legs[i]["_arrival_ms"]
+            dep_ms = transit_legs[i + 1]["_departure_ms"]
+            gap_min = (dep_ms - arr_ms) // 60000
+            if min_transfer_time is None or gap_min < min_transfer_time:
+                min_transfer_time = gap_min
+            if gap_min <= 0:
+                connection_feasible = False
+                transfer_risk = "missed"
+            elif gap_min <= 3 and transfer_risk != "missed":
+                transfer_risk = "high"
+            elif gap_min <= 5 and transfer_risk not in ("missed", "high"):
+                transfer_risk = "medium"
+
+        # Strip internal keys before returning
+        for leg in transit_legs:
+            leg.pop("_arrival_ms", None)
+            leg.pop("_departure_ms", None)
+
+        first_dep = transit_legs[0].get("departure_estimated") or transit_legs[0].get("departure_planned", "")
+        last_arr = transit_legs[-1].get("arrival_estimated") or transit_legs[-1].get("arrival_planned", "")
+        duration_ms = itin.get("duration", 0) * 1000  # OTP duration is in seconds
+
+        results.append(
+            {
+                "departure": first_dep,
+                "arrival": last_arr,
+                "duration_minutes": round(itin.get("duration", 0) / 60),
+                "transfers": itin.get("transfers", len(transit_legs) - 1),
+                "connection_feasible": connection_feasible,
+                "transfer_risk": transfer_risk,
+                "min_transfer_time": min_transfer_time,
+                "legs": transit_legs,
+            }
+        )
+
+    return results
+
+
+def _ms_to_hhmm(ms: int) -> str:
+    """Convert OTP millisecond Unix timestamp to HH:MM in local time."""
+    if not ms:
+        return ""
+    try:
+        dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+        return dt_util.as_local(dt).strftime("%H:%M")
+    except (ValueError, OSError):
+        return ""
 
 
 def _parse_journeys(journeys: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -252,7 +252,6 @@ def _parse_otp_itineraries(itineraries: List[Dict[str, Any]]) -> List[Dict[str, 
 
         first_dep = transit_legs[0].get("departure_estimated") or transit_legs[0].get("departure_planned", "")
         last_arr = transit_legs[-1].get("arrival_estimated") or transit_legs[-1].get("arrival_planned", "")
-        duration_ms = itin.get("duration", 0) * 1000  # OTP duration is in seconds
 
         results.append(
             {

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import CONF_SCAN_INTERVAL, CONF_VBN_API_KEY, DEFAULT_SCAN_INTERVAL, DOMAIN
 from .trip import async_plan_trip
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,6 +42,7 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
         scan_interval: int = 120,
         origin_id: Optional[str] = None,
         dest_id: Optional[str] = None,
+        api_key: Optional[str] = None,
     ):
         """Initialize."""
         super().__init__(
@@ -57,6 +58,7 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
         self.destination_city = destination_city
         self.origin_id = origin_id
         self.dest_id = dest_id
+        self.api_key = api_key
 
     async def _async_update_data(self) -> Optional[List[Dict[str, Any]]]:
         """Fetch trip data."""
@@ -69,6 +71,7 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
             self.destination_city,
             origin_id=self.origin_id,
             dest_id=self.dest_id,
+            api_key=self.api_key,
         )
 
 
@@ -85,6 +88,7 @@ async def async_setup_trip_entry(
     origin_id = config_entry.data.get("trip_origin_id")
     dest_id = config_entry.data.get("trip_destination_id")
     scan_interval = config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    api_key = config_entry.data.get(CONF_VBN_API_KEY)
 
     coordinator = TripDataUpdateCoordinator(
         hass,
@@ -96,6 +100,7 @@ async def async_setup_trip_entry(
         scan_interval,
         origin_id=origin_id,
         dest_id=dest_id,
+        api_key=api_key,
     )
 
     coordinator_key = f"{config_entry.entry_id}_trip_coordinator"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v2026.5.3 - VBN OTP Trip Planner
+
+### New Features
+
+- **VBN OTP trip planner** — VBN OTP now supports the built-in trip planner (`entry_type = "trip"`). The integration calls the OTP `/plan` endpoint with `TRANSIT,WALK` mode, resolves stop coordinates from the OTP index automatically, and parses up to 3 itineraries into the unified journey format with legs, delay, and transfer risk assessment.
+
+### Improvements
+
+- **Trip planner comparison table** — Added Trip Planner row to the provider comparison table in docs and README.
+- **HTTP 204 on `/alerts`** — OTP returns 204 (No Content) when there are no active alerts. Treated silently as "no alerts" instead of logging a warning.
+
+### Bugfixes
+
+- **VBN OTP trip: API key not passed** — The trip config entry did not persist the API key, causing 401 errors on `/index/stops` and `/plan` calls. Fixed: `async_step_trip_settings()` now saves `CONF_VBN_API_KEY` when the provider requires one.
+
+!!! note "VBN TRIAS"
+    VBN TRIAS does not support trip planning. TRIAS XML trip requests are not implemented.
+
+---
+
 ## v2026.5.2 - VBN Provider (OTP + TRIAS) & New OTPBaseProvider
 
 ### New Providers

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -14,6 +14,7 @@ The Public Transport Integration supports multiple transit providers across Euro
 | **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available |
 | **Agency/Operator** | No | No | No | No | No | No | No | Yes | Yes | Yes | No | No | No | No | No | No | No | No | No | No | No | Yes | Yes | No | When available |
 | **Alerts/Notices** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | No | Yes | When available |
+| **Trip Planner** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | No | No | No | No | No | No | No | No | No | No | No | No | No | No | No |
 | **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Geocoded¹ | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete |
 
 ¹ VBN OTP has no native name-based stop search. The integration geocodes your search term via Nominatim (OpenStreetMap) and finds stops within 500 m of the resolved coordinates.

--- a/docs/providers/vbn.md
+++ b/docs/providers/vbn.md
@@ -87,11 +87,32 @@ Authorization: <your-api-key>
 - **Stop search**: Geocodes your search term via Nominatim (OpenStreetMap), then finds nearby OTP stops within 500 m
 - **Agency/Operator**: Shown in the `agency` departure attribute (e.g. "Bremer Straßenbahn AG")
 - **Stop alerts**: Active service alerts for the stop are attached as `notices` to all departures
+- **Trip planner**: Supported — plan A-to-B connections via the OTP `/plan` endpoint
 
 ### VBN TRIAS
 
 - **Stop search**: Native TRIAS `LocationInformationRequest` — returns direct name matches
 - **Platform info**: Platform/track numbers included when provided by VBN
+- **Trip planner**: Not supported (TRIAS XML trip planning not implemented)
+
+## Trip Planner (VBN OTP only)
+
+VBN OTP supports the built-in trip planner. Select **Verbindungssuche / Trip Planner (A → B)** as entry type during setup.
+
+The integration uses the OTP `/plan` endpoint with `TRANSIT,WALK` mode. It resolves stop coordinates automatically from the OTP stop index — no manual coordinate entry needed.
+
+```yaml
+# Service call example
+service: openpublictransport.plan_trip
+data:
+  provider: vbn_otp
+  origin: Bremen Hauptbahnhof
+  origin_city: Bremen
+  destination: Bremen Domsheide
+  destination_city: Bremen
+```
+
+The trip sensor shows the next connection as state and exposes `legs`, `transfer_risk`, and up to 3 alternative journeys as attributes.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

VBN OTP now supports the built-in trip planner (entry type: **Verbindungssuche / Trip Planner A → B**).

- Dispatches to OTP 2.x REST \`/plan\` endpoint (\`TRANSIT,WALK\` mode)
- Stop coordinates resolved from \`/index/stops/{id}\` (stop IDs stored, not lat/lon)
- Up to 3 itineraries parsed into the unified journey dict — legs, delay, transfer risk
- \`api_key\` correctly threaded through \`TripDataUpdateCoordinator\` and \`plan_trip\` service
- VBN TRIAS unchanged — trip planning not supported

## Files Changed

| File | Change |
|------|--------|
| \`trip.py\` | OTP dispatch in \`async_plan_trip()\`, new \`_async_plan_trip_otp()\`, \`_parse_otp_itineraries()\`, \`_ms_to_hhmm()\` |
| \`trip_sensor.py\` | \`api_key\` param on coordinator, passed through to \`async_plan_trip()\` |
| \`__init__.py\` | \`plan_trip\` service looks up VBN OTP key from existing departure config entry |
| \`config_flow.py\` | \`async_step_trip_settings()\` persists \`CONF_VBN_API_KEY\` in trip config entry |
| \`providers/otp_base.py\` | HTTP 204 treated as empty (no warning) |
| \`docs/providers/vbn.md\` | Trip planner section with setup instructions and service call example |
| \`docs/providers/index.md\` | Trip Planner row added to provider comparison table |
| \`README.md\` | Trip Planner column added to provider table |
| \`docs/changelog.md\` | v2026.5.3 entry |

## Bugfixes Included

- **401 on trip planning**: Trip config entry was not saving the API key — fixed in \`async_step_trip_settings()\`
- **HTTP 204 warning on /alerts**: OTP returns 204 for empty alert responses — now treated silently

## Test Plan

- [ ] Add trip sensor: VBN OTP, origin = Bremen Hauptbahnhof, destination = Bremen Domsheide
- [ ] Sensor state shows \`HH:MM → HH:MM (N min, N transfers)\`
- [ ] \`legs\` attribute has transit legs with correct line names and times
- [ ] \`transfer_risk\` populated correctly
- [ ] Service call \`openpublictransport.plan_trip\` with \`provider: vbn_otp\` returns journeys
- [ ] No 401 errors in logs after setup
- [ ] No HTTP 204 warnings in logs
- [ ] VBN TRIAS: trip entry shows "No connections" / unsupported warning (no regression)
- [ ] EFA providers (VRR, MVV etc.) still work for trips (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)