### PR TITLE
docs: update installation guide for HACS Default store

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,13 @@ Real-time public transport departures for Home Assistant — 28 providers across
 ### Install via HACS
 
 1. Open **HACS** → **Integrations**
-2. Click the three dots → **Custom repositories**
-3. Add `https://github.com/NerdySoftPaw/openpublictransport` (category: Integration)
-4. Search for **"Public Transport Departures"** and install
-5. Restart Home Assistant
+2. Search for **"OpenPublicTransport"** and click **Download**
+3. Restart Home Assistant
 
 ### Configure
 
 1. **Settings** → **Devices & Services** → **Add Integration**
-2. Search for **"Public Transport Departures"**
+2. Search for **"OpenPublicTransport"**
 3. Pick your provider, search for your stop, done
 
 No YAML needed. Setup takes under 2 minutes.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,12 +13,8 @@
 
 1. Open HACS in Home Assistant
 2. Go to **Integrations**
-3. Click the three dots in the top right and select **Custom repositories**
-4. Add this repository URL: `https://github.com/NerdySoftPaw/openpublictransport`
-5. Select **Integration** as category
-6. Click **Add**
-7. Search for "Public" and install the integration
-8. Restart Home Assistant
+3. Search for **"OpenPublicTransport"** and click **Download**
+4. Restart Home Assistant
 
 !!! tip
     After installation, the integration will appear in your list of available integrations.
@@ -68,7 +64,7 @@ After restarting Home Assistant:
 
 1. Go to **Settings** > **Devices & Services**
 2. Click **+ Add Integration**
-3. Search for "Public Transport Departures"
+3. Search for "OpenPublicTransport"
 
 If the integration appears in the list, installation was successful.
 


### PR DESCRIPTION
## Summary

- Remove the "add custom repository" steps — integration is now in the official HACS Default store
- Update HACS search name to **"OpenPublicTransport"** (matches `hacs.json`) in README and `docs/installation.md`
- HACS steps trimmed from 5 → 3 (README) and 8 → 4 (docs)
- Manual installation section stays untouched

## Test plan

- [ ] HACS steps in README render correctly on GitHub
- [ ] `docs/installation.md` renders correctly in MkDocs
- [ ] "OpenPublicTransport" is the correct search term in the HACS store

🤖 Generated with [Claude Code](https://claude.com/claude-code)