### PR TITLE
feat: openpublictransport community OTP2 + Custom OTP2 instance (28 providers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Code Quality](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/lint.yaml/badge.svg)](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/lint.yaml)
 [![Tests](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/tests.yaml/badge.svg)](https://github.com/NerdySoftPaw/openpublictransport/actions/workflows/tests.yaml)
 
-Real-time public transport departures for Home Assistant — 26 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
+Real-time public transport departures for Home Assistant — 28 providers across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide.
 
 **Website**: [openpublictransport.net](https://openpublictransport.net) | **Docs**: [docs.openpublictransport.net](https://docs.openpublictransport.net/)
 
@@ -21,7 +21,7 @@ Real-time public transport departures for Home Assistant — 26 providers across
 > The domain changed from `vrr` to `openpublictransport` — entity IDs and services have new names.
 > See the [Migration Guide](https://docs.openpublictransport.net/migration/) for step-by-step instructions.
 
-## Supported Providers (26)
+## Supported Providers (28)
 
 | Provider | Region | API Key | Trip Planner |
 |----------|--------|---------|--------------|
@@ -38,6 +38,8 @@ Real-time public transport departures for Home Assistant — 26 providers across
 | **NVBW** | Baden-Württemberg | No | No |
 | **NWL** | Westfalen-Lippe | No | No |
 | **ÖBB** | Austria (nationwide) | No | No |
+| **openpublictransport** | Germany (nationwide, GTFS.DE + GTFS-RT, community OTP2) | Yes ([request](https://openpublictransport.net/api-key)) | No |
+| **OTP2 Custom** | Any OTP2 instance (self-hosted) | Optional | No |
 | **RMV** | Frankfurt / Rhein-Main | Yes (free) | No |
 | **RVV** | Regensburg | No | No |
 | **SBB** | Switzerland (nationwide) | No | No |
@@ -55,7 +57,7 @@ Real-time public transport departures for Home Assistant — 26 providers across
 ## Features
 
 - **Real-time departures** with delay tracking, platform changes, and disruption notices
-- **26 transit providers** — most require no API key
+- **28 transit providers** — most require no API key
 - **Trip planner** — A-to-B routes with transfer risk assessment
 - **7 entity types** — sensor, binary sensor, calendar, event, camera, trip sensor, statistics
 - **4 services** — refresh_departures, plan_trip, check_delays, announce_departure (TTS)

--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -10,7 +10,9 @@ from homeassistant.helpers import entity_registry as er
 from .const import (
     CONF_DEPARTURES,
     CONF_NTA_API_KEY,
+    CONF_OPT_API_KEY,
     CONF_OTP_BASE_URL,
+    CONF_OTP_CUSTOM_API_KEY,
     CONF_PROVIDER,
     CONF_RMV_API_KEY,
     CONF_SCAN_INTERVAL,
@@ -107,8 +109,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     nta_api_key = entry.data.get(CONF_NTA_API_KEY)  # For NTA
     rmv_api_key = entry.data.get(CONF_RMV_API_KEY)  # For RMV
     vbn_api_key = entry.data.get(CONF_VBN_API_KEY)  # For VBN (OTP + TRIAS)
-    opt_api_key = entry.data.get("opt_api_key")  # For community OTP server
-    otp_custom_api_key = entry.data.get("otp_custom_api_key")  # For custom OTP instance
+    opt_api_key = entry.data.get(CONF_OPT_API_KEY)  # For community OTP server
+    otp_custom_api_key = entry.data.get(CONF_OTP_CUSTOM_API_KEY)  # For custom OTP instance
     otp_custom_url = entry.data.get(CONF_OTP_BASE_URL)  # For custom OTP instance
 
     # Use appropriate API key (and URL) based on provider

--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 from .const import (
     CONF_DEPARTURES,
     CONF_NTA_API_KEY,
+    CONF_OTP_BASE_URL,
     CONF_PROVIDER,
     CONF_RMV_API_KEY,
     CONF_SCAN_INTERVAL,
@@ -20,6 +21,8 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     PROVIDER_NTA_IE,
+    PROVIDER_OPT,
+    PROVIDER_OTP_CUSTOM,
     PROVIDER_RMV,
     PROVIDER_TRAFIKLAB_SE,
     PROVIDER_VBN_OTP,
@@ -104,9 +107,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     nta_api_key = entry.data.get(CONF_NTA_API_KEY)  # For NTA
     rmv_api_key = entry.data.get(CONF_RMV_API_KEY)  # For RMV
     vbn_api_key = entry.data.get(CONF_VBN_API_KEY)  # For VBN (OTP + TRIAS)
+    opt_api_key = entry.data.get("opt_api_key")  # For community OTP server
+    otp_custom_api_key = entry.data.get("otp_custom_api_key")  # For custom OTP instance
+    otp_custom_url = entry.data.get(CONF_OTP_BASE_URL)  # For custom OTP instance
 
-    # Use appropriate API key based on provider
+    # Use appropriate API key (and URL) based on provider
     api_key = None
+    custom_url = None
     if provider == PROVIDER_TRAFIKLAB_SE:
         api_key = trafiklab_api_key
     elif provider == PROVIDER_NTA_IE:
@@ -115,6 +122,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         api_key = rmv_api_key
     elif provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
         api_key = vbn_api_key
+    elif provider == PROVIDER_OPT:
+        api_key = opt_api_key
+    elif provider == PROVIDER_OTP_CUSTOM:
+        api_key = otp_custom_api_key
+        custom_url = otp_custom_url
 
     departures = entry.options.get(CONF_DEPARTURES, entry.data.get(CONF_DEPARTURES, DEFAULT_DEPARTURES))
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
@@ -129,6 +141,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         scan_interval,
         config_entry=entry,
         api_key=api_key,
+        custom_url=custom_url,
     )
 
     # Store coordinator before first refresh

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -558,6 +558,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             self.hass,
             api_key=self._api_key,
             api_key_secondary=self._api_key_secondary,
+            custom_url=self._otp_custom_url,
         )
         if provider_instance:
             try:

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -196,8 +196,9 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         schema = vol.Schema(
             {
                 vol.Required(
-                    CONF_OTP_BASE_URL, description={"suggested_value": "http://192.168.1.10:8080/otp/routers/default"}
-                ): str,
+                    CONF_OTP_BASE_URL,
+                    description={"suggested_value": "http://192.168.1.10:8080/otp/routers/default"},
+                ): cv.url,
                 vol.Optional("otp_custom_api_key"): str,
             }
         )

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -98,7 +98,10 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             {"value": "rvv", "label": "RVV — Regensburg"},
             {"value": "sbb", "label": "SBB — Schweiz"},
             {"value": "trafiklab_se", "label": "Trafiklab — Schweden (API Key)"},
-            {"value": "openpublictransport", "label": "Deutschland — Community Server (api.openpublictransport.net, API Key)"},
+            {
+                "value": "openpublictransport",
+                "label": "Deutschland — Community Server (api.openpublictransport.net, API Key)",
+            },
             {"value": "otp_custom", "label": "OTP2 — Eigene Instanz (URL + optionaler API Key)"},
             {"value": "transitous", "label": "Transitous — Weltweit (Community, Beta)"},
             {"value": "vagfr", "label": "VAG — Freiburg"},
@@ -190,10 +193,14 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     return await self.async_step_trip_search()
                 return await self.async_step_stop_search()
 
-        schema = vol.Schema({
-            vol.Required(CONF_OTP_BASE_URL, description={"suggested_value": "http://192.168.1.10:8080/otp/routers/default"}): str,
-            vol.Optional("otp_custom_api_key"): str,
-        })
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_OTP_BASE_URL, description={"suggested_value": "http://192.168.1.10:8080/otp/routers/default"}
+                ): str,
+                vol.Optional("otp_custom_api_key"): str,
+            }
+        )
         return self.async_show_form(
             step_id="otp_custom_url",
             data_schema=schema,

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -157,23 +157,28 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         return self.async_show_form(step_id="user", data_schema=schema)
 
     async def async_step_opt_key(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
-        """Optional API key step for the openpublictransport community server."""
+        """Required API key step for the openpublictransport community server."""
+        errors: Dict[str, str] = {}
         if user_input is not None:
-            self._api_key = user_input.get("opt_api_key", "").strip() or None
-            if self._entry_type == "trip":
-                self._trip_search_phase = "origin"
-                return await self.async_step_trip_search()
-            return await self.async_step_stop_search()
+            key = user_input.get("opt_api_key", "").strip()
+            if not key:
+                errors["opt_api_key"] = "opt_api_key_required"
+            else:
+                self._api_key = key
+                if self._entry_type == "trip":
+                    self._trip_search_phase = "origin"
+                    return await self.async_step_trip_search()
+                return await self.async_step_stop_search()
 
-        schema = vol.Schema({vol.Optional("opt_api_key"): str})
+        schema = vol.Schema({vol.Required("opt_api_key"): str})
         return self.async_show_form(
             step_id="opt_key",
             data_schema=schema,
+            errors=errors,
             description_placeholders={
                 "info": (
-                    "API key for api.openpublictransport.net (optional for now, required later). "
-                    "Request a free key at openpublictransport.net/api-key — "
-                    "just send your name and use case."
+                    "API key for api.openpublictransport.net — required. "
+                    "Request a free key at openpublictransport.net/api-key."
                 )
             },
         )

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -24,7 +24,9 @@ from .const import (
     CONF_LINE_FILTER,
     CONF_NTA_API_KEY,
     CONF_NTA_API_KEY_SECONDARY,
+    CONF_OPT_API_KEY,
     CONF_OTP_BASE_URL,
+    CONF_OTP_CUSTOM_API_KEY,
     CONF_PROVIDER,
     CONF_RMV_API_KEY,
     CONF_SCAN_INTERVAL,
@@ -160,9 +162,9 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         """Required API key step for the openpublictransport community server."""
         errors: Dict[str, str] = {}
         if user_input is not None:
-            key = user_input.get("opt_api_key", "").strip()
+            key = user_input.get(CONF_OPT_API_KEY, "").strip()
             if not key:
-                errors["opt_api_key"] = "opt_api_key_required"
+                errors[CONF_OPT_API_KEY] = "opt_api_key_required"
             else:
                 self._api_key = key
                 if self._entry_type == "trip":
@@ -170,7 +172,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     return await self.async_step_trip_search()
                 return await self.async_step_stop_search()
 
-        schema = vol.Schema({vol.Required("opt_api_key"): str})
+        schema = vol.Schema({vol.Required(CONF_OPT_API_KEY): str})
         return self.async_show_form(
             step_id="opt_key",
             data_schema=schema,
@@ -192,7 +194,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 errors[CONF_OTP_BASE_URL] = "otp_url_required"
             else:
                 self._otp_custom_url = url
-                self._api_key = user_input.get("otp_custom_api_key", "").strip() or None
+                self._api_key = user_input.get(CONF_OTP_CUSTOM_API_KEY, "").strip() or None
                 if self._entry_type == "trip":
                     self._trip_search_phase = "origin"
                     return await self.async_step_trip_search()
@@ -204,7 +206,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     CONF_OTP_BASE_URL,
                     description={"suggested_value": "http://192.168.1.10:8080/otp/routers/default"},
                 ): cv.url,
-                vol.Optional("otp_custom_api_key"): str,
+                vol.Optional(CONF_OTP_CUSTOM_API_KEY): str,
             }
         )
         return self.async_show_form(
@@ -509,12 +511,12 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 data[CONF_VBN_API_KEY] = self._api_key
             elif self._provider == PROVIDER_OPT:
                 if self._api_key:
-                    data["opt_api_key"] = self._api_key
+                    data[CONF_OPT_API_KEY] = self._api_key
             elif self._provider == PROVIDER_OTP_CUSTOM:
                 if self._otp_custom_url:
                     data[CONF_OTP_BASE_URL] = self._otp_custom_url
                 if self._api_key:
-                    data["otp_custom_api_key"] = self._api_key
+                    data[CONF_OTP_CUSTOM_API_KEY] = self._api_key
 
             # Create unique ID (self._selected_stop validated above)
             unique_id = f"{self._provider}_{self._selected_stop['id']}"

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_LINE_FILTER,
     CONF_NTA_API_KEY,
     CONF_NTA_API_KEY_SECONDARY,
+    CONF_OTP_BASE_URL,
     CONF_PROVIDER,
     CONF_RMV_API_KEY,
     CONF_SCAN_INTERVAL,
@@ -40,6 +41,8 @@ from .const import (
     PROVIDER_HVV,
     PROVIDER_KVV,
     PROVIDER_NTA_IE,
+    PROVIDER_OPT,
+    PROVIDER_OTP_CUSTOM,
     PROVIDER_RMV,
     PROVIDER_TRAFIKLAB_SE,
     PROVIDER_VBN_OTP,
@@ -64,6 +67,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         self._selected_stop: Optional[Dict[str, Any]] = None
         self._api_key: Optional[str] = None  # For Trafiklab or NTA (Primary)
         self._api_key_secondary: Optional[str] = None  # For NTA (Secondary, optional)
+        self._otp_custom_url: Optional[str] = None  # For otp_custom provider
         # Trip planning fields
         self._trip_origin: Optional[Dict[str, Any]] = None
         self._trip_destination: Optional[Dict[str, Any]] = None
@@ -94,6 +98,8 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             {"value": "rvv", "label": "RVV — Regensburg"},
             {"value": "sbb", "label": "SBB — Schweiz"},
             {"value": "trafiklab_se", "label": "Trafiklab — Schweden (API Key)"},
+            {"value": "openpublictransport", "label": "Deutschland — Community Server (api.openpublictransport.net, API Key)"},
+            {"value": "otp_custom", "label": "OTP2 — Eigene Instanz (URL + optionaler API Key)"},
             {"value": "transitous", "label": "Transitous — Weltweit (Community, Beta)"},
             {"value": "vagfr", "label": "VAG — Freiburg"},
             {"value": "vbn_otp", "label": "VBN — Bremen / Niedersachsen — OTP (API Key)"},
@@ -115,6 +121,12 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 return await self.async_step_multi_stop()
 
             self._provider = user_input[CONF_PROVIDER]
+
+            if self._provider == PROVIDER_OTP_CUSTOM:
+                return await self.async_step_otp_custom_url()
+
+            if self._provider == PROVIDER_OPT:
+                return await self.async_step_opt_key()
 
             provider_instance = get_provider(self._provider, self.hass)
             if provider_instance and provider_instance.requires_api_key:
@@ -140,6 +152,60 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         )
 
         return self.async_show_form(step_id="user", data_schema=schema)
+
+    async def async_step_opt_key(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
+        """Optional API key step for the openpublictransport community server."""
+        if user_input is not None:
+            self._api_key = user_input.get("opt_api_key", "").strip() or None
+            if self._entry_type == "trip":
+                self._trip_search_phase = "origin"
+                return await self.async_step_trip_search()
+            return await self.async_step_stop_search()
+
+        schema = vol.Schema({vol.Optional("opt_api_key"): str})
+        return self.async_show_form(
+            step_id="opt_key",
+            data_schema=schema,
+            description_placeholders={
+                "info": (
+                    "API key for api.openpublictransport.net (optional for now, required later). "
+                    "Request a free key at openpublictransport.net/api-key — "
+                    "just send your name and use case."
+                )
+            },
+        )
+
+    async def async_step_otp_custom_url(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
+        """URL + optional API key for a user-provided OTP2 instance."""
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            url = user_input.get(CONF_OTP_BASE_URL, "").strip()
+            if not url:
+                errors[CONF_OTP_BASE_URL] = "otp_url_required"
+            else:
+                self._otp_custom_url = url
+                self._api_key = user_input.get("otp_custom_api_key", "").strip() or None
+                if self._entry_type == "trip":
+                    self._trip_search_phase = "origin"
+                    return await self.async_step_trip_search()
+                return await self.async_step_stop_search()
+
+        schema = vol.Schema({
+            vol.Required(CONF_OTP_BASE_URL, description={"suggested_value": "http://192.168.1.10:8080/otp/routers/default"}): str,
+            vol.Optional("otp_custom_api_key"): str,
+        })
+        return self.async_show_form(
+            step_id="otp_custom_url",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={
+                "info": (
+                    "Base URL of your OTP2 instance up to and including the router path, "
+                    "e.g. http://192.168.1.10:8080/otp/routers/default. "
+                    "Leave API key empty if your server runs without auth."
+                )
+            },
+        )
 
     async def async_step_api_key(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         """Handle API key input for providers that require it."""
@@ -428,6 +494,14 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                         errors={"base": "vbn_api_key_required"},
                     )
                 data[CONF_VBN_API_KEY] = self._api_key
+            elif self._provider == PROVIDER_OPT:
+                if self._api_key:
+                    data["opt_api_key"] = self._api_key
+            elif self._provider == PROVIDER_OTP_CUSTOM:
+                if self._otp_custom_url:
+                    data[CONF_OTP_BASE_URL] = self._otp_custom_url
+                if self._api_key:
+                    data["otp_custom_api_key"] = self._api_key
 
             # Create unique ID (self._selected_stop validated above)
             unique_id = f"{self._provider}_{self._selected_stop['id']}"

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -50,9 +50,9 @@ PROVIDER_DB = "db"
 PROVIDER_VBN_OTP = "vbn_otp"
 PROVIDER_VBN_TRIAS = "vbn_trias"
 CONF_VBN_API_KEY = "vbn_api_key"
-PROVIDER_OPT = "openpublictransport" # community server at api.openpublictransport.net
-PROVIDER_OTP_CUSTOM = "otp_custom"   # user-provided OTP2 instance
-CONF_OTP_BASE_URL = "otp_base_url"   # custom URL for otp_custom provider
+PROVIDER_OPT = "openpublictransport"  # community server at api.openpublictransport.net
+PROVIDER_OTP_CUSTOM = "otp_custom"  # user-provided OTP2 instance
+CONF_OTP_BASE_URL = "otp_base_url"  # custom URL for otp_custom provider
 PROVIDERS = [
     PROVIDER_VRR,
     PROVIDER_KVV,

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -53,6 +53,8 @@ CONF_VBN_API_KEY = "vbn_api_key"
 PROVIDER_OPT = "openpublictransport"  # community server at api.openpublictransport.net
 PROVIDER_OTP_CUSTOM = "otp_custom"  # user-provided OTP2 instance
 CONF_OTP_BASE_URL = "otp_base_url"  # custom URL for otp_custom provider
+CONF_OPT_API_KEY = "opt_api_key"  # API key for community OTP server
+CONF_OTP_CUSTOM_API_KEY = "otp_custom_api_key"  # API key for custom OTP instance
 PROVIDERS = [
     PROVIDER_VRR,
     PROVIDER_KVV,

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -50,6 +50,9 @@ PROVIDER_DB = "db"
 PROVIDER_VBN_OTP = "vbn_otp"
 PROVIDER_VBN_TRIAS = "vbn_trias"
 CONF_VBN_API_KEY = "vbn_api_key"
+PROVIDER_OPT = "openpublictransport" # community server at api.openpublictransport.net
+PROVIDER_OTP_CUSTOM = "otp_custom"   # user-provided OTP2 instance
+CONF_OTP_BASE_URL = "otp_base_url"   # custom URL for otp_custom provider
 PROVIDERS = [
     PROVIDER_VRR,
     PROVIDER_KVV,
@@ -77,6 +80,8 @@ PROVIDERS = [
     PROVIDER_DB,
     PROVIDER_VBN_OTP,
     PROVIDER_VBN_TRIAS,
+    PROVIDER_OPT,
+    PROVIDER_OTP_CUSTOM,
 ]
 
 # Transportation types mapping
@@ -160,6 +165,8 @@ PROVIDER_ICONS = {
     "beg": "mdi:train",
     "vbn_otp": "mdi:bus-clock",
     "vbn_trias": "mdi:bus-clock",
+    "openpublictransport": "mdi:train-variant",
+    "otp_custom": "mdi:server-network",
 }
 
 # Provider-specific entity pictures (logos)
@@ -192,4 +199,5 @@ PROVIDER_ENTITY_PICTURES = {
     "db": "https://www.bahn.de/favicon.ico",
     "vbn_otp": "https://www.vbn.de/favicon.ico",
     "vbn_trias": "https://www.vbn.de/favicon.ico",
+    "openpublictransport": "https://openpublictransport.net/favicon.ico",
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.3b3"
+  "version": "2026.5.3b4"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.3b2"
+  "version": "2026.5.3b3"
 }

--- a/custom_components/openpublictransport/providers/__init__.py
+++ b/custom_components/openpublictransport/providers/__init__.py
@@ -26,6 +26,8 @@ from ..const import (
     PROVIDER_VAGFR,
     PROVIDER_VBN_OTP,
     PROVIDER_VBN_TRIAS,
+    PROVIDER_OPT,
+    PROVIDER_OTP_CUSTOM,
     PROVIDER_VGN,
     PROVIDER_VRN,
     PROVIDER_VRR,
@@ -52,6 +54,8 @@ from .sbb import SBBProvider
 from .trafiklab import TrafiklabProvider
 from .transitous import TransitousProvider
 from .vagfr import VAGFRProvider
+from .gtfsde import OPTProvider
+from .otp_custom import OTPCustomProvider
 from .vbn import VBNOTPProvider, VBNTriasProvider
 from .vgn import VGNProvider
 from .vrn import VRNProvider
@@ -72,13 +76,19 @@ def get_provider(
     hass: HomeAssistant,
     api_key: Optional[str] = None,
     api_key_secondary: Optional[str] = None,
+    custom_url: Optional[str] = None,
 ) -> Optional[BaseProvider]:
     """Get a provider instance by ID."""
     if provider_id is None:
         return None
     provider_class = _PROVIDER_REGISTRY.get(provider_id)
     if provider_class:
-        return provider_class(hass, api_key=api_key, api_key_secondary=api_key_secondary)
+        return provider_class(
+            hass,
+            api_key=api_key,
+            api_key_secondary=api_key_secondary,
+            custom_url=custom_url,
+        )
     return None
 
 
@@ -114,3 +124,5 @@ register_provider(PROVIDER_TRANSITOUS, TransitousProvider)
 register_provider(PROVIDER_DB, DBProvider)
 register_provider(PROVIDER_VBN_OTP, VBNOTPProvider)
 register_provider(PROVIDER_VBN_TRIAS, VBNTriasProvider)
+register_provider(PROVIDER_OPT, OPTProvider)
+register_provider(PROVIDER_OTP_CUSTOM, OTPCustomProvider)

--- a/custom_components/openpublictransport/providers/__init__.py
+++ b/custom_components/openpublictransport/providers/__init__.py
@@ -18,6 +18,8 @@ from ..const import (
     PROVIDER_NVBW,
     PROVIDER_NWL,
     PROVIDER_OEBB,
+    PROVIDER_OPT,
+    PROVIDER_OTP_CUSTOM,
     PROVIDER_RMV,
     PROVIDER_RVV,
     PROVIDER_SBB,
@@ -26,8 +28,6 @@ from ..const import (
     PROVIDER_VAGFR,
     PROVIDER_VBN_OTP,
     PROVIDER_VBN_TRIAS,
-    PROVIDER_OPT,
-    PROVIDER_OTP_CUSTOM,
     PROVIDER_VGN,
     PROVIDER_VRN,
     PROVIDER_VRR,
@@ -41,6 +41,7 @@ from .bsvg import BSVGProvider
 from .bvg import BVGProvider
 from .db import DBProvider
 from .ding import DINGProvider
+from .gtfsde import OPTProvider
 from .hvv import HVVProvider
 from .kvv import KVVProvider
 from .mvv import MVVProvider
@@ -48,14 +49,13 @@ from .nta import NTAProvider
 from .nvbw import NVBWProvider
 from .nwl import NWLProvider
 from .oebb import OeBBProvider
+from .otp_custom import OTPCustomProvider
 from .rmv import RMVProvider
 from .rvv import RVVProvider
 from .sbb import SBBProvider
 from .trafiklab import TrafiklabProvider
 from .transitous import TransitousProvider
 from .vagfr import VAGFRProvider
-from .gtfsde import OPTProvider
-from .otp_custom import OTPCustomProvider
 from .vbn import VBNOTPProvider, VBNTriasProvider
 from .vgn import VGNProvider
 from .vrn import VRNProvider

--- a/custom_components/openpublictransport/providers/base.py
+++ b/custom_components/openpublictransport/providers/base.py
@@ -13,17 +13,17 @@ from ..data_models import UnifiedDeparture
 class BaseProvider(ABC):
     """Abstract base class for all public transport providers."""
 
-    def __init__(self, hass: HomeAssistant, api_key: Optional[str] = None, api_key_secondary: Optional[str] = None):
-        """Initialize the provider.
-
-        Args:
-            hass: Home Assistant instance
-            api_key: Primary API key (if required)
-            api_key_secondary: Secondary API key (if required, e.g., for NTA)
-        """
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_key: Optional[str] = None,
+        api_key_secondary: Optional[str] = None,
+        custom_url: Optional[str] = None,
+    ):
         self.hass = hass
         self.api_key = api_key
         self.api_key_secondary = api_key_secondary
+        self.custom_url = custom_url
 
     @property
     @abstractmethod

--- a/custom_components/openpublictransport/providers/gtfsde.py
+++ b/custom_components/openpublictransport/providers/gtfsde.py
@@ -1,0 +1,17 @@
+"""Community OTP2 provider — api.openpublictransport.net (GTFS.DE data, Germany-wide)."""
+
+from .otp import OTPProvider
+
+
+class OPTProvider(OTPProvider):
+    """Community server at api.openpublictransport.net."""
+
+    otp_base_url = "https://api.openpublictransport.net/otp/routers/default"
+
+    @property
+    def provider_id(self) -> str:
+        return "openpublictransport"
+
+    @property
+    def provider_name(self) -> str:
+        return "Deutschland (api.openpublictransport.net)"

--- a/custom_components/openpublictransport/providers/gtfsde.py
+++ b/custom_components/openpublictransport/providers/gtfsde.py
@@ -15,3 +15,7 @@ class OPTProvider(OTPProvider):
     @property
     def provider_name(self) -> str:
         return "Deutschland (api.openpublictransport.net)"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return True

--- a/custom_components/openpublictransport/providers/nta.py
+++ b/custom_components/openpublictransport/providers/nta.py
@@ -22,7 +22,13 @@ _LOGGER = logging.getLogger(__name__)
 class NTAProvider(BaseProvider):
     """NTA (National Transport Authority, Ireland) provider."""
 
-    def __init__(self, hass, api_key: Optional[str] = None, api_key_secondary: Optional[str] = None):
+    def __init__(
+        self,
+        hass,
+        api_key: Optional[str] = None,
+        api_key_secondary: Optional[str] = None,
+        custom_url: Optional[str] = None,
+    ):
         """Initialize NTA provider."""
         super().__init__(hass, api_key=api_key, api_key_secondary=api_key_secondary)
 

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -123,8 +123,7 @@ class OTPProvider(OTPBaseProvider):
 
     def _raw_stops_from_body(self, body: Optional[Dict]) -> List[Dict[str, Any]]:
         return [
-            s for s in (((body or {}).get("data") or {}).get("stops") or [])
-            if isinstance(s, dict) and "gtfsId" in s
+            s for s in (((body or {}).get("data") or {}).get("stops") or []) if isinstance(s, dict) and "gtfsId" in s
         ]
 
     def _group_by_name(self, raw_stops: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -132,10 +131,7 @@ class OTPProvider(OTPBaseProvider):
         groups: Dict[str, List[str]] = {}
         for s in raw_stops:
             groups.setdefault(s["name"], []).append(s["gtfsId"])
-        return [
-            {"id": "|".join(ids), "name": name, "place": name, "area_type": "stop"}
-            for name, ids in groups.items()
-        ]
+        return [{"id": "|".join(ids), "name": name, "place": name, "area_type": "stop"} for name, ids in groups.items()]
 
     async def _search_one(self, term: str) -> List[Dict[str, Any]]:
         q = _GRAPHQL_STOP_SEARCH % term.replace('"', '\\"')
@@ -170,9 +166,7 @@ class OTPProvider(OTPBaseProvider):
         seen_terms: set = set()
         unique = [t for t in prefixed if not (t in seen_terms or seen_terms.add(t))]  # type: ignore[func-returns-value]
 
-        bodies = await asyncio.gather(
-            *[self._graphql(_GRAPHQL_STOP_SEARCH % t.replace('"', '\\"')) for t in unique]
-        )
+        bodies = await asyncio.gather(*[self._graphql(_GRAPHQL_STOP_SEARCH % t.replace('"', '\\"')) for t in unique])
         all_raw: List[Dict[str, Any]] = []
         seen_ids: set = set()
         for body in bodies:

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -1,0 +1,223 @@
+"""Generic OTP2 provider base — used by the community server and custom instances.
+
+Handles:
+- GraphQL stop search with ß→ss and VRR/NRW city-prefix fallback
+- Multi-platform compound stop IDs (pipe-separated)
+- Parallel platform fetch + merge
+- X-API-Key header when api_key is set
+- custom_url override for self-hosted instances
+"""
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict, List, Optional, Union
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import aiohttp
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from ..data_models import UnifiedDeparture
+from .otp_base import OTPBaseProvider
+
+_LOGGER = logging.getLogger(__name__)
+
+# gtfs.de stores VRR/NRW stops with a city-prefix: "D-Elbruchstraße" not "Elbruchstraße"
+_CITY_PREFIXES: Dict[str, str] = {
+    "düsseldorf": "D-",
+    "duesseldorf": "D-",
+    "köln": "K-",
+    "koeln": "K-",
+    "cologne": "K-",
+    "dortmund": "Do-",
+    "essen": "E-",
+    "duisburg": "DU-",
+    "wuppertal": "W-",
+    "bochum": "BO-",
+    "bielefeld": "BI-",
+    "münster": "MS-",
+    "muenster": "MS-",
+    "aachen": "AC-",
+    "krefeld": "KR-",
+    "mönchengladbach": "MG-",
+    "moenchengladbach": "MG-",
+    "oberhausen": "OB-",
+    "hagen": "HA-",
+    "hamm": "HAM-",
+    "gelsenkirchen": "GE-",
+    "mülheim": "MH-",
+    "muelheim": "MH-",
+    "leverkusen": "LEV-",
+    "bonn": "BN-",
+}
+
+_GRAPHQL_STOP_SEARCH = '{ stops(name: "%s") { gtfsId name lat lon } }'
+
+_GRAPHQL_STOPTIMES = """{
+  stop(id: "%s") {
+    name
+    stoptimesWithoutPatterns(numberOfDepartures: %d, startTime: %d) {
+      serviceDay
+      scheduledDeparture
+      realtimeDeparture
+      departureDelay
+      realtime
+      headsign
+      trip {
+        route {
+          shortName
+          mode
+        }
+      }
+    }
+  }
+}"""
+
+
+class OTPProvider(OTPBaseProvider):
+    """Generic OTP2 provider — subclass and set otp_base_url, provider_id, provider_name."""
+
+    otp_base_url: str = ""
+
+    @property
+    def _effective_base_url(self) -> str:
+        return (self.custom_url or "").rstrip("/") or self.otp_base_url
+
+    def _auth_headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        return headers
+
+    async def _graphql(self, query: str) -> Optional[Dict[str, Any]]:
+        session = async_get_clientsession(self.hass)
+        url = f"{self._effective_base_url}/index/graphql"
+        try:
+            async with session.post(
+                url,
+                json={"query": query},
+                headers=self._auth_headers(),
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+                _LOGGER.warning("%s GraphQL → HTTP %s", self.provider_name, resp.status)
+        except Exception as exc:
+            _LOGGER.warning("%s GraphQL request failed: %s", self.provider_name, exc)
+        return None
+
+    def _raw_stops_from_body(self, body: Optional[Dict]) -> List[Dict[str, Any]]:
+        return [
+            s for s in (((body or {}).get("data") or {}).get("stops") or [])
+            if isinstance(s, dict) and "gtfsId" in s
+        ]
+
+    def _group_by_name(self, raw_stops: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Group platform stops by name into compound entries (one per physical station)."""
+        groups: Dict[str, List[str]] = {}
+        for s in raw_stops:
+            groups.setdefault(s["name"], []).append(s["gtfsId"])
+        return [
+            {"id": "|".join(ids), "name": name, "place": name, "area_type": "stop"}
+            for name, ids in groups.items()
+        ]
+
+    async def _search_one(self, term: str) -> List[Dict[str, Any]]:
+        q = _GRAPHQL_STOP_SEARCH % term.replace('"', '\\"')
+        return self._raw_stops_from_body(await self._graphql(q))
+
+    async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:
+        """Search stops via OTP2 GraphQL with city-prefix fallback for VRR/NRW."""
+        ss_term = search_term.replace("ß", "ss") if "ß" in search_term else None
+
+        # Phase 1: bare name and ß→ss variant
+        for term in filter(None, [search_term, ss_term]):
+            raw = await self._search_one(term)
+            if raw:
+                return self._group_by_name(raw)[:20]
+
+        # Phase 2: all city prefixes in parallel
+        prefixed = [p + search_term for p in _CITY_PREFIXES.values()]
+        if ss_term:
+            prefixed += [p + ss_term for p in _CITY_PREFIXES.values()]
+        seen_terms: set = set()
+        unique = [t for t in prefixed if not (t in seen_terms or seen_terms.add(t))]  # type: ignore[func-returns-value]
+
+        bodies = await asyncio.gather(
+            *[self._graphql(_GRAPHQL_STOP_SEARCH % t.replace('"', '\\"')) for t in unique]
+        )
+        all_raw: List[Dict[str, Any]] = []
+        seen_ids: set = set()
+        for body in bodies:
+            for stop in self._raw_stops_from_body(body):
+                if stop["gtfsId"] not in seen_ids:
+                    seen_ids.add(stop["gtfsId"])
+                    all_raw.append(stop)
+        if all_raw:
+            return self._group_by_name(all_raw)[:20]
+
+        # Phase 3: Nominatim + OTP radius search
+        return await super().search_stops(search_term)
+
+    def _stoptimes_to_events(self, stoptimes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        mode_mapping = self.get_mode_mapping()
+        return [
+            {
+                "routeName": ((st.get("trip") or {}).get("route") or {}).get("shortName", ""),
+                "transportType": mode_mapping.get(
+                    ((st.get("trip") or {}).get("route") or {}).get("mode", ""), "unknown"
+                ),
+                "agency": "",
+                "notices": None,
+                "serviceDay": st.get("serviceDay", 0),
+                "scheduledDeparture": st.get("scheduledDeparture", 0),
+                "realtimeDeparture": st.get("realtimeDeparture", 0),
+                "departureDelay": st.get("departureDelay", 0),
+                "realtime": st.get("realtime", False),
+                "headsign": st.get("headsign", ""),
+            }
+            for st in stoptimes
+        ]
+
+    async def _fetch_one_stop(self, gtfs_id: str, limit: int, start_epoch: int) -> List[Dict[str, Any]]:
+        q = _GRAPHQL_STOPTIMES % (gtfs_id.replace('"', '\\"'), limit, start_epoch)
+        body = await self._graphql(q)
+        if body is None:
+            return []
+        stoptimes = (((body.get("data") or {}).get("stop")) or {}).get("stoptimesWithoutPatterns") or []
+        return self._stoptimes_to_events(stoptimes)
+
+    async def fetch_departures(
+        self,
+        station_id: Optional[str],
+        place_dm: str,
+        name_dm: str,
+        departures_limit: int,
+    ) -> Optional[Dict[str, Any]]:
+        if not station_id:
+            return None
+
+        gtfs_ids = station_id.split("|")
+        start_epoch = int(time.time())
+
+        if len(gtfs_ids) == 1:
+            events = await self._fetch_one_stop(gtfs_ids[0], departures_limit, start_epoch)
+        else:
+            results = await asyncio.gather(
+                *[self._fetch_one_stop(gid, departures_limit, start_epoch) for gid in gtfs_ids]
+            )
+            seen_keys: set = set()
+            merged = []
+            for batch in results:
+                for ev in batch:
+                    key = (ev["serviceDay"], ev["realtimeDeparture"], ev["routeName"], ev["headsign"])
+                    if key not in seen_keys:
+                        seen_keys.add(key)
+                        merged.append(ev)
+            merged.sort(key=lambda x: x["serviceDay"] + x["realtimeDeparture"])
+            events = merged[:departures_limit]
+
+        return {"stopEvents": events}
+
+    # parse_departure inherited from OTPBaseProvider: serviceDay + departure as UTC → correct local time

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -54,6 +54,22 @@ _CITY_PREFIXES: Dict[str, str] = {
 
 _GRAPHQL_STOP_SEARCH = '{ stops(name: "%s") { gtfsId name lat lon } }'
 
+
+def _detect_city_prefix(search_term: str) -> Optional[str]:
+    """If the search contains a known city name, return PREFIX + stop_part.
+
+    Handles "Düsseldorf Elbruchstraße" and "Elbruchstraße, Düsseldorf" by
+    removing the city word and prepending its gtfs.de prefix to the remainder.
+    """
+    words = search_term.strip().replace(",", " ").split()
+    for i, word in enumerate(words):
+        prefix = _CITY_PREFIXES.get(word.lower())
+        if prefix:
+            remaining = " ".join(w for j, w in enumerate(words) if j != i).strip()
+            if remaining:
+                return prefix + remaining
+    return None
+
 _GRAPHQL_STOPTIMES = """{
   stop(id: "%s") {
     name
@@ -136,6 +152,18 @@ class OTPProvider(OTPBaseProvider):
             raw = await self._search_one(term)
             if raw:
                 return self._group_by_name(raw)[:20]
+
+        # Phase 1b: city-word detection — "Düsseldorf Elbruchstraße" → "D-Elbruchstraße"
+        detected = _detect_city_prefix(search_term)
+        if detected:
+            raw = await self._search_one(detected)
+            if raw:
+                return self._group_by_name(raw)[:20]
+            detected_ss = detected.replace("ß", "ss") if "ß" in detected else None
+            if detected_ss:
+                raw = await self._search_one(detected_ss)
+                if raw:
+                    return self._group_by_name(raw)[:20]
 
         # Phase 2: all city prefixes in parallel
         prefixed = [p + search_term for p in _CITY_PREFIXES.values()]

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -10,6 +10,7 @@ Handles:
 
 import asyncio
 import logging
+import math
 import time
 from typing import Any, Dict, List, Optional
 
@@ -66,6 +67,47 @@ def _detect_city_prefix(search_term: str) -> Optional[str]:
             if remaining:
                 return prefix + remaining
     return None
+
+
+_MAX_PLATFORM_DISTANCE_M = 500
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in metres between two lat/lon points."""
+    r = 6_371_000
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    return r * 2 * math.asin(math.sqrt(a))
+
+
+def _cluster_by_proximity(stops: List[Dict[str, Any]]) -> List[List[Dict[str, Any]]]:
+    """Union-find clustering: stops within _MAX_PLATFORM_DISTANCE_M form one cluster.
+
+    Prevents stops from different cities that share a name (e.g. "Hauptbahnhof")
+    from being merged into a single compound ID.
+    """
+    n = len(stops)
+    parent = list(range(n))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            si, sj = stops[i], stops[j]
+            if si.get("lat") and si.get("lon") and sj.get("lat") and sj.get("lon"):
+                if _haversine_m(si["lat"], si["lon"], sj["lat"], sj["lon"]) <= _MAX_PLATFORM_DISTANCE_M:
+                    parent[find(i)] = find(j)
+
+    groups: Dict[int, List[Dict[str, Any]]] = {}
+    for i, stop in enumerate(stops):
+        groups.setdefault(find(i), []).append(stop)
+    return list(groups.values())
 
 
 _GRAPHQL_STOPTIMES = """{
@@ -127,11 +169,22 @@ class OTPProvider(OTPBaseProvider):
         ]
 
     def _group_by_name(self, raw_stops: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Group platform stops by name into compound entries (one per physical station)."""
-        groups: Dict[str, List[str]] = {}
+        """Group platform stops into compound entries per physical station.
+
+        First groups by name, then further splits by proximity so stops in
+        different cities that share a name (e.g. "Hauptbahnhof") are not
+        merged into a single compound ID.
+        """
+        by_name: Dict[str, List[Dict[str, Any]]] = {}
         for s in raw_stops:
-            groups.setdefault(s["name"], []).append(s["gtfsId"])
-        return [{"id": "|".join(ids), "name": name, "place": name, "area_type": "stop"} for name, ids in groups.items()]
+            by_name.setdefault(s["name"], []).append(s)
+
+        result = []
+        for name, stops in by_name.items():
+            for cluster in _cluster_by_proximity(stops):
+                compound_id = "|".join(s["gtfsId"] for s in cluster)
+                result.append({"id": compound_id, "name": name, "place": name, "area_type": "stop"})
+        return result
 
     async def _search_one(self, term: str) -> List[Dict[str, Any]]:
         q = _GRAPHQL_STOP_SEARCH % term.replace('"', '\\"')

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -11,14 +11,11 @@ Handles:
 import asyncio
 import logging
 import time
-from typing import Any, Dict, List, Optional, Union
-from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from ..data_models import UnifiedDeparture
 from .otp_base import OTPBaseProvider
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,6 +66,7 @@ def _detect_city_prefix(search_term: str) -> Optional[str]:
             if remaining:
                 return prefix + remaining
     return None
+
 
 _GRAPHQL_STOPTIMES = """{
   stop(id: "%s") {

--- a/custom_components/openpublictransport/providers/otp_custom.py
+++ b/custom_components/openpublictransport/providers/otp_custom.py
@@ -1,0 +1,22 @@
+"""Generic OTP2 provider for user-hosted instances.
+
+Users supply their own OTP2 base URL (e.g. http://192.168.1.10:8080/otp/routers/default)
+and an optional X-API-Key.  Stop search and departure logic are identical to the
+community server — this is a thin subclass that sets no default URL.
+"""
+
+from .otp import OTPProvider
+
+
+class OTPCustomProvider(OTPProvider):
+    """User-provided OTP2 instance with configurable URL and optional API key."""
+
+    otp_base_url = ""  # always overridden by self.custom_url set via constructor
+
+    @property
+    def provider_id(self) -> str:
+        return "otp_custom"
+
+    @property
+    def provider_name(self) -> str:
+        return "Custom OTP Server"

--- a/custom_components/openpublictransport/providers/vbn.py
+++ b/custom_components/openpublictransport/providers/vbn.py
@@ -28,6 +28,7 @@ class VBNOTPProvider(OTPBaseProvider):
         hass: HomeAssistant,
         api_key: Optional[str] = None,
         api_key_secondary: Optional[str] = None,
+        custom_url: Optional[str] = None,
     ) -> None:
         super().__init__(hass, api_key, api_key_secondary)
 
@@ -60,6 +61,7 @@ class VBNTriasProvider(TRIASBaseProvider):
         hass: HomeAssistant,
         api_key: Optional[str] = None,
         api_key_secondary: Optional[str] = None,
+        custom_url: Optional[str] = None,
     ) -> None:
         super().__init__(hass, api_key, api_key_secondary)
 

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_LINE_FILTER,
     CONF_NTA_API_KEY,
     CONF_NTA_API_KEY_SECONDARY,
+    CONF_OTP_BASE_URL,
     CONF_PROVIDER,
     CONF_SCAN_INTERVAL,
     CONF_STATION_ID,
@@ -36,6 +37,8 @@ from .const import (
     DOMAIN,
     PROVIDER_ENTITY_PICTURES,
     PROVIDER_NTA_IE,
+    PROVIDER_OPT,
+    PROVIDER_OTP_CUSTOM,
     PROVIDER_TRAFIKLAB_SE,
     PROVIDER_VBN_OTP,
     PROVIDER_VBN_TRIAS,
@@ -62,6 +65,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
         scan_interval: int,
         config_entry: Optional[ConfigEntry] = None,
         api_key: Optional[str] = None,
+        custom_url: Optional[str] = None,
     ):
         """Initialize."""
         self.provider = provider
@@ -73,6 +77,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
         self._last_api_reset = datetime.now().date()
         self.api_key = api_key  # For Trafiklab API or NTA API (Primary)
         self.api_key_secondary: Optional[str] = None  # For NTA API (Secondary, optional fallback)
+        self.custom_url = custom_url  # For otp_custom provider
 
         # Note: config_entry parameter was added in HA 2024.11+
         # We store it ourselves for compatibility with older versions
@@ -90,6 +95,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
                 if config_entry and provider == PROVIDER_NTA_IE
                 else None
             ),
+            custom_url=custom_url,
         )
         if not self.provider_instance:
             _LOGGER.error("Failed to initialize provider: %s", provider)
@@ -267,13 +273,23 @@ async def async_setup_entry(
         vbn_api_key = config_entry.data.get(CONF_VBN_API_KEY)
 
         # Use appropriate API key based on provider
+        opt_api_key = config_entry.data.get("opt_api_key")
+        otp_custom_api_key = config_entry.data.get("otp_custom_api_key")
+        otp_custom_url = config_entry.data.get(CONF_OTP_BASE_URL)
+
         api_key = None
+        custom_url = None
         if provider == PROVIDER_TRAFIKLAB_SE:
             api_key = trafiklab_api_key
         elif provider == PROVIDER_NTA_IE:
             api_key = nta_api_key
         elif provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
             api_key = vbn_api_key
+        elif provider == PROVIDER_OPT:
+            api_key = opt_api_key
+        elif provider == PROVIDER_OTP_CUSTOM:
+            api_key = otp_custom_api_key
+            custom_url = otp_custom_url
 
         departures = config_entry.options.get(
             CONF_DEPARTURES, config_entry.data.get(CONF_DEPARTURES, DEFAULT_DEPARTURES)
@@ -292,6 +308,7 @@ async def async_setup_entry(
             scan_interval,
             config_entry=config_entry,
             api_key=api_key,
+            custom_url=custom_url,
         )
         hass.data.setdefault(DOMAIN, {})
         hass.data[DOMAIN][coordinator_key] = coordinator

--- a/custom_components/openpublictransport/strings.json
+++ b/custom_components/openpublictransport/strings.json
@@ -26,6 +26,28 @@
           "stop": "Haltestelle"
         }
       },
+      "opt_key": {
+        "title": "API-Schlüssel (openpublictransport.net)",
+        "description": "Gib deinen kostenlosen API-Schlüssel für den Community-OTP2-Server ein. Schlüssel anfordern auf openpublictransport.net/api-key.",
+        "data": {
+          "opt_api_key": "API-Schlüssel"
+        },
+        "data_description": {
+          "opt_api_key": "Kostenloser API-Schlüssel (erforderlich) — erhältlich auf openpublictransport.net/api-key"
+        }
+      },
+      "otp_custom_url": {
+        "title": "Eigene OTP2-Instanz konfigurieren",
+        "description": "Gib die Basis-URL deines OTP2-Servers ein. Format: http://host:8080/otp/routers/default",
+        "data": {
+          "otp_base_url": "OTP2-Server-URL",
+          "otp_custom_api_key": "API-Schlüssel (optional)"
+        },
+        "data_description": {
+          "otp_base_url": "Basis-URL inkl. Router-Pfad, z.B. http://192.168.1.10:8080/otp/routers/default",
+          "otp_custom_api_key": "Optionaler API-Schlüssel, falls deine Instanz Authentifizierung erfordert"
+        }
+      },
       "api_key": {
         "title": "API-Schlüssel eingeben",
         "description": "{info}",
@@ -100,6 +122,8 @@
       "missing_location": "Bitte geben Sie entweder eine Stations-ID oder Ort und Haltestelle an",
       "empty_search": "Bitte geben Sie einen Suchbegriff ein",
       "no_results": "Keine Ergebnisse gefunden. Bitte versuchen Sie einen anderen Suchbegriff.",
+      "opt_api_key_required": "API-Schlüssel ist erforderlich (kostenlos anfordern auf openpublictransport.net/api-key)",
+      "otp_url_required": "Bitte gib eine gültige URL für deinen OTP2-Server ein",
       "api_key_required": "API-Schlüssel ist erforderlich",
       "trafiklab_api_key_required": "Trafiklab API-Schlüssel ist erforderlich",
       "nta_api_key_required": "NTA API-Schlüssel ist erforderlich",

--- a/custom_components/openpublictransport/translations/de.json
+++ b/custom_components/openpublictransport/translations/de.json
@@ -23,6 +23,28 @@
           "stop": "Haltestelle"
         }
       },
+      "opt_key": {
+        "title": "API-Schlüssel (openpublictransport.net)",
+        "description": "Gib deinen kostenlosen API-Schlüssel für den Community-OTP2-Server ein. Schlüssel anfordern auf openpublictransport.net/api-key.",
+        "data": {
+          "opt_api_key": "API-Schlüssel"
+        },
+        "data_description": {
+          "opt_api_key": "Kostenloser API-Schlüssel (erforderlich) — erhältlich auf openpublictransport.net/api-key"
+        }
+      },
+      "otp_custom_url": {
+        "title": "Eigene OTP2-Instanz konfigurieren",
+        "description": "Gib die Basis-URL deines OTP2-Servers ein. Format: http://host:8080/otp/routers/default",
+        "data": {
+          "otp_base_url": "OTP2-Server-URL",
+          "otp_custom_api_key": "API-Schlüssel (optional)"
+        },
+        "data_description": {
+          "otp_base_url": "Basis-URL inkl. Router-Pfad, z.B. http://192.168.1.10:8080/otp/routers/default",
+          "otp_custom_api_key": "Optionaler API-Schlüssel, falls deine Instanz Authentifizierung erfordert"
+        }
+      },
       "api_key": {
         "title": "API-Schlüssel eingeben",
         "description": "{info}",
@@ -96,6 +118,8 @@
       }
     },
     "error": {
+      "opt_api_key_required": "API-Schlüssel ist erforderlich (kostenlos anfordern auf openpublictransport.net/api-key)",
+      "otp_url_required": "Bitte gib eine gültige URL für deinen OTP2-Server ein",
       "missing_location": "Bitte geben Sie entweder eine Stations-ID oder Ort und Haltestelle an",
       "empty_search": "Bitte geben Sie einen Suchbegriff ein",
       "no_results": "Keine Ergebnisse gefunden. Bitte versuchen Sie einen anderen Suchbegriff.",

--- a/custom_components/openpublictransport/translations/en.json
+++ b/custom_components/openpublictransport/translations/en.json
@@ -23,6 +23,28 @@
           "stop": "Stop"
         }
       },
+      "opt_key": {
+        "title": "API Key (openpublictransport.net)",
+        "description": "Enter your free API key for the community OTP2 server. Request one at openpublictransport.net/api-key.",
+        "data": {
+          "opt_api_key": "API Key"
+        },
+        "data_description": {
+          "opt_api_key": "Free API key (required) — request at openpublictransport.net/api-key"
+        }
+      },
+      "otp_custom_url": {
+        "title": "Configure Custom OTP2 Instance",
+        "description": "Enter the base URL of your OTP2 server. Format: http://host:8080/otp/routers/default",
+        "data": {
+          "otp_base_url": "OTP2 Server URL",
+          "otp_custom_api_key": "API Key (optional)"
+        },
+        "data_description": {
+          "otp_base_url": "Base URL including router path, e.g. http://192.168.1.10:8080/otp/routers/default",
+          "otp_custom_api_key": "Optional API key if your instance requires authentication"
+        }
+      },
       "api_key": {
         "title": "Enter API Key",
         "description": "{info}",
@@ -99,6 +121,8 @@
       "missing_location": "Please provide either a station ID or location and stop name",
       "empty_search": "Please enter a search term",
       "no_results": "No results found. Please try a different search term.",
+      "opt_api_key_required": "API key is required (request a free key at openpublictransport.net/api-key)",
+      "otp_url_required": "Please enter a valid URL for your OTP2 server",
       "api_key_required": "API key is required",
       "trafiklab_api_key_required": "Trafiklab API key is required",
       "nta_api_key_required": "NTA API key is required",

--- a/custom_components/openpublictransport/translations/fr.json
+++ b/custom_components/openpublictransport/translations/fr.json
@@ -26,6 +26,28 @@
           "stop": "Arrêt"
         }
       },
+      "opt_key": {
+        "title": "API Key (openpublictransport.net)",
+        "description": "Enter your free API key for the community OTP2 server. Request one at openpublictransport.net/api-key.",
+        "data": {
+          "opt_api_key": "API Key"
+        },
+        "data_description": {
+          "opt_api_key": "Free API key (required) — request at openpublictransport.net/api-key"
+        }
+      },
+      "otp_custom_url": {
+        "title": "Configure Custom OTP2 Instance",
+        "description": "Enter the base URL of your OTP2 server. Format: http://host:8080/otp/routers/default",
+        "data": {
+          "otp_base_url": "OTP2 Server URL",
+          "otp_custom_api_key": "API Key (optional)"
+        },
+        "data_description": {
+          "otp_base_url": "Base URL including router path, e.g. http://192.168.1.10:8080/otp/routers/default",
+          "otp_custom_api_key": "Optional API key if your instance requires authentication"
+        }
+      },
       "api_key": {
         "title": "Saisir la clé API",
         "description": "{info}",
@@ -97,6 +119,8 @@
       }
     },
     "error": {
+      "opt_api_key_required": "API key is required (request a free key at openpublictransport.net/api-key)",
+      "otp_url_required": "Please enter a valid URL for your OTP2 server",
       "missing_location": "Veuillez fournir un identifiant de gare ou un emplacement et un nom d'arrêt",
       "empty_search": "Veuillez saisir un terme de recherche",
       "no_results": "Aucun résultat trouvé. Veuillez essayer un autre terme de recherche.",

--- a/custom_components/openpublictransport/translations/it.json
+++ b/custom_components/openpublictransport/translations/it.json
@@ -26,6 +26,28 @@
           "stop": "Fermata"
         }
       },
+      "opt_key": {
+        "title": "API Key (openpublictransport.net)",
+        "description": "Enter your free API key for the community OTP2 server. Request one at openpublictransport.net/api-key.",
+        "data": {
+          "opt_api_key": "API Key"
+        },
+        "data_description": {
+          "opt_api_key": "Free API key (required) — request at openpublictransport.net/api-key"
+        }
+      },
+      "otp_custom_url": {
+        "title": "Configure Custom OTP2 Instance",
+        "description": "Enter the base URL of your OTP2 server. Format: http://host:8080/otp/routers/default",
+        "data": {
+          "otp_base_url": "OTP2 Server URL",
+          "otp_custom_api_key": "API Key (optional)"
+        },
+        "data_description": {
+          "otp_base_url": "Base URL including router path, e.g. http://192.168.1.10:8080/otp/routers/default",
+          "otp_custom_api_key": "Optional API key if your instance requires authentication"
+        }
+      },
       "api_key": {
         "title": "Inserisci API Key",
         "description": "{info}",
@@ -97,6 +119,8 @@
       }
     },
     "error": {
+      "opt_api_key_required": "API key is required (request a free key at openpublictransport.net/api-key)",
+      "otp_url_required": "Please enter a valid URL for your OTP2 server",
       "missing_location": "Fornisci un ID stazione oppure una posizione e un nome di fermata",
       "empty_search": "Inserisci un termine di ricerca",
       "no_results": "Nessun risultato trovato. Prova con un altro termine di ricerca.",

--- a/custom_components/openpublictransport/translations/nl.json
+++ b/custom_components/openpublictransport/translations/nl.json
@@ -26,6 +26,28 @@
           "stop": "Halte"
         }
       },
+      "opt_key": {
+        "title": "API Key (openpublictransport.net)",
+        "description": "Enter your free API key for the community OTP2 server. Request one at openpublictransport.net/api-key.",
+        "data": {
+          "opt_api_key": "API Key"
+        },
+        "data_description": {
+          "opt_api_key": "Free API key (required) — request at openpublictransport.net/api-key"
+        }
+      },
+      "otp_custom_url": {
+        "title": "Configure Custom OTP2 Instance",
+        "description": "Enter the base URL of your OTP2 server. Format: http://host:8080/otp/routers/default",
+        "data": {
+          "otp_base_url": "OTP2 Server URL",
+          "otp_custom_api_key": "API Key (optional)"
+        },
+        "data_description": {
+          "otp_base_url": "Base URL including router path, e.g. http://192.168.1.10:8080/otp/routers/default",
+          "otp_custom_api_key": "Optional API key if your instance requires authentication"
+        }
+      },
       "api_key": {
         "title": "API Key invoeren",
         "description": "{info}",
@@ -97,6 +119,8 @@
       }
     },
     "error": {
+      "opt_api_key_required": "API key is required (request a free key at openpublictransport.net/api-key)",
+      "otp_url_required": "Please enter a valid URL for your OTP2 server",
       "missing_location": "Geef een station-ID of locatie en haltenaam op",
       "empty_search": "Voer een zoekterm in",
       "no_results": "Geen resultaten gevonden. Probeer een andere zoekterm.",

--- a/custom_components/openpublictransport/translations/pl.json
+++ b/custom_components/openpublictransport/translations/pl.json
@@ -26,6 +26,28 @@
           "stop": "Przystanek"
         }
       },
+      "opt_key": {
+        "title": "API Key (openpublictransport.net)",
+        "description": "Enter your free API key for the community OTP2 server. Request one at openpublictransport.net/api-key.",
+        "data": {
+          "opt_api_key": "API Key"
+        },
+        "data_description": {
+          "opt_api_key": "Free API key (required) — request at openpublictransport.net/api-key"
+        }
+      },
+      "otp_custom_url": {
+        "title": "Configure Custom OTP2 Instance",
+        "description": "Enter the base URL of your OTP2 server. Format: http://host:8080/otp/routers/default",
+        "data": {
+          "otp_base_url": "OTP2 Server URL",
+          "otp_custom_api_key": "API Key (optional)"
+        },
+        "data_description": {
+          "otp_base_url": "Base URL including router path, e.g. http://192.168.1.10:8080/otp/routers/default",
+          "otp_custom_api_key": "Optional API key if your instance requires authentication"
+        }
+      },
       "api_key": {
         "title": "Wprowadź klucz API",
         "description": "{info}",
@@ -97,6 +119,8 @@
       }
     },
     "error": {
+      "opt_api_key_required": "API key is required (request a free key at openpublictransport.net/api-key)",
+      "otp_url_required": "Please enter a valid URL for your OTP2 server",
       "missing_location": "Podaj identyfikator stacji lub lokalizację i nazwę przystanku",
       "empty_search": "Wprowadź frazę wyszukiwania",
       "no_results": "Nie znaleziono wyników. Spróbuj innej frazy wyszukiwania.",

--- a/custom_components/openpublictransport/translations/sv.json
+++ b/custom_components/openpublictransport/translations/sv.json
@@ -26,6 +26,28 @@
           "stop": "Hållplats"
         }
       },
+      "opt_key": {
+        "title": "API Key (openpublictransport.net)",
+        "description": "Enter your free API key for the community OTP2 server. Request one at openpublictransport.net/api-key.",
+        "data": {
+          "opt_api_key": "API Key"
+        },
+        "data_description": {
+          "opt_api_key": "Free API key (required) — request at openpublictransport.net/api-key"
+        }
+      },
+      "otp_custom_url": {
+        "title": "Configure Custom OTP2 Instance",
+        "description": "Enter the base URL of your OTP2 server. Format: http://host:8080/otp/routers/default",
+        "data": {
+          "otp_base_url": "OTP2 Server URL",
+          "otp_custom_api_key": "API Key (optional)"
+        },
+        "data_description": {
+          "otp_base_url": "Base URL including router path, e.g. http://192.168.1.10:8080/otp/routers/default",
+          "otp_custom_api_key": "Optional API key if your instance requires authentication"
+        }
+      },
       "api_key": {
         "title": "Ange API-nyckel",
         "description": "{info}",
@@ -97,6 +119,8 @@
       }
     },
     "error": {
+      "opt_api_key_required": "API key is required (request a free key at openpublictransport.net/api-key)",
+      "otp_url_required": "Please enter a valid URL for your OTP2 server",
       "missing_location": "Ange antingen ett stations-ID eller en plats och hållplatsnamn",
       "empty_search": "Ange en sökterm",
       "no_results": "Inga resultat hittades. Försök med en annan sökterm.",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v2026.5.3-beta.4 — Bugfixes: API Key 401, Stop Search
+
+### Bugfixes
+
+- **HTTP 401 on sensor polling** — `__init__.py` did not read `opt_api_key` / `otp_custom_api_key` from the config entry. The coordinator was created without credentials, causing every poll to return 401. Fixed for both `openpublictransport` and `otp_custom`.
+- **Stop search: "Düsseldorf Elbruchstraße" found nothing** — Inputs like `Düsseldorf Elbruchstraße` or `Elbruchstraße, Düsseldorf` failed because Phase 2 was searching `D-Düsseldorf Elbruchstraße` instead of `D-Elbruchstraße`. New Phase 1b detects city names in the search term and builds the correct prefix. All formats now work: bare stop name, `City Stopname`, `Stopname, City`.
+- **Config flow: `custom_url` missing for OTP Custom stop search** — `get_provider()` in `_search_stops()` was not passing `custom_url`, which would have broken stop search for custom OTP instances during setup.
+
+---
+
+## v2026.5.3-beta.3 — openpublictransport Community OTP2 + Custom OTP2 Instance
+
+### New Features
+
+- **openpublictransport provider** — Germany-wide real-time departures via community-hosted OTP2 server at `api.openpublictransport.net`. Data: gtfs.de CC 4.0 (daily update, 461 agencies, 437k stops) + GTFS-RT realtime (25+ Verbünde, every 30s). Requires a free API key — [request here](https://openpublictransport.net/api-key).
+- **OTP2 Custom provider** — Connect any self-hosted OpenTripPlanner 2 instance. Provide a base URL and optional X-API-Key. Useful for self-hosting the community server image or running a private GTFS feed.
+- **OTPProvider base class** — New `otp.py` with shared OTP2 GraphQL logic: 3-phase stop search (bare name → city-word detection → parallel prefix search → Nominatim fallback), multi-platform stop merging (compound pipe-separated IDs), parallel platform fetch, deduplication.
+
+### Technical Details
+
+- VRR/NRW city-prefix search: gtfs.de stores NRW stops as `D-Elbruchstraße`, `K-Hauptbahnhof`, etc. The integration tries all known city prefixes in parallel when a bare search finds nothing.
+- Compound stop IDs: GTFS platform stops are grouped by name (`gtfsde:537545|gtfsde:568685`). All platforms are fetched in parallel and merged per sensor.
+- Total providers: **26 → 28**
+
+---
+
 ## v2026.5.3 - VBN OTP Trip Planner
 
 ### New Features

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -4,20 +4,22 @@ The Public Transport Integration supports multiple transit providers across Euro
 
 ## Provider Comparison
 
-| Feature | VRR | KVV | HVV | MVV | VVS | VGN | VAG Freiburg | BVG | RMV | VBN OTP | VBN TRIAS | VRN | VVO | DING | AVV | RVV | BSVG | NWL | NVBW | BEG | SBB | ÖBB | Trafiklab | NTA | Transitous |
-|---------|-----|-----|-----|-----|-----|-----|--------------|-----|-----|---------|-----------|-----|-----|------|-----|-----|------|-----|------|-----|-----|-----|-----------|-----|-----------|
-| **Region** | NRW | Karlsruhe | Hamburg | Munich | Stuttgart | Nuremberg | Freiburg | Berlin | Frankfurt | Bremen/Niedersachsen | Bremen/Niedersachsen | Rhein-Neckar | Dresden | Ulm | Augsburg | Regensburg | Braunschweig | Westfalen-Lippe | Baden-Württemberg | Bayern | Switzerland | Austria | Sweden | Ireland | Worldwide |
-| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | OTP REST | TRIAS XML | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | FPTF REST | REST | GTFS-RT | MOTIS2 |
-| **API Key** | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | Yes (free) | No | No | No | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No |
-| **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
-| **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available |
-| **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available |
-| **Agency/Operator** | No | No | No | No | No | No | No | Yes | Yes | Yes | No | No | No | No | No | No | No | No | No | No | No | Yes | Yes | No | When available |
-| **Alerts/Notices** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | No | Yes | When available |
-| **Trip Planner** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | No | No | No | No | No | No | No | No | No | No | No | No | No | No | No |
-| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Geocoded¹ | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete |
+| Feature | VRR | KVV | HVV | MVV | VVS | VGN | VAG Freiburg | BVG | RMV | VBN OTP | VBN TRIAS | VRN | VVO | DING | AVV | RVV | BSVG | NWL | NVBW | BEG | SBB | ÖBB | Trafiklab | NTA | Transitous | openpublictransport | OTP2 Custom |
+|---------|-----|-----|-----|-----|-----|-----|--------------|-----|-----|---------|-----------|-----|-----|------|-----|-----|------|-----|------|-----|-----|-----|-----------|-----|-----------|---------------------|-------------|
+| **Region** | NRW | Karlsruhe | Hamburg | Munich | Stuttgart | Nuremberg | Freiburg | Berlin | Frankfurt | Bremen/Niedersachsen | Bremen/Niedersachsen | Rhein-Neckar | Dresden | Ulm | Augsburg | Regensburg | Braunschweig | Westfalen-Lippe | Baden-Württemberg | Bayern | Switzerland | Austria | Sweden | Ireland | Worldwide | Germany (all) | Any OTP2 |
+| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | OTP REST | TRIAS XML | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | FPTF REST | REST | GTFS-RT | MOTIS2 | OTP2 GraphQL | OTP2 GraphQL |
+| **API Key** | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | Yes (free) | No | No | No | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No | Yes (free²) | Optional |
+| **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available | Yes (GTFS-RT) | Depends on server |
+| **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available | Yes | Depends on server |
+| **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available | No | No |
+| **Agency/Operator** | No | No | No | No | No | No | No | Yes | Yes | Yes | No | No | No | No | No | No | No | No | No | No | No | Yes | Yes | No | When available | No | No |
+| **Alerts/Notices** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | No | Yes | When available | No | No |
+| **Trip Planner** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | No | No | No | No | No | No | No | No | No | No | No | No | No | No | No | No | No |
+| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Geocoded¹ | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete | GraphQL + prefix | GraphQL + prefix |
 
 ¹ VBN OTP has no native name-based stop search. The integration geocodes your search term via Nominatim (OpenStreetMap) and finds stops within 500 m of the resolved coordinates.
+
+² API key for the community server is free — [request it here](https://openpublictransport.net/api-key).
 
 ## Timezone Handling
 
@@ -50,6 +52,8 @@ Each provider uses its local timezone for departure times:
 | Trafiklab | Europe/Stockholm |
 | NTA | Europe/Dublin |
 | Transitous | Per-stop (automatic) |
+| openpublictransport | Europe/Berlin |
+| OTP2 Custom | Europe/Berlin (or per OTP2 config) |
 
 ## Transport Type Mapping
 

--- a/docs/providers/openpublictransport.md
+++ b/docs/providers/openpublictransport.md
@@ -1,0 +1,119 @@
+# openpublictransport (Deutschland, Community Server)
+
+!!! info "Community Server"
+    This provider uses a community-hosted OTP2 server at **api.openpublictransport.net**, backed by [gtfs.de](https://gtfs.de) data (CC 4.0, Germany-wide). An API key is required — [request one here](https://openpublictransport.net/api-key).
+
+The `openpublictransport` provider gives you Germany-wide real-time departures for all transit modes — S-Bahn, U-Bahn, Bus, Tram, Regional, IC/ICE — from a single unified endpoint. Data is updated daily from gtfs.de and enriched with GTFS-RT realtime delays every 30 seconds from 25+ Verbünde.
+
+## Coverage Area
+
+- All of Germany (461 agencies, 437 000+ stops)
+- Data source: [gtfs.de](https://gtfs.de) Germany Full feed (CC 4.0)
+- Realtime: [realtime.gtfs.de](https://gtfs.de/de/realtime/) GTFS-RT (VRR, BSVG, NWL, MVV, S-Bahn Berlin, and more)
+
+## API Details
+
+| Property | Value |
+|----------|-------|
+| **Server** | `https://api.openpublictransport.net/otp/routers/default` |
+| **API Type** | OTP2 GraphQL |
+| **API Key** | Yes — [request free key](https://openpublictransport.net/api-key) |
+| **Timezone** | Europe/Berlin |
+| **Data Source** | gtfs.de CC 4.0 + GTFS-RT |
+
+## Transport Types
+
+| OTP2 Mode | Type | Description |
+|-----------|------|-------------|
+| RAIL | train | Regional and long-distance trains (RE, RB, IC, ICE) |
+| SUBWAY | subway | U-Bahn |
+| TRAM | tram | Tram / Straßenbahn |
+| BUS | bus | All bus services |
+| FERRY | ferry | Ferry |
+| COACH | bus | Coach / express bus |
+
+## Configuration
+
+### Getting an API Key
+
+1. Go to [openpublictransport.net/api-key](https://openpublictransport.net/api-key)
+2. Enter your name, email, and a brief description of your use case
+3. You will receive a key by email within a few hours
+
+### Setup Steps
+
+1. In Home Assistant, go to **Settings → Integrations → Add Integration**
+2. Search for *Public Transport Departures*
+3. Select **Entry Type**: Abfahrtsanzeige / Departure Monitor
+4. Select **Provider**: `Deutschland — Community Server (api.openpublictransport.net, API Key)`
+5. Enter your API key
+6. Search for your stop (see stop search tips below)
+7. Configure departure count, transport types, and scan interval
+
+### Stop Search Tips
+
+The gtfs.de feed stores VRR/NRW stops with a city prefix. The integration handles this automatically — just search naturally:
+
+| What you type | What it searches |
+|---------------|-----------------|
+| `Elbruchstraße` | Tries `Elbruchstraße`, then all city prefixes in parallel → finds `D-Elbruchstraße` |
+| `Düsseldorf Elbruchstraße` | Detects city → searches `D-Elbruchstraße` directly |
+| `Elbruchstraße, Düsseldorf` | Detects city → searches `D-Elbruchstraße` directly |
+| `Hauptbahnhof` | Found directly (no prefix needed) |
+| `Hamburg Hbf` | Detects no prefix needed, found directly |
+
+!!! tip
+    For NRW stops (VRR area), entering the city name together with the stop name (e.g. `Düsseldorf Hauptbahnhof`) gives the fastest result.
+
+## Multi-Platform Stop Merging
+
+GTFS stores one entry per platform/direction. The integration automatically groups stops by name and creates compound IDs (`gtfsde:537545|gtfsde:568685`). When fetching departures, all platforms are queried in parallel and merged — the sensor shows a complete view of the station.
+
+## Self-Hosting
+
+You can run your own OTP2 instance with gtfs.de data using the Docker image:
+
+```bash
+docker pull ghcr.io/nerdysoftpaw/otp-gtfsde:latest
+```
+
+See [github.com/NerdySoftPaw/otp-gtfsde](https://github.com/NerdySoftPaw/otp-gtfsde) for the full setup guide. Once running, use the **OTP2 Custom** provider instead and point it at your server.
+
+## Realtime Data
+
+The community server polls `realtime.gtfs.de` every 30 seconds. Coverage varies by Verbund:
+
+| Verbund | Realtime |
+|---------|----------|
+| VRR (NRW) | Yes |
+| BSVG (Braunschweig) | Yes |
+| NWL (Westfalen-Lippe) | Yes |
+| MVV (München) | Yes |
+| S-Bahn Berlin | Yes |
+| And more... | See [gtfs.de/de/realtime](https://gtfs.de/de/realtime/) |
+
+!!! note
+    Realtime coverage depends on the GTFS-RT feed from each Verbund. If your stop shows no delays, the Verbund may not provide a realtime feed. Scheduled times are always available.
+
+## Troubleshooting
+
+### HTTP 401
+
+Your API key is invalid or not passed. Make sure you:
+
+1. Entered the key in the integration setup step (not left blank)
+2. Deleted and re-added the integration if you previously added it without a key
+
+### No Stops Found
+
+- Try entering the city name together with the stop: `Köln Hbf` instead of `Hbf`
+- Some very small stops may not be in the GTFS feed
+- Check [openpublictransport.net](https://openpublictransport.net) for server status
+
+### No Departures
+
+The stop exists but shows no departures:
+
+- The stop may be a platform-only ID — try searching again to pick the compound stop
+- Check if the stop has service at the current time
+- Night / low-frequency service may not appear within the default time window

--- a/docs/providers/otp-custom.md
+++ b/docs/providers/otp-custom.md
@@ -1,0 +1,114 @@
+# OTP2 Custom Instance
+
+The `otp_custom` provider lets you connect any self-hosted [OpenTripPlanner 2](https://www.opentripplanner.org/) server to Home Assistant. This is useful if you run your own OTP2 instance — for example a local gtfs.de deployment, a private GTFS feed, or the community server image on your own hardware.
+
+## When to Use This
+
+| Scenario | Provider to Use |
+|----------|----------------|
+| You want Germany-wide data, no hassle | [openpublictransport](openpublictransport.md) (community server) |
+| You run your own OTP2 with gtfs.de data | **otp_custom** → point at your server |
+| You have a private/local GTFS feed in OTP2 | **otp_custom** |
+| You self-host the community server image | **otp_custom** |
+
+## API Details
+
+| Property | Value |
+|----------|-------|
+| **Server** | Your own URL |
+| **API Type** | OTP2 GraphQL |
+| **API Key** | Optional (X-API-Key header) |
+| **Timezone** | Europe/Berlin (configurable via OTP2) |
+
+## Configuration
+
+### Setup Steps
+
+1. In Home Assistant, go to **Settings → Integrations → Add Integration**
+2. Search for *Public Transport Departures*
+3. Select **Entry Type**: Abfahrtsanzeige / Departure Monitor
+4. Select **Provider**: `OTP2 — Eigene Instanz (URL + optionaler API Key)`
+5. Enter your **OTP2 Base URL** — include the router path:
+   ```
+   http://192.168.1.10:8080/otp/routers/default
+   ```
+6. Enter an **API Key** if your server requires one (leave blank otherwise)
+7. Search for your stop and finish configuration
+
+### URL Format
+
+The base URL must point to the OTP2 router, not just the server root:
+
+| Setup | Correct URL |
+|-------|-------------|
+| Local OTP2 (default port) | `http://192.168.1.10:8080/otp/routers/default` |
+| Reverse proxy without path | `https://otp.yourdomain.com/otp/routers/default` |
+| Reverse proxy with subpath | `https://yourdomain.com/otp/otp/routers/default` |
+| Community server image (self-hosted) | `https://your-vps.example.com/otp/routers/default` |
+
+The integration appends `/index/graphql` to this URL for all requests.
+
+## Self-Hosting with gtfs.de
+
+The easiest way to run your own server is the community Docker image:
+
+```bash
+# Clone the repo
+git clone https://github.com/NerdySoftPaw/otp-gtfsde
+cd otp-gtfsde
+
+# Start (downloads GTFS, builds graph, starts OTP2)
+docker compose up -d
+```
+
+The graph build takes 15–30 minutes on first start. After that, the server is available at `http://localhost:8080` and the GTFS data is refreshed daily.
+
+**Minimum requirements:**
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| RAM | 6 GB | 8 GB |
+| CPU | 2 cores | 4 cores |
+| Storage | 15 GB | 20 GB |
+
+See the [otp-gtfsde repository](https://github.com/NerdySoftPaw/otp-gtfsde) for full configuration, nginx reverse proxy setup, and API key authentication.
+
+## Transport Types
+
+Same as the community server — all OTP2 GTFS modes are supported:
+
+| OTP2 Mode | Type |
+|-----------|------|
+| RAIL | train |
+| SUBWAY | subway |
+| TRAM | tram |
+| BUS | bus |
+| FERRY | ferry |
+| COACH | bus |
+
+## Features
+
+- **Full city-prefix search** — same VRR/NRW prefix logic as the community server
+- **Multi-platform merging** — stops grouped by name, platforms fetched in parallel
+- **Optional API key** — `X-API-Key` header sent when configured
+- **GTFS-RT** — realtime delays if your OTP2 instance is configured with a GTFS-RT updater
+
+## Troubleshooting
+
+### Connection Refused / Timeout
+
+- Check that OTP2 is running: `curl http://localhost:8080/otp/routers/default/index/graphql -X POST -H "Content-Type: application/json" -d '{"query":"{ stops(name: \"Hbf\") { gtfsId name } }"}'`
+- Verify the port is correct and not blocked by a firewall
+- If using a reverse proxy, check the nginx/Caddy configuration
+
+### GraphQL Errors
+
+- Verify your OTP2 version supports the GraphQL endpoint (OTP2 2.x required)
+- The legacy REST API (`/otp/routers/default/index/stops`) is not used — only GraphQL
+- Check OTP2 logs for query errors
+
+### No Stops Found
+
+- Confirm the graph was built with your GTFS feed
+- Test the GraphQL endpoint directly with a known stop name
+- Graph build may still be in progress (check OTP2 logs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: openpublictransport
-site_description: Multi-Provider Public Transport Home Assistant Integration for 23 transit networks across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide
+site_description: Multi-Provider Public Transport Home Assistant Integration for 28 transit networks across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide
 site_url: https://docs.openpublictransport.net
 repo_url: https://github.com/NerdySoftPaw/openpublictransport
 repo_name: NerdySoftPaw/openpublictransport
@@ -80,6 +80,8 @@ nav:
       - Trafiklab (Sweden): providers/trafiklab.md
       - NTA (Ireland): providers/nta.md
       - Transitous (Worldwide): providers/transitous.md
+      - openpublictransport (Deutschland): providers/openpublictransport.md
+      - OTP2 Custom Instance: providers/otp-custom.md
   - Sensors & Attributes: sensors.md
   - Services: services.md
   - Trip Planner: trip-planner.md


### PR DESCRIPTION
## Summary

Adds two new providers built on a shared generic OTP2 base, bringing the total to **28 providers**.

### New: openpublictransport (Community Server)
Germany-wide real-time departures via `api.openpublictransport.net`:
- Data: [gtfs.de](https://gtfs.de) CC 4.0 (daily update, 461 agencies, 437k stops)
- Realtime: GTFS-RT from realtime.gtfs.de (25+ Verbünde, every 30s)
- Free API key required → [openpublictransport.net/api-key](https://openpublictransport.net/api-key)

### New: OTP2 Custom Instance
Connect any self-hosted OpenTripPlanner 2 server with a configurable base URL and optional X-API-Key.

### Architecture
- `providers/otp.py` — `OTPProvider` generic OTP2 GraphQL base:
  - 3-phase stop search: bare name → city-word detection (`Düsseldorf Elbruchstraße` → `D-Elbruchstraße`) → parallel VRR/NRW prefix search → Nominatim fallback
  - Multi-platform stop merging: GTFS platform IDs grouped by name into compound pipe-separated IDs
  - Parallel platform fetch + deduplication per sensor
  - `X-API-Key` header support
- `providers/gtfsde.py` — `OPTProvider(OTPProvider)` with community server URL
- `providers/otp_custom.py` — `OTPCustomProvider(OTPProvider)` with no default URL
- `__init__.py`, `sensor.py`, `base.py` — `custom_url` parameter wired through the full stack

### Bugfixes
- `__init__.py` was not reading `opt_api_key`/`otp_custom_api_key` → 401 on every poll
- Config flow `_search_stops()` was not passing `custom_url` for OTP_CUSTOM
- City-word search (`Düsseldorf Elbruchstraße`) now correctly builds `D-Elbruchstraße` (Phase 1b)

### Docs
- `docs/providers/openpublictransport.md` — full provider page
- `docs/providers/otp-custom.md` — self-hosting guide
- Provider comparison table expanded to 28 columns
- Changelog entries for beta.3 and beta.4

## Test plan

- [ ] `openpublictransport` provider — stop search finds `Elbruchstraße` via bare name / `Düsseldorf Elbruchstraße` / `Elbruchstraße, Düsseldorf`
- [ ] Sensor shows departures with correct realtime delay after entering API key
- [ ] No HTTP 401 in logs after setup (API key passed correctly to coordinator)
- [ ] `otp_custom` provider — stop search works with custom URL
- [ ] OTP_CUSTOM stops found during config flow when custom_url is set
- [ ] Multi-platform stop: compound ID fetches all platforms, deduplicates, sorts by departure
- [ ] Provider count 28 in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)