### PR TITLE
feat: National Rail (UK) provider via OpenLDBWS

### DIFF
--- a/custom_components/openpublictransport/providers/__init__.py
+++ b/custom_components/openpublictransport/providers/__init__.py
@@ -14,7 +14,7 @@ from ..const import (
     PROVIDER_HVV,
     PROVIDER_KVV,
     PROVIDER_MVV,
-    PROVIDER_NATIONAL_RAIL,
+    PROVIDER_NATIONAL_RAIL,  # noqa: F401
     PROVIDER_NTA_IE,
     PROVIDER_NVBW,
     PROVIDER_NWL,
@@ -46,7 +46,7 @@ from .gtfsde import OPTProvider
 from .hvv import HVVProvider
 from .kvv import KVVProvider
 from .mvv import MVVProvider
-from .national_rail import NationalRailProvider
+from .national_rail import NationalRailProvider  # noqa: F401
 from .nta import NTAProvider
 from .nvbw import NVBWProvider
 from .nwl import NWLProvider

--- a/custom_components/openpublictransport/providers/__init__.py
+++ b/custom_components/openpublictransport/providers/__init__.py
@@ -14,13 +14,13 @@ from ..const import (
     PROVIDER_HVV,
     PROVIDER_KVV,
     PROVIDER_MVV,
+    PROVIDER_NATIONAL_RAIL,
     PROVIDER_NTA_IE,
     PROVIDER_NVBW,
     PROVIDER_NWL,
     PROVIDER_OEBB,
     PROVIDER_OPT,
     PROVIDER_OTP_CUSTOM,
-    PROVIDER_NATIONAL_RAIL,
     PROVIDER_RMV,
     PROVIDER_RVV,
     PROVIDER_SBB,
@@ -43,10 +43,10 @@ from .bvg import BVGProvider
 from .db import DBProvider
 from .ding import DINGProvider
 from .gtfsde import OPTProvider
-from .national_rail import NationalRailProvider
 from .hvv import HVVProvider
 from .kvv import KVVProvider
 from .mvv import MVVProvider
+from .national_rail import NationalRailProvider
 from .nta import NTAProvider
 from .nvbw import NVBWProvider
 from .nwl import NWLProvider

--- a/custom_components/openpublictransport/providers/__init__.py
+++ b/custom_components/openpublictransport/providers/__init__.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Type
 
 from homeassistant.core import HomeAssistant
 
+from ..const import PROVIDER_NATIONAL_RAIL  # noqa: F401
 from ..const import (
     PROVIDER_AVV_AUGSBURG,
     PROVIDER_BEG,
@@ -14,7 +15,6 @@ from ..const import (
     PROVIDER_HVV,
     PROVIDER_KVV,
     PROVIDER_MVV,
-    PROVIDER_NATIONAL_RAIL,  # noqa: F401
     PROVIDER_NTA_IE,
     PROVIDER_NVBW,
     PROVIDER_NWL,

--- a/custom_components/openpublictransport/providers/national_rail.py
+++ b/custom_components/openpublictransport/providers/national_rail.py
@@ -7,7 +7,7 @@ ref:crs tags, returning the 3-letter CRS code used by OpenLDBWS.
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree as ET
 from zoneinfo import ZoneInfo
 


### PR DESCRIPTION
## Summary

- New provider for all National Rail (GB) services
- Uses OpenLDBWS SOAP API (free, 100k calls/month)
- Stop search via Overpass API (OSM) — finds UK railway stations by `ref:crs` tag, returns 3-letter CRS codes
- Realtime: handles On time / HH:MM / Delayed / Cancelled etd values
- Line badge shows operator code (GR=LNER, GW=GWR, VT=Avanti, etc.)
- Timezone: Europe/London

## Test plan

- [ ] CI passes (Black, isort, HACS validation, Tests)
- [ ] Once API token arrives from National Rail: test stop search (e.g. "King's Cross") and departures

🤖 Generated with [Claude Code](https://claude.com/claude-code)