### PR TITLE
chore: bump version to 2026.6.13

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.11"
+  "version": "2026.6.13"
 }


### PR DESCRIPTION
Version bump for the HACS Default store celebration release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)