### PR TITLE
fix/feat: OTP stop search, agency sensor name, line colors (v2026.6.2)

### DIFF
--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -617,6 +617,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 CONF_STATION_ID: self._selected_stop.get("id"),
                 "place_dm": self._selected_stop.get("place", ""),
                 "name_dm": self._selected_stop.get("name", ""),
+                "agency_name": self._selected_stop.get("agency", ""),
                 CONF_DEPARTURES: user_input[CONF_DEPARTURES],
                 CONF_TRANSPORTATION_TYPES: user_input[CONF_TRANSPORTATION_TYPES],
                 CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -106,7 +106,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             {"value": "trafiklab_se", "label": "Trafiklab — Schweden (API Key)"},
             {
                 "value": "openpublictransport",
-                "label": "Deutschland — openpublictransport.net (API Key)",
+                "label": "openpublictransport.net (Deutschlandweit, API Key)",
             },
             {"value": "otp_custom", "label": "OTP2 — Eigene Instanz (URL + optionaler API Key)"},
             {"value": "transitous", "label": "Transitous — Weltweit (Community, Beta)"},
@@ -236,7 +236,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         return {}
 
     _PROVIDER_CREDENTIAL_NAMES: Dict[str, str] = {
-        PROVIDER_OPT: "Deutschland — openpublictransport.net",
+        PROVIDER_OPT: "openpublictransport.net (Deutschlandweit)",
         PROVIDER_OTP_CUSTOM: "OTP2 Eigene Instanz",
         PROVIDER_TRAFIKLAB_SE: "Trafiklab (Schweden)",
         PROVIDER_RMV: "RMV (Rhein-Main)",

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -106,7 +106,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             {"value": "trafiklab_se", "label": "Trafiklab — Schweden (API Key)"},
             {
                 "value": "openpublictransport",
-                "label": "Deutschland — Community Server (api.openpublictransport.net, API Key)",
+                "label": "Deutschland — openpublictransport.net (API Key)",
             },
             {"value": "otp_custom", "label": "OTP2 — Eigene Instanz (URL + optionaler API Key)"},
             {"value": "transitous", "label": "Transitous — Weltweit (Community, Beta)"},
@@ -236,7 +236,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         return {}
 
     _PROVIDER_CREDENTIAL_NAMES: Dict[str, str] = {
-        PROVIDER_OPT: "Deutschland Community Server (api.openpublictransport.net)",
+        PROVIDER_OPT: "Deutschland — openpublictransport.net",
         PROVIDER_OTP_CUSTOM: "OTP2 Eigene Instanz",
         PROVIDER_TRAFIKLAB_SE: "Trafiklab (Schweden)",
         PROVIDER_RMV: "RMV (Rhein-Main)",

--- a/custom_components/openpublictransport/data_models.py
+++ b/custom_components/openpublictransport/data_models.py
@@ -46,6 +46,8 @@ class UnifiedDeparture:
     notices: Optional[list[str]] = None  # Disruption/info messages
     planned_platform: Optional[str] = None  # Original platform before changes
     platform_changed: bool = False  # True if platform differs from planned
+    line_color: Optional[str] = None  # Route background color (e.g. "#e10098")
+    line_text_color: Optional[str] = None  # Route text color (e.g. "#ffffff")
 
     def to_dict(self) -> dict:
         """Convert to dictionary for Home Assistant attributes."""
@@ -69,6 +71,10 @@ class UnifiedDeparture:
         if self.platform_changed:
             result["planned_platform"] = self.planned_platform
             result["platform_changed"] = True
+        if self.line_color:
+            result["line_color"] = self.line_color
+        if self.line_text_color:
+            result["line_text_color"] = self.line_text_color
         return result
 
 

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -16,5 +16,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.2-beta2"
+  "version": "2026.6.2"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -16,5 +16,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.1"
+  "version": "2026.6.2"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -16,5 +16,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.2-beta1"
+  "version": "2026.6.2-beta2"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -16,5 +16,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.2"
+  "version": "2026.6.2-beta1"
 }

--- a/custom_components/openpublictransport/providers/gtfsde.py
+++ b/custom_components/openpublictransport/providers/gtfsde.py
@@ -14,7 +14,7 @@ class OPTProvider(OTPProvider):
 
     @property
     def provider_name(self) -> str:
-        return "Deutschland — openpublictransport.net"
+        return "openpublictransport.net (Deutschlandweit)"
 
     @property
     def requires_api_key(self) -> bool:

--- a/custom_components/openpublictransport/providers/gtfsde.py
+++ b/custom_components/openpublictransport/providers/gtfsde.py
@@ -14,7 +14,7 @@ class OPTProvider(OTPProvider):
 
     @property
     def provider_name(self) -> str:
-        return "Deutschland (api.openpublictransport.net)"
+        return "Deutschland — openpublictransport.net"
 
     @property
     def requires_api_key(self) -> bool:

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -50,7 +50,7 @@ _CITY_PREFIXES: Dict[str, str] = {
     "bonn": "BN-",
 }
 
-_GRAPHQL_STOP_SEARCH = '{ stops(name: "%s") { gtfsId name lat lon parentStation { gtfsId name } } }'
+_GRAPHQL_STOP_SEARCH = '{ stops(name: "%s") { gtfsId name lat lon parentStation { gtfsId name } routes { agency { name } } } }'
 
 
 def _smart_title(s: str) -> str:
@@ -59,6 +59,17 @@ def _smart_title(s: str) -> str:
     Keeps abbreviations like KIT, S2, ICE intact while fixing lowercase input.
     """
     return " ".join(w[0].upper() + w[1:] if w else w for w in s.split())
+
+
+def _primary_agency(stops: List[Dict[str, Any]]) -> str:
+    """Return the most common agency name across all routes of the given stops."""
+    counts: Dict[str, int] = {}
+    for s in stops:
+        for route in (s.get("routes") or []):
+            name = (route.get("agency") or {}).get("name", "")
+            if name:
+                counts[name] = counts.get(name, 0) + 1
+    return max(counts, key=lambda k: counts[k]) if counts else ""
 
 _GRAPHQL_NEAREST = """{
   nearest(lat: %f, lon: %f, maxDistance: %d, filterByPlaceTypes: [STOP]) {
@@ -71,6 +82,7 @@ _GRAPHQL_NEAREST = """{
             lat
             lon
             parentStation { gtfsId name }
+            routes { agency { name } }
           }
         }
         distance
@@ -231,7 +243,8 @@ class OTPProvider(OTPBaseProvider):
         for stops in by_parent.values():
             compound_id = "|".join(s["gtfsId"] for s in stops)
             name = (stops[0].get("parentStation") or {}).get("name") or stops[0]["name"]
-            result.append({"id": compound_id, "name": name, "place": name, "area_type": "stop"})
+            agency = _primary_agency(stops)
+            result.append({"id": compound_id, "name": name, "place": name, "agency": agency, "area_type": "stop"})
 
         by_name: Dict[str, List[Dict[str, Any]]] = {}
         for s in no_parent:
@@ -239,7 +252,8 @@ class OTPProvider(OTPBaseProvider):
         for name, stops in by_name.items():
             for cluster in _cluster_by_proximity(stops):
                 compound_id = "|".join(s["gtfsId"] for s in cluster)
-                result.append({"id": compound_id, "name": name, "place": name, "area_type": "stop"})
+                agency = _primary_agency(cluster)
+                result.append({"id": compound_id, "name": name, "place": name, "agency": agency, "area_type": "stop"})
 
         return result
 

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -242,9 +242,11 @@ class OTPProvider(OTPBaseProvider):
     async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:
         """Search stops via OTP2 GraphQL with city-prefix fallback for VRR/NRW."""
         ss_term = search_term.replace("ß", "ss") if "ß" in search_term else None
+        # OTP stops(name:) is case-sensitive — also try first-letter-capitalised variant
+        cap_term = search_term[0].upper() + search_term[1:] if search_term and search_term[0].islower() else None
 
-        # Phase 1: bare name and ß→ss variant
-        for term in filter(None, [search_term, ss_term]):
+        # Phase 1: bare name, ß→ss variant, capitalised variant
+        for term in filter(None, [search_term, ss_term, cap_term]):
             raw = await self._search_one(term)
             if raw:
                 return self._group_by_name(raw)[:20]

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -52,6 +52,14 @@ _CITY_PREFIXES: Dict[str, str] = {
 
 _GRAPHQL_STOP_SEARCH = '{ stops(name: "%s") { gtfsId name lat lon parentStation { gtfsId name } } }'
 
+
+def _smart_title(s: str) -> str:
+    """Capitalize the first letter of each word, preserving the rest.
+
+    Keeps abbreviations like KIT, S2, ICE intact while fixing lowercase input.
+    """
+    return " ".join(w[0].upper() + w[1:] if w else w for w in s.split())
+
 _GRAPHQL_NEAREST = """{
   nearest(lat: %f, lon: %f, maxDistance: %d, filterByPlaceTypes: [STOP]) {
     edges {
@@ -242,11 +250,12 @@ class OTPProvider(OTPBaseProvider):
     async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:
         """Search stops via OTP2 GraphQL with city-prefix fallback for VRR/NRW."""
         ss_term = search_term.replace("ß", "ss") if "ß" in search_term else None
-        # OTP stops(name:) is case-sensitive — also try first-letter-capitalised variant
-        cap_term = search_term[0].upper() + search_term[1:] if search_term and search_term[0].islower() else None
+        # OTP stops(name:) is case-sensitive — also try smart-title-cased variant
+        smart_term = _smart_title(search_term)
+        smart_term = smart_term if smart_term != search_term else None
 
-        # Phase 1: bare name, ß→ss variant, capitalised variant
-        for term in filter(None, [search_term, ss_term, cap_term]):
+        # Phase 1: bare name, ß→ss variant, smart-title variant
+        for term in filter(None, [search_term, ss_term, smart_term]):
             raw = await self._search_one(term)
             if raw:
                 return self._group_by_name(raw)[:20]

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -52,6 +52,25 @@ _CITY_PREFIXES: Dict[str, str] = {
 
 _GRAPHQL_STOP_SEARCH = '{ stops(name: "%s") { gtfsId name lat lon parentStation { gtfsId name } } }'
 
+_GRAPHQL_NEAREST = """{
+  nearest(lat: %f, lon: %f, maxDistance: %d, filterByPlaceTypes: [STOP]) {
+    edges {
+      node {
+        place {
+          ... on Stop {
+            gtfsId
+            name
+            lat
+            lon
+            parentStation { gtfsId name }
+          }
+        }
+        distance
+      }
+    }
+  }
+}"""
+
 
 def _detect_city_prefix(search_term: str) -> Optional[str]:
     """If the search contains a known city name, return PREFIX + stop_part.
@@ -260,8 +279,24 @@ class OTPProvider(OTPBaseProvider):
         if all_raw:
             return self._group_by_name(all_raw)[:20]
 
-        # Phase 3: Nominatim + OTP radius search
-        return await super().search_stops(search_term)
+        # Phase 3: Nominatim geocode → GraphQL nearest (REST /index/stops not exposed)
+        coords = await self._geocode(search_term)
+        if coords is None:
+            _LOGGER.warning("%s: could not geocode '%s'", self.provider_name, search_term)
+            return []
+        lat, lon = coords
+        q = _GRAPHQL_NEAREST % (lat, lon, self.stop_search_radius)
+        body = await self._graphql(q)
+        edges = (((body or {}).get("data") or {}).get("nearest") or {}).get("edges") or []
+        raw = [
+            edge["node"]["place"]
+            for edge in edges
+            if isinstance((edge.get("node") or {}).get("place"), dict)
+            and "gtfsId" in edge["node"]["place"]
+        ]
+        if raw:
+            return self._group_by_name(raw)[:20]
+        return []
 
     @staticmethod
     def _alert_texts(alerts: Optional[List[Dict[str, Any]]]) -> List[str]:

--- a/custom_components/openpublictransport/providers/otp.py
+++ b/custom_components/openpublictransport/providers/otp.py
@@ -171,6 +171,8 @@ _GRAPHQL_STOPTIMES = """{
         route {
           shortName
           mode
+          color
+          textColor
           agency {
             name
           }
@@ -343,6 +345,8 @@ class OTPProvider(OTPBaseProvider):
             trip_notices = self._alert_texts(trip.get("alerts"))
             route_notices = [t for t in self._alert_texts(route.get("alerts")) if t not in trip_notices]
             notices = trip_notices + route_notices
+            raw_color = route.get("color") or ""
+            raw_text = route.get("textColor") or ""
             events.append(
                 {
                     "routeName": route.get("shortName", ""),
@@ -355,6 +359,8 @@ class OTPProvider(OTPBaseProvider):
                     "departureDelay": st.get("departureDelay", 0),
                     "realtime": st.get("realtime", False),
                     "headsign": st.get("headsign", ""),
+                    "lineColor": f"#{raw_color}" if raw_color and not raw_color.startswith("#") else raw_color or None,
+                    "lineTextColor": f"#{raw_text}" if raw_text and not raw_text.startswith("#") else raw_text or None,
                 }
             )
         return events

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -303,6 +303,8 @@ class OTPBaseProvider(BaseProvider):
                 notices=notices,
                 planned_platform=None,
                 platform_changed=False,
+                line_color=stop.get("lineColor") or None,
+                line_text_color=stop.get("lineTextColor") or None,
             )
         except Exception as exc:
             _LOGGER.debug("%s OTP parse_departure error: %s", self.provider_name, exc)

--- a/custom_components/openpublictransport/providers/otp_base.py
+++ b/custom_components/openpublictransport/providers/otp_base.py
@@ -33,6 +33,33 @@ _LOGGER = logging.getLogger(__name__)
 _NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 _NOMINATIM_UA = "openpublictransport-homeassistant/1.0 (github.com/NerdySoftPaw/openpublictransport)"
 
+
+def _nominatim_candidates(term: str) -> List[str]:
+    """Return progressively simpler Nominatim queries for a search term.
+
+    Strategy (stops after first hit in _geocode):
+    1. Full term
+    2. Comma-swap: "Karlsruhe, KIT Haupteingang" → "KIT Haupteingang Karlsruhe"
+    3. Remove each word once — catches generic words like "Haupteingang"
+       that Nominatim doesn't know as POI names.
+    """
+    candidates: List[str] = [term]
+
+    if "," in term:
+        parts = [p.strip() for p in term.split(",", 1)]
+        swapped = " ".join(reversed(parts))
+        if swapped not in candidates:
+            candidates.append(swapped)
+
+    words = term.replace(",", " ").split()
+    if len(words) > 2:
+        for i in range(len(words)):
+            shorter = " ".join(w for j, w in enumerate(words) if j != i)
+            if shorter not in candidates:
+                candidates.append(shorter)
+
+    return candidates
+
 OTP_MODE_MAP: Dict[str, str] = {
     "BUS": "bus",
     "COACH": "bus",
@@ -96,24 +123,30 @@ class OTPBaseProvider(BaseProvider):
     async def _geocode(self, search_term: str) -> Optional[Tuple[float, float]]:
         """Resolve a stop name to (lat, lon) via Nominatim / OpenStreetMap.
 
-        OTP 2.x REST API has no name-based stop search; we geocode first,
-        then use the coordinate-based /index/stops?lat=&lon=&radius= endpoint.
+        Tries progressively simpler queries so that inputs like
+        "KIT Haupteingang Karlsruhe" still resolve even when Nominatim
+        doesn't know the generic word ("Haupteingang").
         """
         session = async_get_clientsession(self.hass)
-        try:
-            async with session.get(
-                _NOMINATIM_URL,
-                params={"q": search_term, "format": "json", "limit": 1},
-                headers={"User-Agent": _NOMINATIM_UA, "Accept": "application/json"},
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as resp:
-                if resp.status == 200:
-                    results = await resp.json(content_type=None)
-                    if results:
-                        return float(results[0]["lat"]), float(results[0]["lon"])
-                    _LOGGER.debug("%s: Nominatim returned no results for '%s'", self.provider_name, search_term)
-        except Exception as exc:
-            _LOGGER.debug("%s: Nominatim geocode error: %s", self.provider_name, exc)
+        for i, candidate in enumerate(_nominatim_candidates(search_term)):
+            if i > 0:
+                await asyncio.sleep(0.3)
+            try:
+                async with session.get(
+                    _NOMINATIM_URL,
+                    params={"q": candidate, "format": "json", "limit": 1, "countrycodes": "de"},
+                    headers={"User-Agent": _NOMINATIM_UA, "Accept": "application/json"},
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status == 200:
+                        results = await resp.json(content_type=None)
+                        if results:
+                            if i > 0:
+                                _LOGGER.debug("%s: Nominatim hit on simplified query '%s'", self.provider_name, candidate)
+                            return float(results[0]["lat"]), float(results[0]["lon"])
+            except Exception as exc:
+                _LOGGER.debug("%s: Nominatim geocode error: %s", self.provider_name, exc)
+        _LOGGER.warning("%s: Nominatim found nothing for '%s'", self.provider_name, search_term)
         return None
 
     async def search_stops(self, search_term: str) -> List[Dict[str, Any]]:

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -387,13 +387,13 @@ class MultiProviderSensor(CoordinatorEntity, SensorEntity):
         station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
         self._attr_unique_id = f"{provider}_{station_key}"
         agency_name = coordinator.agency_name
-        name_prefix = agency_name if agency_name else provider.upper()
-        self._attr_name = f"{name_prefix} - {name_dm}"
+        display_name = f"{agency_name} - {name_dm}" if agency_name else name_dm
+        self._attr_name = display_name
 
         # Device info
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{provider}_{station_key}")},
-            name=f"{name_prefix} - {name_dm}",
+            name=display_name,
             manufacturer=f"{provider.upper()} Public Transport",
             model="Departure Monitor",
             sw_version=INTEGRATION_VERSION,

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -84,6 +84,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
         self._config_entry = config_entry
         self._base_scan_interval = scan_interval
         self._empty_result_count = 0
+        self.agency_name = config_entry.data.get("agency_name", "") if config_entry else ""
 
         # Initialize provider instance
         self.provider_instance = get_provider(
@@ -385,12 +386,14 @@ class MultiProviderSensor(CoordinatorEntity, SensorEntity):
 
         station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
         self._attr_unique_id = f"{provider}_{station_key}"
-        self._attr_name = f"{provider.upper()} {place_dm} - {name_dm}"
+        agency_name = coordinator.agency_name
+        name_prefix = agency_name if agency_name else provider.upper()
+        self._attr_name = f"{name_prefix} - {name_dm}"
 
         # Device info
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{provider}_{station_key}")},
-            name=f"{place_dm} - {name_dm}",
+            name=f"{name_prefix} - {name_dm}",
             manufacturer=f"{provider.upper()} Public Transport",
             model="Departure Monitor",
             sw_version=INTEGRATION_VERSION,


### PR DESCRIPTION
## Summary

- **Fix:** OTP stop search case-insensitiv (smart title case) — `karlsruhe hauptfriedhof` findet `Karlsruhe Hauptfriedhof`
- **Fix:** GraphQL `nearest` ersetzt REST-Endpoint für Nominatim-Fallback (war nicht exposed)
- **Fix:** Nominatim-Fallback mit Wortelimination — `KIT Haupteingang Karlsruhe` → `KIT Karlsruhe`
- **Feat:** Sensor-Name zeigt Agency — `Karlsruher Verkehrsverbund - Rastatt Kehler Straße`
- **Feat:** `line_color` / `line_text_color` in Abfahrts-Attributen
- **Chore:** Provider-Label → `openpublictransport.net (Deutschlandweit, API Key)`

## Test plan

- [x] Stop-Suche mit lowercase funktioniert
- [x] `nearest`-Query gegen API getestet
- [x] Agency-Name im Sensor-Titel sichtbar
- [x] Pre-release v2026.6.2-beta2 ausgiebig getestet

🤖 Generated with [Claude Code](https://claude.com/claude-code)