### PR TITLE
feat: Bronze Quality Scale — Task 12 (test-before-configure)

### DIFF
--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -329,12 +329,29 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             if not url:
                 errors[CONF_OTP_BASE_URL] = "otp_url_required"
             else:
-                self._otp_custom_url = url
-                self._api_key = user_input.get(CONF_OTP_CUSTOM_API_KEY, "").strip() or None
-                if self._entry_type == "trip":
-                    self._trip_search_phase = "origin"
-                    return await self.async_step_trip_search()
-                return await self.async_step_stop_search()
+                api_key = user_input.get(CONF_OTP_CUSTOM_API_KEY, "").strip() or None
+                # Health-check: verify the OTP instance is reachable before proceeding
+                try:
+                    session = async_get_clientsession(self.hass)
+                    headers = {"Accept": "application/json"}
+                    if api_key:
+                        headers["X-API-Key"] = api_key
+                    health_url = f"{url.rstrip('/')}/index"
+                    async with session.get(
+                        health_url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)
+                    ) as resp:
+                        if resp.status not in (200, 204):
+                            errors[CONF_OTP_BASE_URL] = "cannot_connect"
+                except Exception:
+                    errors[CONF_OTP_BASE_URL] = "cannot_connect"
+
+                if not errors:
+                    self._otp_custom_url = url
+                    self._api_key = api_key
+                    if self._entry_type == "trip":
+                        self._trip_search_phase = "origin"
+                        return await self.async_step_trip_search()
+                    return await self.async_step_stop_search()
 
         schema = vol.Schema(
             {
@@ -459,7 +476,49 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         if self._entry_type == "trip":
             self._trip_search_phase = "origin"
             return await self.async_step_trip_search()
+        if self._provider == PROVIDER_NTA_IE:
+            return await self.async_step_nta_stop_id()
         return await self.async_step_stop_search()
+
+    async def async_step_nta_stop_id(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
+        """NTA: accept manual stop ID and validate connectivity before proceeding."""
+        errors: Dict[str, str] = {}
+
+        if user_input is not None:
+            station_id = user_input.get(CONF_STATION_ID, "").strip()
+            if not station_id:
+                errors[CONF_STATION_ID] = "station_id_required"
+            else:
+                # Validate: attempt a minimal GTFS-RT fetch to confirm key + reachability
+                try:
+                    session = async_get_clientsession(self.hass)
+                    provider_instance = get_provider(
+                        PROVIDER_NTA_IE,
+                        session,
+                        api_key=self._api_key,
+                        api_key_secondary=self._api_key_secondary,
+                    )
+                    if provider_instance:
+                        await provider_instance.fetch_departures(station_id, "", station_id, 1)
+                except Exception:
+                    errors["base"] = "cannot_connect"
+
+                if not errors:
+                    self._selected_stop = {"id": station_id, "name": station_id, "place": ""}
+                    return await self.async_step_settings()
+
+        schema = vol.Schema({vol.Required(CONF_STATION_ID): str})
+        return self.async_show_form(
+            step_id="nta_stop_id",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={
+                "info": (
+                    "NTA stop IDs look like 8250DB002011. "
+                    "Find your stop ID at developer.nationaltransport.ie or in the GTFS Static feed."
+                )
+            },
+        )
 
     async def async_step_stop_search(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
         """Handle combined stop search and selection step.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 """Tests for OpenPublicTransport config flow with simplified 2-step flow."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant import config_entries
@@ -14,6 +14,7 @@ from custom_components.openpublictransport.const import (
     CONF_PROVIDER,
     CONF_RMV_API_KEY,
     CONF_SCAN_INTERVAL,
+    CONF_STATION_ID,
     CONF_TRAFIKLAB_API_KEY,
     CONF_TRANSPORTATION_TYPES,
     CONF_VBN_API_KEY,
@@ -275,15 +276,45 @@ async def test_stop_search_api_error(hass: HomeAssistant):
 
 
 async def test_otp_custom_url_flow(hass: HomeAssistant):
-    """OTP Custom provider asks for URL first, then proceeds to stop_search."""
+    """OTP Custom provider asks for URL, health-checks it, then proceeds to stop_search."""
     result = await _init_flow(hass)
     result = await _select_provider(hass, result["flow_id"], provider=PROVIDER_OTP_CUSTOM)
     assert result["step_id"] == "otp_custom_url"
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_OTP_BASE_URL: "http://192.168.1.10:8080/otp/routers/default"}
-    )
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "custom_components.openpublictransport.config_flow.async_get_clientsession"
+    ) as mock_get_session:
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_get_session.return_value = mock_session
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_OTP_BASE_URL: "http://192.168.1.10:8080/otp/routers/default"}
+        )
     assert result["step_id"] == "stop_search"
