### PR TITLE
feat: Application Credentials + Rename to OpenPublicTransport

### DIFF
--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -2,6 +2,10 @@ import logging
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import entity_registry as er
@@ -9,6 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from .const import (
     CONF_DEPARTURES,
     CONF_NTA_API_KEY,
+    CONF_NTA_API_KEY_SECONDARY,
     CONF_OPT_API_KEY,
     CONF_OTP_BASE_URL,
     CONF_OTP_CUSTOM_API_KEY,
@@ -75,6 +80,61 @@ SERVICE_ANNOUNCE_SCHEMA = vol.Schema(
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
+_PROVIDER_CREDENTIAL_NAMES: dict[str, str] = {
+    PROVIDER_OPT: "Deutschland Community Server (api.openpublictransport.net)",
+    PROVIDER_OTP_CUSTOM: "OTP2 Eigene Instanz",
+    PROVIDER_TRAFIKLAB_SE: "Trafiklab (Schweden)",
+    PROVIDER_RMV: "RMV (Rhein-Main)",
+    PROVIDER_VBN_OTP: "VBN (Bremen/Niedersachsen) — OTP",
+    PROVIDER_VBN_TRIAS: "VBN (Bremen/Niedersachsen) — TRIAS",
+    PROVIDER_NTA_IE: "NTA (Irland)",
+}
+
+
+async def _async_migrate_credential(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Migrate API key from a config entry into HA's Application Credentials store.
+
+    Called for every existing entry on startup so that keys entered before this
+    feature existed show up centrally under Application Credentials.
+    The underlying async_import_item is idempotent — duplicate keys are silently skipped.
+    """
+    provider = entry.data.get(CONF_PROVIDER) or entry.data.get("trip_provider")
+    if not provider:
+        return
+
+    key_map: dict[str, tuple[str, str]] = {
+        # provider: (primary_conf_key, secondary_conf_key_or_empty)
+        PROVIDER_OPT: (CONF_OPT_API_KEY, ""),
+        PROVIDER_OTP_CUSTOM: (CONF_OTP_CUSTOM_API_KEY, ""),
+        PROVIDER_TRAFIKLAB_SE: (CONF_TRAFIKLAB_API_KEY, ""),
+        PROVIDER_RMV: (CONF_RMV_API_KEY, ""),
+        PROVIDER_VBN_OTP: (CONF_VBN_API_KEY, ""),
+        PROVIDER_VBN_TRIAS: (CONF_VBN_API_KEY, ""),
+        PROVIDER_NTA_IE: (CONF_NTA_API_KEY, CONF_NTA_API_KEY_SECONDARY),
+    }
+
+    if provider not in key_map:
+        return
+
+    primary_key, secondary_key = key_map[provider]
+    api_key = entry.data.get(primary_key, "")
+    if not api_key:
+        return
+
+    secondary = entry.data.get(secondary_key, "") if secondary_key else ""
+    name = _PROVIDER_CREDENTIAL_NAMES.get(provider, f"{provider.upper()} API Key")
+
+    try:
+        await async_import_client_credential(
+            hass,
+            DOMAIN,
+            ClientCredential(client_id=api_key, client_secret=secondary, name=name),
+            auth_domain=f"{DOMAIN}.{provider}",
+        )
+        _LOGGER.debug("Migrated %s credential to Application Credentials store", provider)
+    except Exception as exc:
+        _LOGGER.warning("Could not migrate credential for %s: %s", provider, exc)
+
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Open Public Transport component."""
@@ -85,6 +145,10 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Open Public Transport from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+
+    # Migrate any API key stored in this entry to the Application Credentials store.
+    # Safe for new entries (no key → no-op) and idempotent for existing ones.
+    await _async_migrate_credential(hass, entry)
 
     # Check if this is a multi-stop entry
     if entry.data.get("is_multi_stop"):

--- a/custom_components/openpublictransport/application_credentials.py
+++ b/custom_components/openpublictransport/application_credentials.py
@@ -1,0 +1,57 @@
+"""Application credentials platform for Open Public Transport.
+
+API keys are stored as ClientCredential(client_id=api_key, client_secret=secondary_key_or_empty).
+This lets users manage all provider API keys centrally under HA's Application Credentials UI
+instead of re-entering them for every sensor entry.
+"""
+
+from homeassistant.components.application_credentials import ClientCredential
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
+
+
+class _ApiKeyImplementation(config_entry_oauth2_flow.LocalOAuth2Implementation):
+    """Wraps a provider API key in HA's OAuth2 credential storage.
+
+    No actual OAuth2 flow is performed — client_id IS the API key.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        auth_domain: str,
+        credential: ClientCredential,
+    ) -> None:
+        super().__init__(
+            hass,
+            auth_domain,
+            credential.client_id,
+            credential.client_secret,
+            "http://localhost/not_used",
+            "http://localhost/not_used",
+        )
+        self._display_name = credential.name or auth_domain
+
+    @property
+    def name(self) -> str:
+        return self._display_name
+
+
+async def async_get_auth_implementation(
+    hass: HomeAssistant,
+    auth_domain: str,
+    credential: ClientCredential,
+) -> _ApiKeyImplementation:
+    """Return auth implementation for API key credentials."""
+    return _ApiKeyImplementation(hass, auth_domain, credential)
+
+
+async def async_get_description_placeholders(hass: HomeAssistant) -> dict[str, str]:
+    """Hint text shown in the Application Credentials dialog."""
+    return {
+        "description": (
+            "Enter your provider API key as **Client ID**. "
+            "For NTA Ireland (two-key setup) enter the secondary key as **Client Secret**. "
+            "Leave Client Secret empty for all other providers."
+        )
+    }

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -12,6 +12,10 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from aiohttp import ClientConnectorError
 from homeassistant import config_entries
+from homeassistant.components.application_credentials import (
+    ClientCredential,
+    async_import_client_credential,
+)
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -158,8 +162,59 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
 
         return self.async_show_form(step_id="user", data_schema=schema)
 
+    def _find_credentials_from_application_credentials(self, provider: str) -> dict:
+        """Return API key for a provider from HA's Application Credentials store."""
+        try:
+            from homeassistant.components.application_credentials import DATA_COMPONENT
+
+            storage = self.hass.data.get(DATA_COMPONENT)
+            if not storage:
+                return {}
+            all_creds = storage.async_client_credentials(DOMAIN)
+            auth_domain = f"{DOMAIN}.{provider}"
+            if auth_domain not in all_creds:
+                return {}
+            credential = all_creds[auth_domain]
+            api_key = credential.client_id
+            secondary_key = credential.client_secret
+            if not api_key:
+                return {}
+            if provider == PROVIDER_OPT:
+                return {CONF_OPT_API_KEY: api_key}
+            if provider == PROVIDER_OTP_CUSTOM:
+                return {CONF_OTP_CUSTOM_API_KEY: api_key}
+            if provider == PROVIDER_TRAFIKLAB_SE:
+                return {CONF_TRAFIKLAB_API_KEY: api_key}
+            if provider == PROVIDER_RMV:
+                return {CONF_RMV_API_KEY: api_key}
+            if provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
+                return {CONF_VBN_API_KEY: api_key}
+            if provider == PROVIDER_NTA_IE:
+                result = {CONF_NTA_API_KEY: api_key}
+                if secondary_key:
+                    result[CONF_NTA_API_KEY_SECONDARY] = secondary_key
+                return result
+        except Exception as exc:
+            _LOGGER.debug("Could not read from application_credentials: %s", exc)
+        return {}
+
     def _find_existing_credentials(self, provider: str) -> dict:
-        """Return stored credentials from any existing entry for this provider."""
+        """Return stored credentials — checks Application Credentials store first, then config entries."""
+        # Prefer central Application Credentials store
+        result = self._find_credentials_from_application_credentials(provider)
+
+        # For otp_custom also grab the URL from existing config entries (URLs are not credentials)
+        if provider == PROVIDER_OTP_CUSTOM and CONF_OTP_BASE_URL not in result:
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                ep = entry.data.get(CONF_PROVIDER) or entry.data.get("trip_provider")
+                if ep == provider and CONF_OTP_BASE_URL in entry.data:
+                    result[CONF_OTP_BASE_URL] = entry.data[CONF_OTP_BASE_URL]
+                    break
+
+        if result:
+            return result
+
+        # Fall back to searching existing config entries (legacy / first-run)
         key_map: Dict[str, list] = {
             PROVIDER_OPT: [CONF_OPT_API_KEY],
             PROVIDER_OTP_CUSTOM: [CONF_OTP_CUSTOM_API_KEY, CONF_OTP_BASE_URL],
@@ -179,6 +234,41 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 if found:
                     return found
         return {}
+
+    _PROVIDER_CREDENTIAL_NAMES: Dict[str, str] = {
+        PROVIDER_OPT: "Deutschland Community Server (api.openpublictransport.net)",
+        PROVIDER_OTP_CUSTOM: "OTP2 Eigene Instanz",
+        PROVIDER_TRAFIKLAB_SE: "Trafiklab (Schweden)",
+        PROVIDER_RMV: "RMV (Rhein-Main)",
+        PROVIDER_VBN_OTP: "VBN (Bremen/Niedersachsen) — OTP",
+        PROVIDER_VBN_TRIAS: "VBN (Bremen/Niedersachsen) — TRIAS",
+        PROVIDER_NTA_IE: "NTA (Irland)",
+    }
+
+    async def _async_store_credential(self, provider: str) -> None:
+        """Persist the current API key in HA's Application Credentials store."""
+        if not self._api_key and provider != PROVIDER_OTP_CUSTOM:
+            return
+        secondary = ""
+        key = self._api_key or ""
+        if provider == PROVIDER_NTA_IE:
+            secondary = self._api_key_secondary or ""
+        if not key:
+            return
+        name = self._PROVIDER_CREDENTIAL_NAMES.get(provider, f"{provider.upper()} API Key")
+        try:
+            await async_import_client_credential(
+                self.hass,
+                DOMAIN,
+                ClientCredential(
+                    client_id=key,
+                    client_secret=secondary,
+                    name=name,
+                ),
+                auth_domain=f"{DOMAIN}.{provider}",
+            )
+        except Exception as exc:
+            _LOGGER.debug("Could not store credential in application_credentials: %s", exc)
 
     async def async_step_opt_key(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         """Required API key step for the openpublictransport community server."""
@@ -577,6 +667,10 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     data[CONF_OTP_BASE_URL] = self._otp_custom_url
                 if self._api_key:
                     data[CONF_OTP_CUSTOM_API_KEY] = self._api_key
+
+            # Persist API key in Application Credentials store
+            if self._provider:
+                await self._async_store_credential(self._provider)
 
             # Create unique ID (self._selected_stop validated above)
             unique_id = f"{self._provider}_{self._selected_stop['id']}"
@@ -1379,6 +1473,10 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     data[CONF_OTP_CUSTOM_API_KEY] = self._api_key
                     if self._otp_custom_url:
                         data[CONF_OTP_BASE_URL] = self._otp_custom_url
+
+            # Persist API key in Application Credentials store
+            if self._provider:
+                await self._async_store_credential(self._provider)
 
             unique_id = f"{self._provider}_trip_{origin.get('id', '')}_{dest.get('id', '')}"
             await self.async_set_unique_id(unique_id)

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -5,7 +5,9 @@
     "@NerdySoftPaw"
   ],
   "config_flow": true,
-  "dependencies": ["application_credentials"],
+  "dependencies": [
+    "application_credentials"
+  ],
   "documentation": "https://docs.openpublictransport.net/",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
@@ -14,5 +16,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.1.0"
+  "version": "2026.6.1"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "openpublictransport",
-  "name": "Public Transport Departures",
+  "name": "OpenPublicTransport",
   "codeowners": [
     "@NerdySoftPaw"
   ],

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -5,7 +5,7 @@
     "@NerdySoftPaw"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["application_credentials"],
   "documentation": "https://docs.openpublictransport.net/",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
@@ -14,5 +14,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.5.25.1"
+  "version": "2026.6.1.0"
 }


### PR DESCRIPTION
## Summary

### 🔑 Provider API Keys in HA Application Credentials
API keys for all providers that require authentication (OPT Community Server, RMV, VBN, Trafiklab, NTA Ireland, custom OTP2 instances) are now stored centrally in Home Assistant's **Application Credentials** store — visible and manageable under **Settings → Integrations → ⋮ → Application credentials**.

Previously, API keys were only saved inside each individual sensor config entry. This meant keys were scattered across multiple entries and not easily visible.

### 🔄 Automatic Migration
On first start after the update, existing keys are automatically migrated from `config_entry.data` into the Application Credentials store. No manual action required. The migration is idempotent — safe to run multiple times.

Keys remain in `config_entry.data` as well (no breaking change, rollback safe).

### ♻️ Key Reuse
When adding a second sensor for a provider whose key is already stored, the key is pre-filled automatically — no need to enter it again.

### 🏷️ Rename
Integration display name changed from `Public Transport Departures` → `OpenPublicTransport`.

---

## Changed Files

| File | Change |
|------|--------|
| `application_credentials.py` | **New** — registers the platform so HA shows the Application Credentials UI for this integration |
| `manifest.json` | Added `application_credentials` dependency, bumped version, renamed integration |
| `config_flow.py` | Writes key to store on entry creation; reads from store first when looking for existing credentials (falls back to config entry data for legacy setups) |
| `__init__.py` | `_async_migrate_credential()` migrates existing keys into the store on every startup |

## Credential Storage Details

Each provider gets its **own named entry** in the store:

| Provider | Name in UI |
|----------|-----------|
| OPT Community Server | Deutschland Community Server (api.openpublictransport.net) |
| RMV | RMV (Rhein-Main) |
| Trafiklab | Trafiklab (Schweden) |
| VBN OTP | VBN (Bremen/Niedersachsen) — OTP |
| VBN TRIAS | VBN (Bremen/Niedersachsen) — TRIAS |
| NTA Ireland | NTA (Irland) |
| Custom OTP2 | OTP2 Eigene Instanz |

`client_id` = API key · `client_secret` = secondary key (NTA only) or empty

## Test Results
- ✅ Migration: existing keys correctly migrated on startup
- ✅ API calls still working after migration
- ✅ New sensor setup: key pre-filled from store
- ✅ Providers without API key: no change in behaviour