### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -9,16 +9,13 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   validate:
     runs-on: ubuntu-latest
     name: Validate HACS
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: HACS Action
         uses: hacs/action@main

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,19 +9,16 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint and Code Quality
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -52,7 +49,7 @@ jobs:
     name: Hassfest Validation
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Hassfest
         uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,16 +7,13 @@ on:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   release:
     runs-on: ubuntu-latest
     name: Prepare Release
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.target_commitish }}
 
@@ -26,11 +23,6 @@ jobs:
           zip -r ../../openpublictransport.zip .
 
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
+        run: gh release upload "${{ github.event.release.tag_name }}" openpublictransport.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./openpublictransport.zip
-          asset_name: openpublictransport.zip
-          asset_content_type: application/zip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install system dependencies
+        run: sudo apt-get install -y libturbojpeg0-dev
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,9 +9,6 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,10 +19,10 @@ jobs:
     name: Test with Python ${{ matrix.python-version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -42,7 +39,7 @@ jobs:
           pytest tests/ -v --cov=custom_components/openpublictransport --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
+          flags: python${{ matrix.python-version }}
+          name: python-${{ matrix.python-version }}
         continue-on-error: true

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,9 +14,9 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.4",
+    "python-openpublictransport==0.1.5",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.8"
+  "version": "2026.6.11"
 }

--- a/custom_components/openpublictransport/quality_scale.yaml
+++ b/custom_components/openpublictransport/quality_scale.yaml
@@ -81,3 +81,9 @@ rules:
   reconfiguration_flow: done
   repair_issues: done
   stale_devices: done
+  # Platinum (strict_typing deferred)
+  async_dependency: done
+  inject_websession: done
+  strict_typing:
+    status: todo
+    comment: Deferred — HA integration boundary errors require significant effort

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,5 @@ pytest-cov>=4.1.0
 pytest-homeassistant-custom-component>=0.13.0
 homeassistant>=2024.1.0
 aiofiles>=23.0.0
-python-openpublictransport>=0.1.4
+python-openpublictransport>=0.1.5
+PyTurboJPEG>=1.7.0

--- a/tests/test_config_flow_flows.py
+++ b/tests/test_config_flow_flows.py
@@ -519,3 +519,47 @@ async def test_reauth_vbn_empty_key_shows_error(hass: HomeAssistant):
     )
     assert result2["type"] == "form"
     assert "vbn_api_key_required" in str(result2.get("errors", {}))
+
+
+# ── reconfigure flow ───────────────────────────────────────────────────────────
+
+async def test_reconfigure_initiates_stop_search(hass: HomeAssistant):
+    """Test reconfigure flow sets _reconfiguring and jumps to stop_search."""
+    from custom_components.openpublictransport.const import PROVIDER_VRR
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROVIDER: PROVIDER_VRR,
+            CONF_STATION_ID: "de:05111:21",
+            "place_dm": "Düsseldorf",
+            "name_dm": "Hauptbahnhof",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "reconfigure", "entry_id": entry.entry_id},
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "stop_search"
+
+
+async def test_reconfigure_no_entry_still_shows_stop_search(hass: HomeAssistant):
+    """Test reconfigure falls through to stop_search even if entry lookup fails."""
+    from custom_components.openpublictransport.const import PROVIDER_VRR
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_PROVIDER: PROVIDER_VRR, CONF_STATION_ID: "de:05111:21",
+              "place_dm": "Düsseldorf", "name_dm": "Hbf"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "reconfigure", "entry_id": entry.entry_id},
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "stop_search"

--- a/tests/test_init_coverage.py
+++ b/tests/test_init_coverage.py
@@ -170,3 +170,49 @@ async def test_async_setup_entry_calls_coordinator_refresh(hass: HomeAssistant):
             result = await async_setup_entry(hass, entry)
 
     assert result is True
+
+
+async def test_async_remove_config_entry_device_stale(hass: HomeAssistant):
+    """Test stale device (different identifier) can be removed."""
+    from custom_components.openpublictransport import async_remove_config_entry_device
+    from custom_components.openpublictransport.const import CONF_STATION_ID, PROVIDER_VRR
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROVIDER: PROVIDER_VRR,
+            CONF_STATION_ID: "de:05111:21",
+            "place_dm": "Düsseldorf",
+            "name_dm": "Hauptbahnhof",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    stale_device = MagicMock()
+    stale_device.identifiers = {(DOMAIN, "vrr_old_station_key")}
+
+    result = await async_remove_config_entry_device(hass, entry, stale_device)
+    assert result is True
+
+
+async def test_async_remove_config_entry_device_current(hass: HomeAssistant):
+    """Test current device cannot be removed."""
+    from custom_components.openpublictransport import async_remove_config_entry_device
+    from custom_components.openpublictransport.const import CONF_STATION_ID, PROVIDER_VRR
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROVIDER: PROVIDER_VRR,
+            CONF_STATION_ID: "de:05111:21",
+            "place_dm": "Düsseldorf",
+            "name_dm": "Hauptbahnhof",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    current_device = MagicMock()
+    current_device.identifiers = {(DOMAIN, "vrr_de:05111:21")}
+
+    result = await async_remove_config_entry_device(hass, entry, current_device)
+    assert result is False


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → **v6** — Node 24, eliminates deprecation warning
- `actions/setup-python` v5 → **v6** — Node 24
- `codecov/codecov-action` v4 → **v5** — Node 24
- `actions/upload-release-asset@v1` → **`gh release upload`** — action is archived/deprecated, CLI is the recommended replacement
- Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` — no longer needed with updated actions

## Test plan

- [ ] CI passes on this PR (all checks green)
- [ ] No more "Node.js 20 is deprecated" warnings in action logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)