+
+
+async def test_otp_custom_url_cannot_connect(hass: HomeAssistant):
+    """OTP Custom URL health-check failure shows cannot_connect error."""
+    result = await _init_flow(hass)
+    result = await _select_provider(hass, result["flow_id"], provider=PROVIDER_OTP_CUSTOM)
+    assert result["step_id"] == "otp_custom_url"
+
+    with patch(
+        "custom_components.openpublictransport.config_flow.async_get_clientsession"
+    ) as mock_get_session:
+        mock_session = MagicMock()
+        mock_session.get.side_effect = Exception("connection refused")
+        mock_get_session.return_value = mock_session
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_OTP_BASE_URL: "http://192.168.1.10:8080/otp/routers/default"}
+        )
+    assert result["step_id"] == "otp_custom_url"
+    assert result["errors"][CONF_OTP_BASE_URL] == "cannot_connect"
 
 
 async def test_trafiklab_api_key_flow(hass: HomeAssistant):
@@ -331,18 +362,62 @@ async def test_vbn_otp_api_key_flow(hass: HomeAssistant):
 
 
 async def test_nta_api_key_flow(hass: HomeAssistant):
-    """NTA requires primary+optional secondary key, then shows manual stop ID field."""
+    """NTA API key → nta_stop_id step → validate → settings."""
+    with patch("homeassistant.config_entries.ConfigEntries.async_forward_entry_setups", return_value=True):
+        result = await _init_flow(hass)
+        result = await _select_provider(hass, result["flow_id"], provider=PROVIDER_NTA_IE)
+        assert result["step_id"] == "api_key"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_NTA_API_KEY: "nta-primary-key"}
+        )
+        assert result["step_id"] == "nta_stop_id"
+
+        # Submit stop ID with mocked validation
+        with (
+            patch(
+                "custom_components.openpublictransport.config_flow.get_provider",
+            ) as mock_get_provider,
+            patch(
+                "custom_components.openpublictransport.PublicTransportDataUpdateCoordinator.async_config_entry_first_refresh",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.fetch_departures = AsyncMock(return_value={"stopEvents": []})
+            mock_get_provider.return_value = mock_provider
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], user_input={CONF_STATION_ID: "8250DB002011"}
+            )
+            assert result["step_id"] == "settings"
+
+            result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=_SETTINGS)
+            assert result["type"] == FlowResultType.CREATE_ENTRY
+            assert result["data"][CONF_STATION_ID] == "8250DB002011"
+
+
+async def test_nta_stop_id_cannot_connect(hass: HomeAssistant):
+    """NTA stop ID validation failure shows cannot_connect error."""
     result = await _init_flow(hass)
     result = await _select_provider(hass, result["flow_id"], provider=PROVIDER_NTA_IE)
-    assert result["step_id"] == "api_key"
-
-    # NTA has primary + secondary key fields
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_NTA_API_KEY: "nta-primary-key"},
+        result["flow_id"], user_input={CONF_NTA_API_KEY: "nta-bad-key"}
     )
-    # NTA skips stop search (no GTFS Static) → goes to stop_search with manual ID input
-    assert result["step_id"] == "stop_search"
+    assert result["step_id"] == "nta_stop_id"
+
+    with patch(
+        "custom_components.openpublictransport.config_flow.get_provider"
+    ) as mock_get_provider:
+        mock_provider = AsyncMock()
+        mock_provider.fetch_departures = AsyncMock(side_effect=Exception("401 Unauthorized"))
+        mock_get_provider.return_value = mock_provider
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_STATION_ID: "BADSTOP"}
+        )
+    assert result["step_id"] == "nta_stop_id"
+    assert result["errors"]["base"] == "cannot_connect"
 
 
 async def test_trip_flow_happy_path(hass: HomeAssistant):


### PR DESCRIPTION
## Summary

Implements connectivity validation before config entry creation for two providers that skip stop search:

**NTA (Ireland):**
- New `async_step_nta_stop_id` step — user enters stop ID manually (NTA has no GTFS Static search)
- Validates by making a minimal GTFS-RT fetch before proceeding to settings
- Shows `cannot_connect` error if API key or stop ID is invalid

**OTP Custom:**
- Health-check against `{base_url}/index` after URL submission
- Shows `cannot_connect` error on the URL field if server is unreachable

## Test plan

- [x] 96/96 tests pass on Python 3.12–3.14
- [x] Black + isort clean
- [ ] Manual: test NTA flow with valid stop ID (e.g. `8250DB002011`)
- [ ] Manual: test OTP Custom with valid/invalid URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)