### PR TITLE
feat: Bronze Quality Scale — Tasks 2, 7, 9 (quick wins)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
     name: Test with Python ${{ matrix.python-version }}
     steps:
       - name: Checkout repository

--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -81,13 +81,13 @@ SERVICE_ANNOUNCE_SCHEMA = vol.Schema(
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _PROVIDER_CREDENTIAL_NAMES: dict[str, str] = {
-    PROVIDER_OPT: "Deutschland Community Server (api.openpublictransport.net)",
-    PROVIDER_OTP_CUSTOM: "OTP2 Eigene Instanz",
-    PROVIDER_TRAFIKLAB_SE: "Trafiklab (Schweden)",
-    PROVIDER_RMV: "RMV (Rhein-Main)",
-    PROVIDER_VBN_OTP: "VBN (Bremen/Niedersachsen) — OTP",
-    PROVIDER_VBN_TRIAS: "VBN (Bremen/Niedersachsen) — TRIAS",
-    PROVIDER_NTA_IE: "NTA (Irland)",
+    PROVIDER_OPT: "Germany Community Server (api.openpublictransport.net)",
+    PROVIDER_OTP_CUSTOM: "OTP2 Custom Instance",
+    PROVIDER_TRAFIKLAB_SE: "Trafiklab (Sweden)",
+    PROVIDER_RMV: "RMV (Rhine-Main)",
+    PROVIDER_VBN_OTP: "VBN (Bremen/Lower Saxony) — OTP",
+    PROVIDER_VBN_TRIAS: "VBN (Bremen/Lower Saxony) — TRIAS",
+    PROVIDER_NTA_IE: "NTA (Ireland)",
 }
 
 
@@ -139,6 +139,168 @@ async def _async_migrate_credential(hass: HomeAssistant, entry: ConfigEntry) -> 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Open Public Transport component."""
     hass.data.setdefault(DOMAIN, {})
+
+    async def handle_refresh(call: ServiceCall) -> None:
+        """Handle the refresh service call."""
+        entity_id = call.data.get("entity_id")
+        if entity_id:
+            entity_registry = er.async_get(hass)
+            entity_entry = entity_registry.async_get(entity_id)
+            if entity_entry and entity_entry.platform == DOMAIN:
+                coordinator_key = f"{entity_entry.config_entry_id}_coordinator"
+                coordinator = hass.data[DOMAIN].get(coordinator_key)
+                if coordinator:
+                    await coordinator.async_request_refresh()
+        else:
+            entity_registry = er.async_get(hass)
+            entities = [e for e in entity_registry.entities.values() if e.platform == DOMAIN]
+            seen_entries: set[str] = set()
+            for entity_entry in entities:
+                entry_id = entity_entry.config_entry_id
+                if entry_id and entry_id not in seen_entries:
+                    seen_entries.add(entry_id)
+                    coordinator_key = f"{entry_id}_coordinator"
+                    coordinator = hass.data[DOMAIN].get(coordinator_key)
+                    if coordinator:
+                        await coordinator.async_request_refresh()
+
+    async def handle_plan_trip(call: ServiceCall) -> dict:
+        """Handle the plan_trip service call."""
+        provider = call.data["provider"]
+        origin = call.data["origin"]
+        origin_city = call.data["origin_city"]
+        destination = call.data["destination"]
+        destination_city = call.data["destination_city"]
+        api_key = None
+        custom_url = None
+        for existing in hass.config_entries.async_entries(DOMAIN):
+            ep = existing.data.get(CONF_PROVIDER) or existing.data.get("trip_provider")
+            if ep == provider:
+                if provider == PROVIDER_VBN_OTP:
+                    api_key = existing.data.get(CONF_VBN_API_KEY)
+                elif provider == PROVIDER_OPT:
+                    api_key = existing.data.get(CONF_OPT_API_KEY)
+                elif provider == PROVIDER_OTP_CUSTOM:
+                    api_key = existing.data.get(CONF_OTP_CUSTOM_API_KEY)
+                    custom_url = existing.data.get(CONF_OTP_BASE_URL)
+                break
+        journeys = await async_plan_trip(
+            hass,
+            provider,
+            origin,
+            origin_city,
+            destination,
+            destination_city,
+            api_key=api_key,
+            custom_url=custom_url,
+        )
+        return {"journeys": journeys or []}
+
+    async def handle_check_delays(call: ServiceCall) -> dict:
+        """Check delays and return delayed departures."""
+        entity_id = call.data["entity_id"]
+        threshold = call.data.get("delay_threshold", 5)
+        line_filter = call.data.get("line", "").strip().lower()
+        state_obj = hass.states.get(entity_id)
+        if not state_obj:
+            return {"delayed": [], "count": 0}
+        departures = state_obj.attributes.get("departures", [])
+        delayed = []
+        for dep in departures:
+            if not isinstance(dep, dict):
+                continue
+            delay = dep.get("delay", 0)
+            line = dep.get("line", "")
+            if delay >= threshold:
+                if not line_filter or line.lower() == line_filter:
+                    delayed.append(dep)
+        if delayed:
+            hass.bus.async_fire(
+                f"{DOMAIN}_delay_alert",
+                {
+                    "entity_id": entity_id,
+                    "delayed_count": len(delayed),
+                    "max_delay": max(d.get("delay", 0) for d in delayed),
+                    "lines": list({d.get("line", "") for d in delayed}),
+                    "departures": delayed[:5],
+                },
+            )
+        return {"delayed": delayed, "count": len(delayed)}
+
+    async def handle_announce(call: ServiceCall) -> dict:
+        """Generate and optionally speak a departure announcement."""
+        entity_id = call.data["entity_id"]
+        index = call.data.get("index", 0)
+        tts_service = call.data.get("tts_service")
+        media_player = call.data.get("media_player")
+        language = call.data.get("language", "de")
+        state_obj = hass.states.get(entity_id)
+        if not state_obj:
+            return {"text": "Keine Abfahrtsinformationen verfügbar."}
+        departures = state_obj.attributes.get("departures", [])
+        if not departures or index >= len(departures):
+            return {"text": "Keine Abfahrten verfügbar."}
+        dep = departures[index]
+        line = dep.get("line", "")
+        destination = dep.get("destination", "")
+        planned_time = dep.get("planned_time", "")
+        minutes = dep.get("minutes_until_departure", 0)
+        platform = dep.get("platform", "")
+        delay = dep.get("delay", 0)
+        transport_type = dep.get("transportation_type", "")
+        if language == "de":
+            type_name = {"train": "Zug", "subway": "U-Bahn", "tram": "Straßenbahn", "bus": "Bus", "ferry": "Fähre"}.get(
+                transport_type, ""
+            )
+            text = "Achtung, eine Durchsage. "
+            text += f"{type_name} {line}" if type_name else f"Linie {line}"
+            text += f" Richtung {destination}"
+            if planned_time:
+                text += f", planmäßige Abfahrt {planned_time} Uhr"
+            if delay > 0:
+                text += f", hat heute circa {delay} Minuten Verspätung"
+            if platform:
+                text += f", Abfahrt von Gleis {platform}"
+            if minutes <= 0:
+                text += ". Bitte einsteigen, Türen schließen selbsttätig."
+            elif minutes <= 2:
+                text += ". Bitte begeben Sie sich zum Bahnsteig."
+            else:
+                text += f". Abfahrt in {minutes} Minuten."
+        else:
+            text = f"Attention please. {line} to {destination}"
+            if planned_time:
+                text += f", scheduled departure {planned_time}"
+            if delay > 0:
+                text += f", is delayed by approximately {delay} minutes"
+            if platform:
+                text += f", departing from platform {platform}"
+            if minutes <= 0:
+                text += ". Please board now."
+            else:
+                text += f". Departing in {minutes} minutes."
+        if tts_service and media_player:
+            try:
+                service_parts = tts_service.split(".", 1)
+                if len(service_parts) == 2:
+                    await hass.services.async_call(
+                        service_parts[0], service_parts[1], {"entity_id": media_player, "message": text}
+                    )
+            except Exception as e:
+                _LOGGER.warning("Failed to call TTS service: %s", e)
+        return {"text": text}
+
+    hass.services.async_register(DOMAIN, SERVICE_REFRESH, handle_refresh, schema=SERVICE_REFRESH_SCHEMA)
+    hass.services.async_register(
+        DOMAIN, SERVICE_PLAN_TRIP, handle_plan_trip, schema=SERVICE_PLAN_TRIP_SCHEMA, supports_response=True
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_CHECK_DELAYS, handle_check_delays, schema=SERVICE_CHECK_DELAYS_SCHEMA, supports_response=True
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_ANNOUNCE, handle_announce, schema=SERVICE_ANNOUNCE_SCHEMA, supports_response=True
+    )
+
     return True
 
 
@@ -221,236 +383,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(
         entry, ["sensor", "binary_sensor", "calendar", "event", "camera"]
-    )
-
-    # Register service for manual refresh
-    async def handle_refresh(call: ServiceCall) -> None:
-        """Handle the refresh service call."""
-        entity_id = call.data.get("entity_id")
-
-        if entity_id:
-            # Refresh specific entity
-            entity_registry = er.async_get(hass)
-            entity_entry = entity_registry.async_get(entity_id)
-
-            if entity_entry and entity_entry.platform == DOMAIN:
-                coordinator_key = f"{entity_entry.config_entry_id}_coordinator"
-                coordinator = hass.data[DOMAIN].get(coordinator_key)
-                if coordinator:
-                    await coordinator.async_request_refresh()
-        else:
-            # Refresh all entities
-            entity_registry = er.async_get(hass)
-            entities = [e for e in entity_registry.entities.values() if e.platform == DOMAIN]
-
-            seen_entries: set[str] = set()
-            for entity_entry in entities:
-                entry_id = entity_entry.config_entry_id
-                if entry_id and entry_id not in seen_entries:
-                    seen_entries.add(entry_id)
-                    coordinator_key = f"{entry_id}_coordinator"
-                    coordinator = hass.data[DOMAIN].get(coordinator_key)
-                    if coordinator:
-                        await coordinator.async_request_refresh()
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_REFRESH,
-        handle_refresh,
-        schema=SERVICE_REFRESH_SCHEMA,
-    )
-
-    # Register trip planning service
-    async def handle_plan_trip(call: ServiceCall) -> dict:
-        """Handle the plan_trip service call."""
-        provider = call.data["provider"]
-        origin = call.data["origin"]
-        origin_city = call.data["origin_city"]
-        destination = call.data["destination"]
-        destination_city = call.data["destination_city"]
-
-        # Look up credentials from an existing config entry for this provider
-        # Trip entries store "trip_provider", departure entries store "provider"
-        api_key = None
-        custom_url = None
-        for existing in hass.config_entries.async_entries(DOMAIN):
-            ep = existing.data.get(CONF_PROVIDER) or existing.data.get("trip_provider")
-            if ep == provider:
-                if provider == PROVIDER_VBN_OTP:
-                    api_key = existing.data.get(CONF_VBN_API_KEY)
-                elif provider == PROVIDER_OPT:
-                    api_key = existing.data.get(CONF_OPT_API_KEY)
-                elif provider == PROVIDER_OTP_CUSTOM:
-                    api_key = existing.data.get(CONF_OTP_CUSTOM_API_KEY)
-                    custom_url = existing.data.get(CONF_OTP_BASE_URL)
-                break
-
-        journeys = await async_plan_trip(
-            hass,
-            provider,
-            origin,
-            origin_city,
-            destination,
-            destination_city,
-            api_key=api_key,
-            custom_url=custom_url,
-        )
-
-        return {"journeys": journeys or []}
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_PLAN_TRIP,
-        handle_plan_trip,
-        schema=SERVICE_PLAN_TRIP_SCHEMA,
-        supports_response=True,
-    )
-
-    # Register delay check service
-    async def handle_check_delays(call: ServiceCall) -> dict:
-        """Check delays and return delayed departures."""
-        entity_id = call.data["entity_id"]
-        threshold = call.data.get("delay_threshold", 5)
-        line_filter = call.data.get("line", "").strip().lower()
-
-        state_obj = hass.states.get(entity_id)
-        if not state_obj:
-            return {"delayed": [], "count": 0}
-
-        departures = state_obj.attributes.get("departures", [])
-        delayed = []
-        for dep in departures:
-            if not isinstance(dep, dict):
-                continue
-            delay = dep.get("delay", 0)
-            line = dep.get("line", "")
-            if delay >= threshold:
-                if not line_filter or line.lower() == line_filter:
-                    delayed.append(dep)
-
-        # Fire event if delays found
-        if delayed:
-            hass.bus.async_fire(
-                f"{DOMAIN}_delay_alert",
-                {
-                    "entity_id": entity_id,
-                    "delayed_count": len(delayed),
-                    "max_delay": max(d.get("delay", 0) for d in delayed),
-                    "lines": list({d.get("line", "") for d in delayed}),
-                    "departures": delayed[:5],
-                },
-            )
-
-        return {"delayed": delayed, "count": len(delayed)}
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_CHECK_DELAYS,
-        handle_check_delays,
-        schema=SERVICE_CHECK_DELAYS_SCHEMA,
-        supports_response=True,
-    )
-
-    # Register TTS announcement service
-    async def handle_announce(call: ServiceCall) -> dict:
-        """Generate and optionally speak a departure announcement."""
-        entity_id = call.data["entity_id"]
-        index = call.data.get("index", 0)
-        tts_service = call.data.get("tts_service")
-        media_player = call.data.get("media_player")
-        language = call.data.get("language", "de")
-
-        state_obj = hass.states.get(entity_id)
-        if not state_obj:
-            return {"text": "Keine Abfahrtsinformationen verfügbar."}
-
-        departures = state_obj.attributes.get("departures", [])
-        if not departures or index >= len(departures):
-            return {"text": "Keine Abfahrten verfügbar."}
-
-        dep = departures[index]
-        line = dep.get("line", "")
-        destination = dep.get("destination", "")
-        planned_time = dep.get("planned_time", "")
-        minutes = dep.get("minutes_until_departure", 0)
-        platform = dep.get("platform", "")
-        delay = dep.get("delay", 0)
-        transport_type = dep.get("transportation_type", "")
-
-        # Build station-style announcement
-        if language == "de":
-            # German: DB-style announcement
-            type_name = {
-                "train": "Zug",
-                "subway": "U-Bahn",
-                "tram": "Straßenbahn",
-                "bus": "Bus",
-                "ferry": "Fähre",
-            }.get(transport_type, "")
-
-            text = "Achtung, eine Durchsage. "
-
-            if type_name:
-                text += f"{type_name} {line}"
-            else:
-                text += f"Linie {line}"
-
-            text += f" Richtung {destination}"
-
-            if planned_time:
-                text += f", planmäßige Abfahrt {planned_time} Uhr"
-
-            if delay > 0:
-                text += f", hat heute circa {delay} Minuten Verspätung"
-
-            if platform:
-                text += f", Abfahrt von Gleis {platform}"
-
-            if minutes <= 0:
-                text += ". Bitte einsteigen, Türen schließen selbsttätig."
-            elif minutes <= 2:
-                text += ". Bitte begeben Sie sich zum Bahnsteig."
-            else:
-                text += f". Abfahrt in {minutes} Minuten."
-        else:
-            # English
-            text = f"Attention please. {line} to {destination}"
-            if planned_time:
-                text += f", scheduled departure {planned_time}"
-            if delay > 0:
-                text += f", is delayed by approximately {delay} minutes"
-            if platform:
-                text += f", departing from platform {platform}"
-            if minutes <= 0:
-                text += ". Please board now."
-            else:
-                text += f". Departing in {minutes} minutes."
-
-        # Optionally speak via TTS service
-        if tts_service and media_player:
-            try:
-                service_parts = tts_service.split(".", 1)
-                if len(service_parts) == 2:
-                    service_data = {
-                        "entity_id": media_player,
-                        "message": text,
-                    }
-                    await hass.services.async_call(
-                        service_parts[0],
-                        service_parts[1],
-                        service_data,
-                    )
-            except Exception as e:
-                _LOGGER.warning("Failed to call TTS service: %s", e)
-
-        return {"text": text}
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_ANNOUNCE,
-        handle_announce,
-        schema=SERVICE_ANNOUNCE_SCHEMA,
-        supports_response=True,
     )
 
     return True

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -79,6 +79,9 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         self._trip_destination: Optional[Dict[str, Any]] = None
         self._trip_search_phase: str = "origin"  # "origin" or "destination"
 
+        # Temp stop results — instance variable instead of hass.data to avoid cross-flow leaks
+        self._found_stops: list[dict] = []
+
         # API response cache to avoid duplicate requests
         self._search_cache: Dict[str, Dict[str, Any]] = {}
         self._cache_ttl: int = 300  # Cache TTL in seconds (5 minutes)
@@ -487,7 +490,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             # User selected a stop from dropdown
             selected_id = user_input.get("stop")
             if selected_id:
-                for stop in self.hass.data.get(f"{DOMAIN}_temp_stops", []):
+                for stop in self._found_stops:
                     if isinstance(stop, dict) and stop.get("id") == selected_id:
                         self._selected_stop = stop
                         return await self.async_step_settings()
@@ -503,7 +506,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     _LOGGER.error("Search returned invalid type: %s", type(stops))
                     cache_key = self._get_cache_key(self._provider, search_term, "stop")
                     self._search_cache.pop(cache_key, None)
-                    self.hass.data.pop(f"{DOMAIN}_temp_stops", None)
+                    self._found_stops = []
                     errors["stop_search"] = "api_error"
                 elif not stops:
                     errors["stop_search"] = "no_results"
@@ -512,7 +515,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     return await self.async_step_settings()
                 else:
                     # Store results and show selection step
-                    self.hass.data[f"{DOMAIN}_temp_stops"] = stops
+                    self._found_stops = stops
                     self._last_search_term = search_term
                     return await self.async_step_stop_select()
 
@@ -538,11 +541,11 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             selected_id = user_input.get("stop")
             if selected_id == "__search_again__":
                 # User wants to search again
-                self.hass.data.pop(f"{DOMAIN}_temp_stops", None)
+                self._found_stops = []
                 return await self.async_step_stop_search()
 
             if selected_id:
-                for stop in self.hass.data.get(f"{DOMAIN}_temp_stops", []):
+                for stop in self._found_stops:
                     if isinstance(stop, dict) and stop.get("id") == selected_id:
                         self._selected_stop = stop
                         return await self.async_step_settings()
@@ -550,10 +553,10 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             return await self.async_step_settings()
 
         # Load stops from temporary storage
-        stops = self.hass.data.get(f"{DOMAIN}_temp_stops", [])
+        stops = self._found_stops
 
         if not isinstance(stops, list) or not stops:
-            self.hass.data.pop(f"{DOMAIN}_temp_stops", None)
+            self._found_stops = []
             return await self.async_step_stop_search()
 
         # Build dropdown: "Haltestellenname, Ort" format
@@ -683,8 +686,8 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             title = f"{(self._provider or '').upper()} {place} - {name}".strip()
 
             # Cleanup temp data
-            self.hass.data.pop(f"{DOMAIN}_temp_locations", None)
-            self.hass.data.pop(f"{DOMAIN}_temp_stops", None)
+
+            self._found_stops = []
 
             return self.async_create_entry(title=title, data=data)
 
@@ -1364,7 +1367,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                         self._trip_destination = stops[0]
                         return await self.async_step_trip_settings()
                 else:
-                    self.hass.data[f"{DOMAIN}_temp_stops"] = stops
+                    self._found_stops = stops
                     self._last_search_term = search_term
                     return await self.async_step_trip_select()
 
@@ -1389,25 +1392,25 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         if user_input is not None:
             selected_id = user_input.get("stop")
             if selected_id == "__search_again__":
-                self.hass.data.pop(f"{DOMAIN}_temp_stops", None)
+                self._found_stops = []
                 return await self.async_step_trip_search()
 
             if selected_id:
-                for stop in self.hass.data.get(f"{DOMAIN}_temp_stops", []):
+                for stop in self._found_stops:
                     if isinstance(stop, dict) and stop.get("id") == selected_id:
                         if self._trip_search_phase == "origin":
                             self._trip_origin = stop
                             self._trip_search_phase = "destination"
-                            self.hass.data.pop(f"{DOMAIN}_temp_stops", None)
+                            self._found_stops = []
                             return await self.async_step_trip_search()
                         else:
                             self._trip_destination = stop
-                            self.hass.data.pop(f"{DOMAIN}_temp_stops", None)
+                            self._found_stops = []
                             return await self.async_step_trip_settings()
 
             return await self.async_step_trip_search()
 
-        stops = self.hass.data.get(f"{DOMAIN}_temp_stops", [])
+        stops = self._found_stops
         if not isinstance(stops, list) or not stops:
             return await self.async_step_trip_search()
 
@@ -1484,7 +1487,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
 
             title = f"{(self._provider or '').upper()} {origin.get('name', '')} → {dest.get('name', '')}"
 
-            self.hass.data.pop(f"{DOMAIN}_temp_stops", None)
+            self._found_stops = []
             return self.async_create_entry(title=title, data=data)
 
         origin_name = self._trip_origin.get("name", "") if self._trip_origin else ""

--- a/custom_components/openpublictransport/multi_stop.py
+++ b/custom_components/openpublictransport/multi_stop.py
@@ -67,11 +67,8 @@ class MultiStopSensor(SensorEntity):
         self.hass = hass
         self._config_entry = config_entry
         self._source_entities = source_entities
-        self._unsub_listeners: list = []
-
         self._attr_unique_id = f"multi_stop_{config_entry.entry_id}"
         self._attr_name = name
-
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"multi_stop_{config_entry.entry_id}")},
             name=name,
@@ -87,17 +84,10 @@ class MultiStopSensor(SensorEntity):
             self._update_from_sources()
             self.async_write_ha_state()
 
-        for entity_id in self._source_entities:
-            self._unsub_listeners.append(async_track_state_change_event(self.hass, entity_id, _state_changed))
+        self.async_on_remove(async_track_state_change_event(self.hass, self._source_entities, _state_changed))
 
         # Initial update
         self._update_from_sources()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Remove listeners."""
-        for unsub in self._unsub_listeners:
-            unsub()
-        self._unsub_listeners.clear()
 
     def _update_from_sources(self) -> None:
         """Merge departures from all source entities."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -49,6 +49,8 @@ async def test_refresh_service(hass: HomeAssistant, mock_config_entry: ConfigEnt
     # mock_config_entry already added to hass in fixture
 
     # Mock the coordinator's first refresh to avoid real API calls
+    await async_setup(hass, {})
+
     with patch(
         "custom_components.openpublictransport.PublicTransportDataUpdateCoordinator.async_refresh",
         new_callable=AsyncMock,
@@ -59,5 +61,5 @@ async def test_refresh_service(hass: HomeAssistant, mock_config_entry: ConfigEnt
         ):
             await async_setup_entry(hass, mock_config_entry)
 
-            # Verify service is registered
+            # Services are registered in async_setup, not async_setup_entry
             assert hass.services.has_service(DOMAIN, "refresh_departures")


### PR DESCRIPTION
## Summary

- **Task 2 (action-setup):** All 4 service handlers moved from \`async_setup_entry\` → \`async_setup\`. Services are now registered once per HA start, not re-registered per config entry.
- **Task 7 (common-modules):** Config flow temp stop storage replaced — \`hass.data[f\"{DOMAIN}_temp_stops\"]\` → \`self._found_stops\` instance variable. Fixes potential cross-flow leaks. Also englishes the provider credential names.
- **Task 9 (entity-event-setup):** \`MultiStopSensor\` now uses \`self.async_on_remove()\` for event listener cleanup instead of manual \`_unsub_listeners\` list + \`async_will_remove_from_hass\`.

## Test plan

- [x] 84/84 tests pass
- [x] Black + isort clean
- [ ] Smoke test: add a multi-stop sensor in HA, verify it updates and cleans up on removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)