### PR TITLE
chore: bump version to 2026.6.8

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.7"
+  "version": "2026.6.8"
 }


### PR DESCRIPTION
Version bump for release.