### PR TITLE
fix(ci): rename deprecated codecov file param to files

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: python${{ matrix.python-version }}
           name: python-${{ matrix.python-version }}
         continue-on-error: true


### PR DESCRIPTION
## Summary

- `codecov/codecov-action@v5` dropped the `file` input; the correct name is `files`
- Every CI run was producing an annotation warning: `Unexpected input(s) 'file'`
- One-character rename, no functional change

## Note

The `Node.js 20` deprecation warning is emitted by `home-assistant/actions/hassfest@master` and `hacs/action@main` internally — not something we control. Will go away once those upstream actions update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)