### PR TITLE
feat: OTP2 agency, alerts, trip planner + EFA trip endpoint fixes

### DIFF
--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -213,16 +213,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         destination = call.data["destination"]
         destination_city = call.data["destination_city"]
 
-        # For API-key providers, look up the key from an existing config entry
+        # Look up credentials from an existing config entry for this provider
         api_key = None
-        if provider == PROVIDER_VBN_OTP:
-            for existing in hass.config_entries.async_entries(DOMAIN):
-                if existing.data.get(CONF_PROVIDER) == PROVIDER_VBN_OTP:
+        custom_url = None
+        for existing in hass.config_entries.async_entries(DOMAIN):
+            if existing.data.get(CONF_PROVIDER) == provider:
+                if provider == PROVIDER_VBN_OTP:
                     api_key = existing.data.get(CONF_VBN_API_KEY)
-                    break
+                elif provider == PROVIDER_OPT:
+                    api_key = existing.data.get(CONF_OPT_API_KEY)
+                elif provider == PROVIDER_OTP_CUSTOM:
+                    api_key = existing.data.get(CONF_OTP_CUSTOM_API_KEY)
+                    custom_url = existing.data.get(CONF_OTP_BASE_URL)
+                break
 
         journeys = await async_plan_trip(
-            hass, provider, origin, origin_city, destination, destination_city, api_key=api_key
+            hass,
+            provider,
+            origin,
+            origin_city,
+            destination,
+            destination_city,
+            api_key=api_key,
+            custom_url=custom_url,
         )
 
         return {"journeys": journeys or []}

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.3b4"
+  "version": "2026.5.4"
 }

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -124,6 +124,9 @@ _GRAPHQL_STOPTIMES = """{
         route {
           shortName
           mode
+          agency {
+            name
+          }
         }
       }
     }
@@ -241,7 +244,7 @@ class OTPProvider(OTPBaseProvider):
                 "transportType": mode_mapping.get(
                     ((st.get("trip") or {}).get("route") or {}).get("mode", ""), "unknown"
                 ),
-                "agency": "",
+                "agency": (((st.get("trip") or {}).get("route") or {}).get("agency") or {}).get("name", ""),
                 "notices": None,
                 "serviceDay": st.get("serviceDay", 0),
                 "scheduledDeparture": st.get("scheduledDeparture", 0),

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -113,6 +113,10 @@ def _cluster_by_proximity(stops: List[Dict[str, Any]]) -> List[List[Dict[str, An
 _GRAPHQL_STOPTIMES = """{
   stop(id: "%s") {
     name
+    alerts {
+      alertHeaderText
+      alertDescriptionText
+    }
     stoptimesWithoutPatterns(numberOfDepartures: %d, startTime: %d) {
       serviceDay
       scheduledDeparture
@@ -121,11 +125,19 @@ _GRAPHQL_STOPTIMES = """{
       realtime
       headsign
       trip {
+        alerts {
+          alertHeaderText
+          alertDescriptionText
+        }
         route {
           shortName
           mode
           agency {
             name
+          }
+          alerts {
+            alertHeaderText
+            alertDescriptionText
           }
         }
       }
@@ -236,33 +248,56 @@ class OTPProvider(OTPBaseProvider):
         # Phase 3: Nominatim + OTP radius search
         return await super().search_stops(search_term)
 
+    @staticmethod
+    def _alert_texts(alerts: Optional[List[Dict[str, Any]]]) -> List[str]:
+        seen: set = set()
+        result = []
+        for a in alerts or []:
+            text = (a.get("alertHeaderText") or a.get("alertDescriptionText") or "").strip()
+            if text and text not in seen:
+                seen.add(text)
+                result.append(text)
+        return result
+
     def _stoptimes_to_events(self, stoptimes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         mode_mapping = self.get_mode_mapping()
-        return [
-            {
-                "routeName": ((st.get("trip") or {}).get("route") or {}).get("shortName", ""),
-                "transportType": mode_mapping.get(
-                    ((st.get("trip") or {}).get("route") or {}).get("mode", ""), "unknown"
-                ),
-                "agency": (((st.get("trip") or {}).get("route") or {}).get("agency") or {}).get("name", ""),
-                "notices": None,
-                "serviceDay": st.get("serviceDay", 0),
-                "scheduledDeparture": st.get("scheduledDeparture", 0),
-                "realtimeDeparture": st.get("realtimeDeparture", 0),
-                "departureDelay": st.get("departureDelay", 0),
-                "realtime": st.get("realtime", False),
-                "headsign": st.get("headsign", ""),
-            }
-            for st in stoptimes
-        ]
+        events = []
+        for st in stoptimes:
+            trip = st.get("trip") or {}
+            route = trip.get("route") or {}
+            trip_notices = self._alert_texts(trip.get("alerts"))
+            route_notices = [t for t in self._alert_texts(route.get("alerts")) if t not in trip_notices]
+            notices = trip_notices + route_notices
+            events.append(
+                {
+                    "routeName": route.get("shortName", ""),
+                    "transportType": mode_mapping.get(route.get("mode", ""), "unknown"),
+                    "agency": (route.get("agency") or {}).get("name", ""),
+                    "notices": notices or None,
+                    "serviceDay": st.get("serviceDay", 0),
+                    "scheduledDeparture": st.get("scheduledDeparture", 0),
+                    "realtimeDeparture": st.get("realtimeDeparture", 0),
+                    "departureDelay": st.get("departureDelay", 0),
+                    "realtime": st.get("realtime", False),
+                    "headsign": st.get("headsign", ""),
+                }
+            )
+        return events
 
     async def _fetch_one_stop(self, gtfs_id: str, limit: int, start_epoch: int) -> List[Dict[str, Any]]:
         q = _GRAPHQL_STOPTIMES % (gtfs_id.replace('"', '\\"'), limit, start_epoch)
         body = await self._graphql(q)
         if body is None:
             return []
-        stoptimes = (((body.get("data") or {}).get("stop")) or {}).get("stoptimesWithoutPatterns") or []
-        return self._stoptimes_to_events(stoptimes)
+        stop_data = ((body.get("data") or {}).get("stop")) or {}
+        stoptimes = stop_data.get("stoptimesWithoutPatterns") or []
+        events = self._stoptimes_to_events(stoptimes)
+        stop_notices = self._alert_texts(stop_data.get("alerts"))
+        if stop_notices:
+            for ev in events:
+                existing = ev.get("notices") or []
+                ev["notices"] = stop_notices + [n for n in existing if n not in stop_notices]
+        return events
 
     async def fetch_departures(
         self,

--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -29,7 +29,7 @@ EFA_TRIP_ENDPOINTS = {
     "vrn": "https://www.vrn.de/mngvrn/XML_TRIP_REQUEST2",
     "vvo": "https://efa.vvo-online.de/VMSSL3/XML_TRIP_REQUEST2",
     "ding": "https://www.ding.eu/ding3/XML_TRIP_REQUEST2",
-    "avv": "https://fahrtauskunft.avv-augsburg.de/efa/XML_TRIP_REQUEST2",
+    "avv_augsburg": "https://fahrtauskunft.avv-augsburg.de/efa/XML_TRIP_REQUEST2",
     "rvv": "https://efa.rvv.de/efa/XML_TRIP_REQUEST2",
     "bsvg": "https://bsvg.efa.de/bsvagstd/XML_TRIP_REQUEST2",
     "nwl": "https://westfalenfahrplan.de/nwl-efa/XML_TRIP_REQUEST2",
@@ -94,8 +94,8 @@ async def async_plan_trip(
 ) -> Optional[List[Dict[str, Any]]]:
     """Plan a trip from origin to destination.
 
-    Dispatches to OTP2 GraphQL for otp_custom/openpublictransport/vbn_otp,
-    EFA XML for all other supported providers.
+    Dispatches to OTP2 GraphQL for otp_custom/openpublictransport,
+    OTP REST for vbn_otp, EFA XML for all other supported providers.
     Uses stop IDs when available (more reliable), falls back to name+place search.
     Returns a list of journey options, each with legs and transfer info.
     """

--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -26,6 +26,13 @@ EFA_TRIP_ENDPOINTS = {
     "vvs": "https://www3.vvs.de/mngvvs/XML_TRIP_REQUEST2",
     "vgn": "https://efa.vgn.de/vgnExt_oeffi/XML_TRIP_REQUEST2",
     "vagfr": "https://efa.vagfr.de/vagfr3/XML_TRIP_REQUEST2",
+    "vrn": "https://www.vrn.de/mngvrn/XML_TRIP_REQUEST2",
+    "vvo": "https://efa.vvo-online.de/VMSSL3/XML_TRIP_REQUEST2",
+    "ding": "https://www.ding.eu/ding3/XML_TRIP_REQUEST2",
+    "avv": "https://fahrtauskunft.avv-augsburg.de/efa/XML_TRIP_REQUEST2",
+    "rvv": "https://efa.rvv.de/efa/XML_TRIP_REQUEST2",
+    "bsvg": "https://bsvg.efa.de/bsvagstd/XML_TRIP_REQUEST2",
+    "nwl": "https://westfalenfahrplan.de/nwl-efa/XML_TRIP_REQUEST2",
 }
 
 # OTP GTFS mode → unified product name
@@ -74,7 +81,7 @@ async def async_plan_trip(
     # EFA providers
     base_url = EFA_TRIP_ENDPOINTS.get(provider)
     if not base_url:
-        _LOGGER.warning("Trip planning not supported for provider: %s", provider)
+        _LOGGER.debug("Trip planning not supported for provider: %s", provider)
         return None
 
     now = departure_time or dt_util.now()

--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -35,6 +35,35 @@ EFA_TRIP_ENDPOINTS = {
     "nwl": "https://westfalenfahrplan.de/nwl-efa/XML_TRIP_REQUEST2",
 }
 
+_GRAPHQL_PLAN = """{
+  plan(
+    from: { stopId: "%s" }
+    to: { stopId: "%s" }
+    date: "%s"
+    time: "%s"
+    numItineraries: 3
+    transportModes: [{ mode: TRANSIT }, { mode: WALK }]
+  ) {
+    itineraries {
+      duration
+      numberOfTransfers
+      legs {
+        mode
+        startTime
+        endTime
+        from { name }
+        to   { name }
+        departureDelay
+        arrivalDelay
+        transitLeg
+        routeShortName
+        duration
+        realTime
+      }
+    }
+  }
+}"""
+
 # OTP GTFS mode → unified product name
 _OTP_MODE_TO_PRODUCT = {
     "BUS": "bus",
@@ -61,20 +90,30 @@ async def async_plan_trip(
     origin_id: Optional[str] = None,
     dest_id: Optional[str] = None,
     api_key: Optional[str] = None,
+    custom_url: Optional[str] = None,
 ) -> Optional[List[Dict[str, Any]]]:
     """Plan a trip from origin to destination.
 
-    Dispatches to OTP REST for vbn_otp, EFA for all other supported providers.
+    Dispatches to OTP2 GraphQL for otp_custom/openpublictransport/vbn_otp,
+    EFA XML for all other supported providers.
     Uses stop IDs when available (more reliable), falls back to name+place search.
     Returns a list of journey options, each with legs and transfer info.
     """
-    # OTP providers
+    from .providers import get_provider
+
+    # OTP2 GraphQL providers (community server + custom instance)
+    if provider in ("openpublictransport", "otp_custom"):
+        if not origin_id or not dest_id:
+            _LOGGER.warning("OTP2 trip planning requires stop IDs — search for stops first")
+            return None
+        provider_instance = get_provider(provider, hass, api_key=api_key, custom_url=custom_url)
+        return await _async_plan_trip_otp2_graphql(origin_id, dest_id, departure_time, provider_instance)
+
+    # VBN OTP — legacy OTP REST plan endpoint
     if provider == "vbn_otp":
         if not origin_id or not dest_id:
             _LOGGER.warning("VBN OTP trip planning requires stop IDs — search for stops first")
             return None
-        from .providers import get_provider
-
         provider_instance = get_provider(provider, hass, api_key=api_key)
         return await _async_plan_trip_otp(hass, origin_id, dest_id, departure_time, provider_instance)
 
@@ -126,6 +165,36 @@ async def async_plan_trip(
     except Exception as e:
         _LOGGER.warning("Trip planning failed: %s", e)
         return None
+
+
+async def _async_plan_trip_otp2_graphql(
+    origin_id: str,
+    dest_id: str,
+    departure_time: Optional[datetime],
+    provider_instance,
+) -> Optional[List[Dict[str, Any]]]:
+    """Plan a trip via OTP2 GraphQL plan query (community server + custom instances)."""
+    now = departure_time or dt_util.now()
+    # Compound stop IDs are pipe-separated — use the first platform ID for routing
+    from_id = origin_id.split("|")[0]
+    to_id = dest_id.split("|")[0]
+
+    query = _GRAPHQL_PLAN % (
+        from_id.replace('"', '\\"'),
+        to_id.replace('"', '\\"'),
+        now.strftime("%Y-%m-%d"),
+        now.strftime("%H:%M:%S"),
+    )
+    body = await provider_instance._graphql(query)
+    if body is None:
+        return None
+
+    itineraries = ((body.get("data") or {}).get("plan") or {}).get("itineraries") or []
+    if not itineraries:
+        _LOGGER.debug("OTP2 plan: no itineraries for %s → %s", from_id, to_id)
+        return None
+
+    return _parse_otp_itineraries(itineraries)
 
 
 async def _async_plan_trip_otp(
@@ -265,7 +334,7 @@ def _parse_otp_itineraries(itineraries: List[Dict[str, Any]]) -> List[Dict[str, 
                 "departure": first_dep,
                 "arrival": last_arr,
                 "duration_minutes": round(itin.get("duration", 0) / 60),
-                "transfers": itin.get("transfers", len(transit_legs) - 1),
+                "transfers": itin.get("numberOfTransfers", itin.get("transfers", len(transit_legs) - 1)),
                 "connection_feasible": connection_feasible,
                 "transfer_risk": transfer_risk,
                 "min_transfer_time": min_transfer_time,

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -15,7 +15,15 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
-from .const import CONF_SCAN_INTERVAL, CONF_VBN_API_KEY, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import (
+    CONF_OPT_API_KEY,
+    CONF_OTP_BASE_URL,
+    CONF_OTP_CUSTOM_API_KEY,
+    CONF_SCAN_INTERVAL,
+    CONF_VBN_API_KEY,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
 from .trip import async_plan_trip
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,6 +51,7 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
         origin_id: Optional[str] = None,
         dest_id: Optional[str] = None,
         api_key: Optional[str] = None,
+        custom_url: Optional[str] = None,
     ):
         """Initialize."""
         super().__init__(
@@ -59,6 +68,7 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
         self.origin_id = origin_id
         self.dest_id = dest_id
         self.api_key = api_key
+        self.custom_url = custom_url
 
     async def _async_update_data(self) -> Optional[List[Dict[str, Any]]]:
         """Fetch trip data."""
@@ -72,6 +82,7 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
             origin_id=self.origin_id,
             dest_id=self.dest_id,
             api_key=self.api_key,
+            custom_url=self.custom_url,
         )
 
 
@@ -88,7 +99,20 @@ async def async_setup_trip_entry(
     origin_id = config_entry.data.get("trip_origin_id")
     dest_id = config_entry.data.get("trip_destination_id")
     scan_interval = config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    api_key = config_entry.data.get(CONF_VBN_API_KEY)
+
+    # Resolve API key and custom URL based on provider
+    if provider == "vbn_otp":
+        api_key = config_entry.data.get(CONF_VBN_API_KEY)
+        custom_url = None
+    elif provider == "openpublictransport":
+        api_key = config_entry.data.get(CONF_OPT_API_KEY)
+        custom_url = None
+    elif provider == "otp_custom":
+        api_key = config_entry.data.get(CONF_OTP_CUSTOM_API_KEY)
+        custom_url = config_entry.data.get(CONF_OTP_BASE_URL)
+    else:
+        api_key = None
+        custom_url = None
 
     coordinator = TripDataUpdateCoordinator(
         hass,
@@ -101,6 +125,7 @@ async def async_setup_trip_entry(
         origin_id=origin_id,
         dest_id=dest_id,
         api_key=api_key,
+        custom_url=custom_url,
     )
 
     coordinator_key = f"{config_entry.entry_id}_trip_coordinator"

--- a/docs/providers/openpublictransport.md
+++ b/docs/providers/openpublictransport.md
@@ -3,7 +3,7 @@
 !!! info "Community Server"
     This provider uses a community-hosted OTP2 server at **api.openpublictransport.net**, backed by [gtfs.de](https://gtfs.de) data (CC 4.0, Germany-wide). An API key is required — [request one here](https://openpublictransport.net/api-key).
 
-The `openpublictransport` provider gives you Germany-wide real-time departures for all transit modes — S-Bahn, U-Bahn, Bus, Tram, Regional, IC/ICE — from a single unified endpoint. Data is updated daily from gtfs.de and enriched with GTFS-RT realtime delays every 30 seconds from 25+ Verbünde.
+The `openpublictransport` provider gives you Germany-wide real-time departures for all transit modes — S-Bahn, U-Bahn, Bus, Tram, Regional, IC/ICE — from a single unified endpoint. Data is updated daily from gtfs.de and enriched with GTFS-RT realtime delays every 30 seconds from VBB, VRR, VRS, VRN, VVO, VBN, NVBW, DEFAS Bayern, VAG Nürnberg, Stadtwerke Münster, and more.
 
 ## Coverage Area
 
@@ -81,19 +81,28 @@ See [github.com/NerdySoftPaw/otp-gtfsde](https://github.com/NerdySoftPaw/otp-gtf
 
 ## Realtime Data
 
-The community server polls `realtime.gtfs.de` every 30 seconds. Coverage varies by Verbund:
+The community server polls `realtime.gtfs.de/realtime-free.pb` every 30 seconds (update frequency on the source side: every 10 s). This single aggregated feed combines data from the following regional providers:
 
-| Verbund | Realtime |
-|---------|----------|
-| VRR (NRW) | Yes |
-| BSVG (Braunschweig) | Yes |
-| NWL (Westfalen-Lippe) | Yes |
-| MVV (München) | Yes |
-| S-Bahn Berlin | Yes |
-| And more... | See [gtfs.de/de/realtime](https://gtfs.de/de/realtime/) |
+| Verbund / Provider | Region | Modes |
+|--------------------|--------|-------|
+| VBB | Berlin & Brandenburg | All modes |
+| VRR | Rhein-Ruhr (NRW) | All modes (bus partially) |
+| VRS | Rhein-Sieg (Köln/Bonn) | All modes |
+| VRN / RNN | Rhein-Neckar | Local transit |
+| VVO | Dresden & Chemnitz (Oberelbe) | All modes |
+| VBN | Bremen, Niedersachsen, Schleswig-Holstein | All modes |
+| NVBW | Baden-Württemberg | All modes (bus partially) |
+| DEFAS Bayern | Bavaria (incl. MVV, S-Bahn München) | All modes |
+| VAG Nürnberg | Nürnberg city | Urban transit |
+| Stadtwerke Münster | Münster city | Local transit |
+| opentransportdata.swiss | Baden-Württemberg / Swiss border | Cross-border |
+| OVapi | Netherlands / German border | Cross-border |
+| DELFI SIRI feeds | Various states | Multiple regions |
 
 !!! note
-    Realtime coverage depends on the GTFS-RT feed from each Verbund. If your stop shows no delays, the Verbund may not provide a realtime feed. Scheduled times are always available.
+    Realtime coverage depends on what each Verbund contributes to the feed. If your stop shows no delays, the operator may not yet provide GTFS-RT data. Scheduled departure times are always available regardless of realtime coverage.
+    
+    See [gtfs.de/de/realtime](https://gtfs.de/de/realtime/) for the full feed list and licensing details.
 
 ## Troubleshooting
 

--- a/docs/providers/openpublictransport.md
+++ b/docs/providers/openpublictransport.md
@@ -3,7 +3,7 @@
 !!! info "Community Server"
     This provider uses a community-hosted OTP2 server at **api.openpublictransport.net**, backed by [gtfs.de](https://gtfs.de) data (CC 4.0, Germany-wide). An API key is required — [request one here](https://openpublictransport.net/api-key).
 
-The `openpublictransport` provider gives you Germany-wide real-time departures for all transit modes — S-Bahn, U-Bahn, Bus, Tram, Regional, IC/ICE — from a single unified endpoint. Data is updated daily from gtfs.de and enriched with GTFS-RT realtime delays every 30 seconds from VBB, VRR, VRS, VRN, VVO, VBN, NVBW, DEFAS Bayern, VAG Nürnberg, Stadtwerke Münster, and more.
+    The `openpublictransport` provider gives you Germany-wide real-time departures for all transit modes — S-Bahn, U-Bahn, Bus, Tram, Regional, IC/ICE — from a single unified endpoint. Data is updated daily from gtfs.de and enriched with GTFS-RT realtime delays every 30 seconds from VBB, VRR, VRS, VRN, VVO, VBN, NVBW, DEFAS Bayern, VAG Nürnberg, Stadtwerke Münster, and more.
 
 ## Coverage Area
 


### PR DESCRIPTION
## Summary

- **Agency in OTP2 departures** — `stoptimesWithoutPatterns` now fetches `route.agency.name` via GraphQL; the field was always empty before
- **GTFS-RT alerts** — all three levels included: stop-level (platform closed etc.), trip-level (this departure), route-level (whole line); merged and deduplicated into `notices` per departure
- **Trip planner for OTP2** — new `_async_plan_trip_otp2_graphql()` handles `openpublictransport` and `otp_custom` providers via the GraphQL `plan` query; stop IDs passed directly (no coordinate resolution needed); compound IDs use first platform
- **`_parse_otp_itineraries` fix** — handles `numberOfTransfers` (GraphQL) and `transfers` (REST) so VBN OTP and OTP2 GraphQL both work
- **EFA trip endpoint fixes** — added 7 missing providers (VRN, VVO, DING, AVV, RVV, BSVG, NWL); `"Trip planning not supported"` downgraded from WARNING to DEBUG
- **Constants** — `CONF_OPT_API_KEY` / `CONF_OTP_CUSTOM_API_KEY` added to `const.py`, all string literals replaced
- **Translation strings** — all 8 language files have entries for `opt_key` / `otp_custom_url` steps and `opt_api_key_required` / `otp_url_required` errors
- **Docs** — complete GTFS-RT feed table on the openpublictransport provider page (VBB, VRR, VRS, VRN, VVO, VBN, NVBW, DEFAS Bayern, VAG Nürnberg, Stadtwerke Münster, cross-border feeds)

## Test plan

- [ ] OTP2 departures show agency name (e.g. "DB Regio AG", "Rheinbahn AG")
- [ ] Active GTFS-RT alerts appear in the `notices` attribute of affected departures
- [ ] Trip planning works for `openpublictransport` and `otp_custom` providers
- [ ] VBN OTP trip planning still works (REST path unchanged)
- [ ] EFA trip planning works for VRN (was logging 367 warnings/day)
- [ ] Setup UI shows correct labels for `opt_key` and `otp_custom_url` steps in all languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)