### PR TITLE
feat: Bronze Quality Scale — Task 6 (has_entity_name)

### DIFF
--- a/custom_components/openpublictransport/binary_sensor.py
+++ b/custom_components/openpublictransport/binary_sensor.py
@@ -52,6 +52,7 @@ class PublicTransportDelayBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Binary sensor for public transport delays."""
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -72,12 +73,14 @@ class PublicTransportDelayBinarySensor(CoordinatorEntity, BinarySensorEntity):
         place_dm = coordinator.place_dm
         name_dm = coordinator.name_dm
 
-        self._attr_unique_id = f"{provider}_{station_id or f'{place_dm}_{name_dm}'.lower().replace(' ', '_')}_delays"
-        self._attr_name = f"{provider.upper()} {place_dm} - {name_dm} Delays"
+        station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
+        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
+        self._attr_unique_id = f"{provider}_{station_key}_delays"
+        self._attr_name = "Delays"
 
-        # Device info - same device as sensor
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{provider}_{station_id or f'{place_dm}_{name_dm}'.lower().replace(' ', '_')}")},
+            identifiers={(DOMAIN, f"{provider}_{station_key}")},
+            name=device_name,
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/calendar.py
+++ b/custom_components/openpublictransport/calendar.py
@@ -39,6 +39,8 @@ async def async_setup_entry(
 class DepartureCalendar(CoordinatorEntity, CalendarEntity):
     """Calendar entity showing departures as events."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: PublicTransportDataUpdateCoordinator,
@@ -55,11 +57,13 @@ class DepartureCalendar(CoordinatorEntity, CalendarEntity):
         name_dm = coordinator.name_dm
         station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
 
+        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
         self._attr_unique_id = f"{provider}_{station_key}_calendar"
-        self._attr_name = f"{provider.upper()} {place_dm} - {name_dm} Departures"
+        self._attr_name = "Schedule"
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{provider}_{station_key}")},
+            name=device_name,
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/camera.py
+++ b/custom_components/openpublictransport/camera.py
@@ -174,6 +174,7 @@ class DepartureBoardCamera(CoordinatorEntity, Camera):
     """Camera entity rendering a departure board image."""
 
     _attr_is_streaming = False
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -193,11 +194,13 @@ class DepartureBoardCamera(CoordinatorEntity, Camera):
         station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
 
         self._station_name = f"{place_dm} - {name_dm}" if place_dm else name_dm
+        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
         self._attr_unique_id = f"{provider}_{station_key}_board"
-        self._attr_name = f"{provider.upper()} {place_dm} - {name_dm} Board"
+        self._attr_name = "Board"
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{provider}_{station_key}")},
+            name=device_name,
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/event.py
+++ b/custom_components/openpublictransport/event.py
@@ -39,6 +39,7 @@ class DisruptionEventEntity(CoordinatorEntity, EventEntity):
     """Event entity that fires when new disruption notices appear."""
 
     _attr_event_types = ["disruption", "platform_change", "info"]
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -56,11 +57,13 @@ class DisruptionEventEntity(CoordinatorEntity, EventEntity):
         name_dm = coordinator.name_dm
         station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
 
+        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
         self._attr_unique_id = f"{provider}_{station_key}_disruptions"
-        self._attr_name = f"{provider.upper()} {place_dm} - {name_dm} Disruptions"
+        self._attr_name = "Disruptions"
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{provider}_{station_key}")},
+            name=device_name,
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/multi_stop.py
+++ b/custom_components/openpublictransport/multi_stop.py
@@ -55,6 +55,7 @@ class MultiStopSensor(SensorEntity):
     """Sensor combining departures from multiple stops."""
 
     _attr_icon = "mdi:map-marker-multiple"
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -68,7 +69,7 @@ class MultiStopSensor(SensorEntity):
         self._config_entry = config_entry
         self._source_entities = source_entities
         self._attr_unique_id = f"multi_stop_{config_entry.entry_id}"
-        self._attr_name = name
+        self._attr_name = None  # device name IS the entity name
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"multi_stop_{config_entry.entry_id}")},
             name=name,

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -282,6 +282,7 @@ async def async_setup_entry(
 
 
 class MultiProviderSensor(CoordinatorEntity, SensorEntity):
+    _attr_has_entity_name = True
     """Sensor für VRR/KVV/HVV using DataUpdateCoordinator."""
 
     def __init__(
@@ -330,7 +331,7 @@ class MultiProviderSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{provider}_{station_key}"
         agency_name = coordinator.agency_name
         display_name = f"{agency_name} - {name_dm}" if agency_name else name_dm
-        self._attr_name = display_name
+        self._attr_name = None  # device name IS the entity name
 
         # Device info
         self._attr_device_info = DeviceInfo(

--- a/custom_components/openpublictransport/statistics.py
+++ b/custom_components/openpublictransport/statistics.py
@@ -44,6 +44,7 @@ class PunctualitySensor(CoordinatorEntity, SensorEntity):
     """Sensor tracking punctuality statistics per line."""
 
     _attr_icon = "mdi:chart-line"
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -60,12 +61,14 @@ class PunctualitySensor(CoordinatorEntity, SensorEntity):
         name_dm = coordinator.name_dm
         station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
 
+        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
         self._attr_unique_id = f"{provider}_{station_key}_statistics"
-        self._attr_name = f"{provider.upper()} {place_dm} - {name_dm} Statistics"
+        self._attr_name = "Punctuality"
         self._attr_native_unit_of_measurement = "%"
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{provider}_{station_key}")},
+            name=device_name,
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -155,6 +155,8 @@ async def async_setup_entry(
 class TripSensor(CoordinatorEntity, SensorEntity):
     """Sensor showing the next best trip from A to B."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: TripDataUpdateCoordinator,
@@ -172,7 +174,7 @@ class TripSensor(CoordinatorEntity, SensorEntity):
         provider = coordinator.provider
 
         self._attr_unique_id = f"{provider}_trip_{origin_city}_{origin}_{dest_city}_{dest}".lower().replace(" ", "_")
-        self._attr_name = f"{provider.upper()} {origin}, {origin_city} → {dest}, {dest_city}"
+        self._attr_name = None  # device name IS the entity name
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},


### PR DESCRIPTION
## Summary

Implements the \`has-entity-name\` Bronze Quality Scale rule across all 8 entity classes.

- \`_attr_has_entity_name = True\` added to every entity
- \`_attr_name\` shortened to suffix only (e.g. \`"Delays"\`, \`"Schedule"\`, \`"Board"\`)
- \`DeviceInfo.name\` now carries the full station identity on secondary entities too
- Primary entities (main sensor, trip sensor, multi-stop) use \`_attr_name = None\` so the device name IS the entity name

**Before:** entity named \`VRR Düsseldorf - Elbruchstraße Delays\`
**After:** device \`Elbruchstraße\`, entity \`Delays\` → displayed as \`Elbruchstraße Delays\`

## Test plan

- [x] 84/84 tests pass on Python 3.12–3.14
- [x] Black + isort clean
- [ ] In HA dev instance: verify entity names in UI look correct (device card shows short names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)