### PR TITLE
fix: diagnostics page crashes with AttributeError: last_update_success_time

### DIFF
--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -82,6 +82,8 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
             config_entry.data.get(CONF_NTA_API_KEY_SECONDARY) if config_entry and provider == PROVIDER_NTA_IE else None
         )
 
+        self.last_update_success_time: Optional[datetime] = None
+
         # Provider is initialized lazily on first update to avoid creating
         # an aiohttp session (and its thread pool) before any data is fetched.
         self.provider_instance = None
@@ -193,6 +195,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
             data = await self._fetch_departures()
             if data and isinstance(data, dict):
                 self._api_calls_today += 1
+                self.last_update_success_time = dt_util.now()
                 if not self.last_update_success:
                     _LOGGER.info("%s: connection re-established", self.provider)
                 ir.async_delete_issue(self.hass, DOMAIN, f"api_error_{self.provider}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ def mock_coordinator(mock_api_response):
     coordinator = MagicMock()
     coordinator.data = mock_api_response
     coordinator.last_update_success = True
+    coordinator.last_update_success_time = None
     coordinator.provider = PROVIDER_VRR
     coordinator.place_dm = "Düsseldorf"
     coordinator.name_dm = "Hauptbahnhof"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -26,6 +26,8 @@ async def test_diagnostics(hass: HomeAssistant, mock_config_entry, mock_coordina
     # Verify API stats are included
     assert "api_calls_today" in diagnostics["coordinator"]
     assert "last_update_success" in diagnostics["coordinator"]
+    assert "last_update_success_time" in diagnostics["coordinator"]
+    assert diagnostics["coordinator"]["last_update_success_time"] is None
 
 
 async def test_diagnostics_no_coordinator(hass: HomeAssistant, mock_config_entry):


### PR DESCRIPTION
## Summary

- Fixes #27 — opening the diagnostics page threw a 500 due to `AttributeError: 'PublicTransportDataUpdateCoordinator' object has no attribute 'last_update_success_time'`
- Adds `self.last_update_success_time: Optional[datetime] = None` to `PublicTransportDataUpdateCoordinator.__init__`
- Stamps it with `dt_util.now()` on every successful data fetch in `_async_update_data`
- Updates `mock_coordinator` fixture and adds assertion in `test_diagnostics.py` to cover the new field

## Test plan

- [x] `pytest tests/test_diagnostics.py -v` — 2 passed
- [ ] Open diagnostics page on a live HA instance and confirm no 500 error
- [ ] Confirm `last_update_success_time` appears as ISO timestamp (or `null` before first successful fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)