### PR TITLE
feat: Silver IQS — action-exceptions, log-when-unavailable, parallel-updates, reauthentication-flow

### DIFF
--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.components.application_credentials import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
@@ -146,11 +147,13 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         if entity_id:
             entity_registry = er.async_get(hass)
             entity_entry = entity_registry.async_get(entity_id)
-            if entity_entry and entity_entry.platform == DOMAIN:
-                entry = hass.config_entries.async_get_entry(entity_entry.config_entry_id)
-                coordinator = getattr(entry, "runtime_data", None) if entry else None
-                if coordinator:
-                    await coordinator.async_request_refresh()
+            if not entity_entry or entity_entry.platform != DOMAIN:
+                raise ServiceValidationError(f"Entity {entity_id} not found or not part of {DOMAIN}")
+            entry = hass.config_entries.async_get_entry(entity_entry.config_entry_id)
+            coordinator = getattr(entry, "runtime_data", None) if entry else None
+            if not coordinator:
+                raise HomeAssistantError(f"No coordinator found for {entity_id}")
+            await coordinator.async_request_refresh()
         else:
             entity_registry = er.async_get(hass)
             entities = [e for e in entity_registry.entities.values() if e.platform == DOMAIN]
@@ -194,7 +197,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
             api_key=api_key,
             custom_url=custom_url,
         )
-        return {"journeys": journeys or []}
+        if journeys is None:
+            raise HomeAssistantError(f"Trip planning failed for provider '{provider}' — check logs for details")
+        return {"journeys": journeys}
 
     async def handle_check_delays(call: ServiceCall) -> dict:
         """Check delays and return delayed departures."""
@@ -203,7 +208,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         line_filter = call.data.get("line", "").strip().lower()
         state_obj = hass.states.get(entity_id)
         if not state_obj:
-            return {"delayed": [], "count": 0}
+            raise ServiceValidationError(f"Entity {entity_id} not found")
         departures = state_obj.attributes.get("departures", [])
         delayed = []
         for dep in departures:
@@ -236,10 +241,12 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         language = call.data.get("language", "de")
         state_obj = hass.states.get(entity_id)
         if not state_obj:
-            return {"text": "Keine Abfahrtsinformationen verfügbar."}
+            raise ServiceValidationError(f"Entity {entity_id} not found")
         departures = state_obj.attributes.get("departures", [])
-        if not departures or index >= len(departures):
-            return {"text": "Keine Abfahrten verfügbar."}
+        if not departures:
+            raise ServiceValidationError(f"No departure data available for {entity_id}")
+        if index >= len(departures):
+            raise ServiceValidationError(f"Index {index} out of range — only {len(departures)} departure(s) available")
         dep = departures[index]
         line = dep.get("line", "")
         destination = dep.get("destination", "")

--- a/custom_components/openpublictransport/binary_sensor.py
+++ b/custom_components/openpublictransport/binary_sensor.py
@@ -27,7 +27,7 @@ from .const import (
 )
 from .sensor import PublicTransportDataUpdateCoordinator
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/custom_components/openpublictransport/binary_sensor.py
+++ b/custom_components/openpublictransport/binary_sensor.py
@@ -27,6 +27,8 @@ from .const import (
 )
 from .sensor import PublicTransportDataUpdateCoordinator
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/openpublictransport/calendar.py
+++ b/custom_components/openpublictransport/calendar.py
@@ -19,6 +19,7 @@ from homeassistant.util import dt as dt_util
 from .const import CONF_TRANSPORTATION_TYPES, DOMAIN, TRANSPORTATION_TYPES
 from .sensor import PublicTransportDataUpdateCoordinator
 
+PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/openpublictransport/calendar.py
+++ b/custom_components/openpublictransport/calendar.py
@@ -19,7 +19,7 @@ from homeassistant.util import dt as dt_util
 from .const import CONF_TRANSPORTATION_TYPES, DOMAIN, TRANSPORTATION_TYPES
 from .sensor import PublicTransportDataUpdateCoordinator
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/openpublictransport/camera.py
+++ b/custom_components/openpublictransport/camera.py
@@ -21,6 +21,7 @@ from PIL import Image, ImageDraw, ImageFont
 from .const import CONF_TRANSPORTATION_TYPES, DOMAIN, TRANSPORTATION_TYPES
 from .sensor import PublicTransportDataUpdateCoordinator
 
+PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
 
 # Board styling

--- a/custom_components/openpublictransport/camera.py
+++ b/custom_components/openpublictransport/camera.py
@@ -21,7 +21,7 @@ from PIL import Image, ImageDraw, ImageFont
 from .const import CONF_TRANSPORTATION_TYPES, DOMAIN, TRANSPORTATION_TYPES
 from .sensor import PublicTransportDataUpdateCoordinator
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 # Board styling

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -1615,6 +1615,120 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             description_placeholders={"hint": hint},
         )
 
+    async def async_step_reauth(self, entry_data: dict) -> FlowResult:
+        """Handle re-authentication when an API key expires or is rotated."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        self._provider = entry_data.get(CONF_PROVIDER) or entry_data.get("trip_provider")
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: Optional[Dict[str, Any]] = None) -> FlowResult:
+        """Show re-authentication form and update credentials on submit."""
+        errors: Dict[str, str] = {}
+        entry = self._reauth_entry
+
+        if user_input is not None:
+            new_data = dict(entry.data)
+
+            if self._provider == PROVIDER_TRAFIKLAB_SE:
+                api_key = user_input.get(CONF_TRAFIKLAB_API_KEY, "").strip()
+                if not api_key:
+                    errors[CONF_TRAFIKLAB_API_KEY] = "trafiklab_api_key_required"
+                else:
+                    new_data[CONF_TRAFIKLAB_API_KEY] = api_key
+                    self._api_key = api_key
+            elif self._provider == PROVIDER_RMV:
+                api_key = user_input.get(CONF_RMV_API_KEY, "").strip()
+                if not api_key:
+                    errors[CONF_RMV_API_KEY] = "rmv_api_key_required"
+                else:
+                    new_data[CONF_RMV_API_KEY] = api_key
+                    self._api_key = api_key
+            elif self._provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
+                api_key = user_input.get(CONF_VBN_API_KEY, "").strip()
+                if not api_key:
+                    errors[CONF_VBN_API_KEY] = "vbn_api_key_required"
+                else:
+                    new_data[CONF_VBN_API_KEY] = api_key
+                    self._api_key = api_key
+            elif self._provider == PROVIDER_NTA_IE:
+                api_key = user_input.get(CONF_NTA_API_KEY, "").strip()
+                secondary = user_input.get(CONF_NTA_API_KEY_SECONDARY, "").strip()
+                if not api_key:
+                    errors[CONF_NTA_API_KEY] = "nta_api_key_required"
+                else:
+                    new_data[CONF_NTA_API_KEY] = api_key
+                    if secondary:
+                        new_data[CONF_NTA_API_KEY_SECONDARY] = secondary
+                    self._api_key = api_key
+                    self._api_key_secondary = secondary or None
+            elif self._provider == PROVIDER_OPT:
+                api_key = user_input.get(CONF_OPT_API_KEY, "").strip()
+                if not api_key:
+                    errors[CONF_OPT_API_KEY] = "opt_api_key_required"
+                else:
+                    new_data[CONF_OPT_API_KEY] = api_key
+                    self._api_key = api_key
+            elif self._provider == PROVIDER_OTP_CUSTOM:
+                api_key = user_input.get(CONF_OTP_CUSTOM_API_KEY, "").strip()
+                base_url = user_input.get(CONF_OTP_BASE_URL, "").strip()
+                if base_url:
+                    new_data[CONF_OTP_BASE_URL] = base_url
+                if api_key:
+                    new_data[CONF_OTP_CUSTOM_API_KEY] = api_key
+                self._api_key = api_key or None
+
+            if not errors:
+                if self._api_key:
+                    await self._async_store_credential(self._provider)
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data=new_data,
+                    reason="reauth_successful",
+                )
+
+        # Build provider-specific schema pre-filled with current key
+        if self._provider == PROVIDER_TRAFIKLAB_SE:
+            schema = vol.Schema(
+                {vol.Required(CONF_TRAFIKLAB_API_KEY, default=entry.data.get(CONF_TRAFIKLAB_API_KEY, "")): str}
+            )
+            description = "Trafiklab API key expired or invalid. Get a new one at trafiklab.se."
+        elif self._provider == PROVIDER_RMV:
+            schema = vol.Schema({vol.Required(CONF_RMV_API_KEY, default=entry.data.get(CONF_RMV_API_KEY, "")): str})
+            description = "RMV API key expired or invalid. Request a new one at opendata.rmv.de."
+        elif self._provider in (PROVIDER_VBN_OTP, PROVIDER_VBN_TRIAS):
+            schema = vol.Schema({vol.Required(CONF_VBN_API_KEY, default=entry.data.get(CONF_VBN_API_KEY, "")): str})
+            description = "VBN API key expired or invalid. Request a new key at api@vbn.de."
+        elif self._provider == PROVIDER_NTA_IE:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_NTA_API_KEY, default=entry.data.get(CONF_NTA_API_KEY, "")): str,
+                    vol.Optional(
+                        CONF_NTA_API_KEY_SECONDARY, default=entry.data.get(CONF_NTA_API_KEY_SECONDARY, "")
+                    ): str,
+                }
+            )
+            description = "NTA API key expired or invalid. Get new keys at developer.nationaltransport.ie."
+        elif self._provider == PROVIDER_OPT:
+            schema = vol.Schema({vol.Required(CONF_OPT_API_KEY, default=entry.data.get(CONF_OPT_API_KEY, "")): str})
+            description = "openpublictransport.net API key expired or invalid. Request a new key at openpublictransport.net/api-key."
+        elif self._provider == PROVIDER_OTP_CUSTOM:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_OTP_BASE_URL, default=entry.data.get(CONF_OTP_BASE_URL, "")): str,
+                    vol.Optional(CONF_OTP_CUSTOM_API_KEY, default=entry.data.get(CONF_OTP_CUSTOM_API_KEY, "")): str,
+                }
+            )
+            description = "OTP2 server URL or API key changed. Enter the new values."
+        else:
+            return self.async_abort(reason="no_reauth_needed")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"info": description},
+        )
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):

--- a/custom_components/openpublictransport/event.py
+++ b/custom_components/openpublictransport/event.py
@@ -18,6 +18,7 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 from .sensor import PublicTransportDataUpdateCoordinator
 
+PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/openpublictransport/event.py
+++ b/custom_components/openpublictransport/event.py
@@ -18,7 +18,7 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 from .sensor import PublicTransportDataUpdateCoordinator
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,7 +14,7 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "bronze",
   "requirements": [
-    "python-openpublictransport==0.1.2",
+    "python-openpublictransport==0.1.4",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],

--- a/custom_components/openpublictransport/quality_scale.yaml
+++ b/custom_components/openpublictransport/quality_scale.yaml
@@ -29,6 +29,7 @@ rules:
   integration_owner: done
   log_when_unavailable: done
   parallel_updates: done
+  reauthentication_flow: done
   docs_configuration_parameters:
     status: exempt
     comment: Documentation is available at https://docs.openpublictransport.net

--- a/custom_components/openpublictransport/quality_scale.yaml
+++ b/custom_components/openpublictransport/quality_scale.yaml
@@ -1,4 +1,5 @@
 rules:
+  action_exceptions: done
   action_setup: done
   appropriate_polling: done
   brands: done
@@ -23,3 +24,14 @@ rules:
   test_before_configure: done
   test_before_setup: done
   unique_config_entry: done
+  config_entry_unloading: done
+  entity_unavailable: done
+  integration_owner: done
+  log_when_unavailable: done
+  parallel_updates: done
+  docs_configuration_parameters:
+    status: exempt
+    comment: Documentation is available at https://docs.openpublictransport.net
+  docs_installation_parameters:
+    status: exempt
+    comment: Documentation is available at https://docs.openpublictransport.net

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -35,6 +35,7 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+PARALLEL_UPDATES = 1
 INTEGRATION_VERSION = json.loads((Path(__file__).parent / "manifest.json").read_text()).get("version", "unknown")
 
 
@@ -191,14 +192,15 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
             data = await self._fetch_departures()
             if data and isinstance(data, dict):
                 self._api_calls_today += 1
-                # Clear API error repair issue on successful fetch
+                if not self.last_update_success:
+                    _LOGGER.info("%s: connection re-established", self.provider)
                 ir.async_delete_issue(self.hass, DOMAIN, f"api_error_{self.provider}")
-                # Adjust polling interval based on results
                 has_departures = bool(data.get("stopEvents"))
                 self._adjust_polling_interval(has_departures)
                 return data
             else:
-                # Create repair issue for invalid API response
+                if self.last_update_success:
+                    _LOGGER.warning("%s: invalid or empty API response — will retry", self.provider)
                 ir.async_create_issue(
                     self.hass,
                     DOMAIN,
@@ -206,15 +208,14 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
                     is_fixable=False,
                     severity=ir.IssueSeverity.ERROR,
                     translation_key="api_error",
-                    translation_placeholders={
-                        "provider": self.provider.upper(),
-                    },
+                    translation_placeholders={"provider": self.provider.upper()},
                 )
                 raise UpdateFailed("Invalid or empty API response")
         except UpdateFailed:
             raise
         except Exception as err:
-            # Create repair issue for API errors
+            if self.last_update_success:
+                _LOGGER.warning("%s: unavailable (%s) — will retry", self.provider, err)
             ir.async_create_issue(
                 self.hass,
                 DOMAIN,
@@ -222,9 +223,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
                 is_fixable=False,
                 severity=ir.IssueSeverity.ERROR,
                 translation_key="api_error",
-                translation_placeholders={
-                    "provider": self.provider.upper(),
-                },
+                translation_placeholders={"provider": self.provider.upper()},
             )
             raise UpdateFailed(f"Error fetching data: {err}")
 

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
@@ -211,6 +212,8 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
                     translation_placeholders={"provider": self.provider.upper()},
                 )
                 raise UpdateFailed("Invalid or empty API response")
+        except ConfigEntryAuthFailed:
+            raise
         except UpdateFailed:
             raise
         except Exception as err:

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -35,7 +35,7 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 INTEGRATION_VERSION = json.loads((Path(__file__).parent / "manifest.json").read_text()).get("version", "unknown")
 
 

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
-from openpublictransport import get_provider
+from openpublictransport import AuthenticationError, get_provider
 
 from .const import (
     API_RATE_LIMIT_PER_DAY,
@@ -214,6 +214,8 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
                 raise UpdateFailed("Invalid or empty API response")
         except ConfigEntryAuthFailed:
             raise
+        except AuthenticationError as err:
+            raise ConfigEntryAuthFailed(str(err)) from err
         except UpdateFailed:
             raise
         except Exception as err:

--- a/custom_components/openpublictransport/statistics.py
+++ b/custom_components/openpublictransport/statistics.py
@@ -20,7 +20,7 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 from .sensor import PublicTransportDataUpdateCoordinator
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/openpublictransport/statistics.py
+++ b/custom_components/openpublictransport/statistics.py
@@ -20,6 +20,7 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 from .sensor import PublicTransportDataUpdateCoordinator
 
+PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/openpublictransport/strings.json
+++ b/custom_components/openpublictransport/strings.json
@@ -116,6 +116,20 @@
         "data": {
           "scan_interval": "Update-Intervall (Sekunden)"
         }
+      },
+      "reauth_confirm": {
+        "title": "API-Schlüssel erneuern",
+        "description": "{info}",
+        "data": {
+          "trafiklab_api_key": "Trafiklab API-Schlüssel",
+          "rmv_api_key": "RMV API-Schlüssel",
+          "vbn_api_key": "VBN API-Schlüssel",
+          "nta_api_key": "NTA API-Schlüssel (primär)",
+          "nta_api_key_secondary": "NTA API-Schlüssel (sekundär, optional)",
+          "opt_api_key": "API-Schlüssel",
+          "otp_base_url": "OTP2-Server-URL",
+          "otp_custom_api_key": "API-Schlüssel (optional)"
+        }
       }
     },
     "error": {
@@ -129,6 +143,10 @@
       "nta_api_key_required": "NTA API-Schlüssel ist erforderlich",
       "rmv_api_key_required": "RMV API-Schlüssel ist erforderlich",
       "min_two_entities": "Bitte mindestens 2 Entity-IDs angeben"
+    },
+    "abort": {
+      "reauth_successful": "API-Schlüssel erfolgreich aktualisiert.",
+      "no_reauth_needed": "Dieser Anbieter benötigt keine Authentifizierung."
     }
   },
   "options": {

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -26,7 +26,7 @@ from .const import (
 )
 from .trip import async_plan_trip
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 CONF_TRIP_ORIGIN = "trip_origin"

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -26,6 +26,7 @@ from .const import (
 )
 from .trip import async_plan_trip
 
+PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
 
 CONF_TRIP_ORIGIN = "trip_origin"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ pytest-cov>=4.1.0
 pytest-homeassistant-custom-component>=0.13.0
 homeassistant>=2024.1.0
 aiofiles>=23.0.0
-python-openpublictransport>=0.1.2
+python-openpublictransport>=0.1.4


### PR DESCRIPTION
## Summary

Implements all remaining quick-win Silver IQS rules plus full reauthentication support.

### action-exceptions
Service handlers now raise `ServiceValidationError` / `HomeAssistantError` on invalid input instead of silently failing:
- `refresh_departures`: raises if entity_id not found
- `plan_trip`: raises if trip planning returns no result
- `check_delays`: raises if entity not found
- `announce_departure`: raises on invalid entity or out-of-range index

### log-when-unavailable
Coordinator logs **once** on first failure (WARNING) and **once** on recovery (INFO) — no repeated log spam on consecutive failures.

### parallel-updates
`PARALLEL_UPDATES = 0` added to all 7 coordinator-based read-only platform files (sensor, binary_sensor, calendar, event, camera, statistics, trip_sensor).

### reauthentication-flow
Full reauth flow via HA UI:
- `async_step_reauth` + `async_step_reauth_confirm` for all API-key providers (Trafiklab, RMV, NTA, VBN, OPT, OTP Custom)
- `ConfigEntryAuthFailed` is raised automatically when a provider returns HTTP 401/403 (via `AuthenticationError` from `python-openpublictransport==0.1.4`)
- Pre-filled form with current key, updates `config_entry.data` + Application Credentials store on submit
- `strings.json`: `reauth_confirm` step + abort reasons

### quality_scale.yaml
Marks `action_exceptions`, `config_entry_unloading`, `entity_unavailable`, `integration_owner`, `log_when_unavailable`, `parallel_updates`, `reauthentication_flow`, `docs_configuration_parameters`, `docs_installation_parameters` as done/exempt.

## Requires
`python-openpublictransport==0.1.4` — surfaces HTTP 401/403 as `AuthenticationError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)