### PR TITLE
feat: add destination filter option for departures (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Real-time public transport departures for Home Assistant — 28 providers across
 - **Reconfigure without re-setup** — change your station anytime via ⚙️ → Reconfigure
 - **Walking time** — hides departures you can't reach on foot
 - **Fuzzy stop search** — handles typos and umlaut variations
-- **Line filtering & favorites** — show only the lines you use
+- **Line & destination filtering & favorites** — show only the lines or directions you use
 - **Departure board camera** — classic yellow-on-black station display
 - **7 languages** — DE, EN, FR, NL, PL, IT, SV
 - **Custom Lovelace card** — [openpublictransport-card](https://github.com/NerdySoftPaw/openpublictransport-card) with table, compact, and trip layouts

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -25,6 +25,7 @@ from openpublictransport import get_provider, get_provider_class
 from .const import (
     CONF_DELAY_THRESHOLD,
     CONF_DEPARTURES,
+    CONF_DESTINATION_FILTER,
     CONF_FAVORITE_LINES,
     CONF_LINE_FILTER,
     CONF_NTA_API_KEY,
@@ -669,6 +670,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     int, vol.Range(min=1, max=30)
                 ),
                 vol.Optional(CONF_LINE_FILTER, default=""): str,
+                vol.Optional(CONF_DESTINATION_FILTER, default=""): str,
                 vol.Optional(CONF_FAVORITE_LINES, default=""): str,
                 vol.Optional(CONF_WALKING_TIME, default=0): vol.All(int, vol.Range(min=0, max=30)),
             }
@@ -1801,6 +1803,10 @@ class OpenPublicTransportOptionsFlowHandler(config_entries.OptionsFlow):
             CONF_LINE_FILTER,
             self.config_entry.data.get(CONF_LINE_FILTER, ""),
         )
+        current_destination_filter = self.config_entry.options.get(
+            CONF_DESTINATION_FILTER,
+            self.config_entry.data.get(CONF_DESTINATION_FILTER, ""),
+        )
         current_walking_time = self.config_entry.options.get(
             CONF_WALKING_TIME,
             self.config_entry.data.get(CONF_WALKING_TIME, 0),
@@ -1820,6 +1826,7 @@ class OpenPublicTransportOptionsFlowHandler(config_entries.OptionsFlow):
                     int, vol.Range(min=1, max=30)
                 ),
                 vol.Optional(CONF_LINE_FILTER, default=current_line_filter): str,
+                vol.Optional(CONF_DESTINATION_FILTER, default=current_destination_filter): str,
                 vol.Optional(
                     CONF_FAVORITE_LINES,
                     default=self.config_entry.options.get(

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -16,6 +16,7 @@ CONF_NTA_API_KEY_SECONDARY = "nta_api_key_secondary"  # For NTA Ireland API (Sec
 CONF_USE_PROVIDER_LOGO = "use_provider_logo"  # Show provider logo instead of transport icon
 CONF_DELAY_THRESHOLD = "delay_threshold"  # Minutes threshold for delay binary sensor
 CONF_LINE_FILTER = "line_filter"  # Comma-separated line numbers to show
+CONF_DESTINATION_FILTER = "destination_filter"  # Comma-separated destinations (substring match) to show
 CONF_WALKING_TIME = "walking_time"  # Minutes to walk to the stop
 CONF_FAVORITE_LINES = "favorite_lines"  # Comma-separated favorite lines (shown first)
 DEFAULT_DELAY_THRESHOLD = 5

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.13"
+  "version": "2026.6.14"
 }

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -19,6 +19,7 @@ from openpublictransport import AuthenticationError, get_provider
 from .const import (
     API_RATE_LIMIT_PER_DAY,
     CONF_DEPARTURES,
+    CONF_DESTINATION_FILTER,
     CONF_FAVORITE_LINES,
     CONF_LINE_FILTER,
     CONF_NTA_API_KEY_SECONDARY,
@@ -311,6 +312,14 @@ class MultiProviderSensor(CoordinatorEntity, SensorEntity):
             {line.strip().lower() for line in line_filter_str.split(",") if line.strip()} if line_filter_str else set()
         )
 
+        # Get destination filter from options/data (substring match, case-insensitive)
+        dest_filter_str = config_entry.options.get(
+            CONF_DESTINATION_FILTER, config_entry.data.get(CONF_DESTINATION_FILTER, "")
+        )
+        self._destination_filter: list[str] = (
+            [d.strip().lower() for d in dest_filter_str.split(",") if d.strip()] if dest_filter_str else []
+        )
+
         # Get favorite lines from options/data
         fav_str = config_entry.options.get(CONF_FAVORITE_LINES, config_entry.data.get(CONF_FAVORITE_LINES, ""))
         self._favorite_lines: set[str] = (
@@ -507,8 +516,13 @@ class MultiProviderSensor(CoordinatorEntity, SensorEntity):
             dep = provider_instance.parse_departure(stop, tz, now)
             # Filter by configured transportation types and line filter
             if dep and dep.transportation_type in transport_types_set:
-                if not self._line_filter or dep.line.lower() in self._line_filter:
-                    departures.append(dep)
+                if self._line_filter and dep.line.lower() not in self._line_filter:
+                    continue
+                if self._destination_filter and not any(
+                    term in (dep.destination or "").lower() for term in self._destination_filter
+                ):
+                    continue
+                departures.append(dep)
 
         # Sort: favorites first (by time), then rest (by time)
         if self._favorite_lines:

--- a/custom_components/openpublictransport/strings.json
+++ b/custom_components/openpublictransport/strings.json
@@ -74,6 +74,7 @@
           "use_provider_logo": "Anbieter-Logo anzeigen",
           "delay_threshold": "Verspätungs-Schwellwert (Minuten)",
           "line_filter": "Linien-Filter",
+          "destination_filter": "Ziel-Filter",
           "walking_time": "Fußweg (Minuten)",
           "favorite_lines": "Favoriten-Linien"
         },
@@ -84,6 +85,7 @@
           "use_provider_logo": "Zeige das Anbieter-Logo anstelle des Verkehrsmittel-Icons",
           "delay_threshold": "Ab wie vielen Minuten Verspätung soll der Delay-Sensor auslösen? (1-30)",
           "line_filter": "Nur bestimmte Linien anzeigen, kommagetrennt (z.B. U79, RE5, Bus 42). Leer = alle Linien",
+          "destination_filter": "Nur Abfahrten mit passendem Ziel anzeigen, kommagetrennt, Teiltreffer (z.B. Duisburg, Flughafen). Leer = alle Ziele",
           "walking_time": "Fußweg zur Haltestelle in Minuten (0 = deaktiviert). Abfahrten die nicht mehr erreichbar sind werden ausgeblendet",
           "favorite_lines": "Kommagetrennte Linien, die zuerst angezeigt werden (z.B. U79, RE5). Leer = keine Favoriten"
         }
@@ -161,6 +163,7 @@
           "use_provider_logo": "Anbieter-Logo anzeigen",
           "delay_threshold": "Verspätungs-Schwellwert (Minuten)",
           "line_filter": "Linien-Filter",
+          "destination_filter": "Ziel-Filter",
           "walking_time": "Fußweg (Minuten)",
           "favorite_lines": "Favoriten-Linien"
         },
@@ -168,6 +171,7 @@
           "use_provider_logo": "Zeige das Anbieter-Logo anstelle des Verkehrsmittel-Icons",
           "delay_threshold": "Ab wie vielen Minuten Verspätung soll der Delay-Sensor auslösen? (1-30)",
           "line_filter": "Nur bestimmte Linien anzeigen, kommagetrennt (z.B. U79, RE5, Bus 42). Leer = alle Linien",
+          "destination_filter": "Nur Abfahrten mit passendem Ziel anzeigen, kommagetrennt, Teiltreffer (z.B. Duisburg, Flughafen). Leer = alle Ziele",
           "walking_time": "Fußweg zur Haltestelle in Minuten (0 = deaktiviert). Abfahrten die nicht mehr erreichbar sind werden ausgeblendet",
           "favorite_lines": "Kommagetrennte Linien, die zuerst angezeigt werden (z.B. U79, RE5). Leer = keine Favoriten"
         }

--- a/custom_components/openpublictransport/translations/de.json
+++ b/custom_components/openpublictransport/translations/de.json
@@ -73,6 +73,7 @@
           "use_provider_logo": "Anbieter-Logo anzeigen",
           "delay_threshold": "Verspätungs-Schwellwert (Minuten)",
           "line_filter": "Linien-Filter",
+          "destination_filter": "Ziel-Filter",
           "walking_time": "Fußweg (Minuten)",
           "favorite_lines": "Favoriten-Linien"
         },
@@ -83,6 +84,7 @@
           "use_provider_logo": "Zeige das Anbieter-Logo anstelle des Verkehrsmittel-Icons",
           "delay_threshold": "Ab wie vielen Minuten Verspätung soll der Delay-Sensor auslösen? (1-30)",
           "line_filter": "Nur bestimmte Linien anzeigen, kommagetrennt (z.B. U79, RE5, Bus 42). Leer = alle Linien",
+          "destination_filter": "Nur Abfahrten mit passendem Ziel anzeigen, kommagetrennt, Teiltreffer (z.B. Duisburg, Flughafen). Leer = alle Ziele",
           "walking_time": "Fußweg zur Haltestelle in Minuten (0 = deaktiviert). Abfahrten die nicht mehr erreichbar sind werden ausgeblendet",
           "favorite_lines": "Kommagetrennte Linien, die zuerst angezeigt werden (z.B. U79, RE5). Leer = keine Favoriten"
         }
@@ -142,6 +144,7 @@
           "use_provider_logo": "Anbieter-Logo anzeigen",
           "delay_threshold": "Verspätungs-Schwellwert (Minuten)",
           "line_filter": "Linien-Filter",
+          "destination_filter": "Ziel-Filter",
           "walking_time": "Fußweg (Minuten)",
           "favorite_lines": "Favoriten-Linien"
         },
@@ -149,6 +152,7 @@
           "use_provider_logo": "Zeige das Anbieter-Logo anstelle des Verkehrsmittel-Icons",
           "delay_threshold": "Ab wie vielen Minuten Verspätung soll der Delay-Sensor auslösen? (1-30)",
           "line_filter": "Nur bestimmte Linien anzeigen, kommagetrennt (z.B. U79, RE5, Bus 42). Leer = alle Linien",
+          "destination_filter": "Nur Abfahrten mit passendem Ziel anzeigen, kommagetrennt, Teiltreffer (z.B. Duisburg, Flughafen). Leer = alle Ziele",
           "walking_time": "Fußweg zur Haltestelle in Minuten (0 = deaktiviert). Abfahrten die nicht mehr erreichbar sind werden ausgeblendet",
           "favorite_lines": "Kommagetrennte Linien, die zuerst angezeigt werden (z.B. U79, RE5). Leer = keine Favoriten"
         }

--- a/custom_components/openpublictransport/translations/en.json
+++ b/custom_components/openpublictransport/translations/en.json
@@ -73,6 +73,7 @@
           "use_provider_logo": "Show provider logo",
           "delay_threshold": "Delay threshold (minutes)",
           "line_filter": "Line filter",
+          "destination_filter": "Destination filter",
           "walking_time": "Walking time (minutes)",
           "favorite_lines": "Favorite lines"
         },
@@ -83,6 +84,7 @@
           "use_provider_logo": "Show the provider logo instead of the transport type icon",
           "delay_threshold": "Minimum delay in minutes to trigger the delay sensor (1-30)",
           "line_filter": "Only show specific lines, comma-separated (e.g. U79, RE5, Bus 42). Empty = all lines",
+          "destination_filter": "Show only departures whose destination matches, comma-separated, partial match (e.g. Duisburg, Airport). Empty = all destinations",
           "walking_time": "Walking time to stop in minutes (0 = disabled). Departures that can no longer be reached are hidden",
           "favorite_lines": "Comma-separated lines to show first (e.g. U79, RE5). Empty = no favorites"
         }
@@ -147,6 +149,7 @@
           "use_provider_logo": "Show provider logo",
           "delay_threshold": "Delay threshold (minutes)",
           "line_filter": "Line filter",
+          "destination_filter": "Destination filter",
           "walking_time": "Walking time (minutes)",
           "favorite_lines": "Favorite lines"
         },
@@ -154,6 +157,7 @@
           "use_provider_logo": "Show the provider logo instead of the transport type icon",
           "delay_threshold": "Minimum delay in minutes to trigger the delay sensor (1-30)",
           "line_filter": "Only show specific lines, comma-separated (e.g. U79, RE5, Bus 42). Empty = all lines",
+          "destination_filter": "Show only departures whose destination matches, comma-separated, partial match (e.g. Duisburg, Airport). Empty = all destinations",
           "walking_time": "Walking time to stop in minutes (0 = disabled). Departures that can no longer be reached are hidden",
           "favorite_lines": "Comma-separated lines to show first (e.g. U79, RE5). Empty = no favorites"
         }

--- a/custom_components/openpublictransport/translations/fr.json
+++ b/custom_components/openpublictransport/translations/fr.json
@@ -74,6 +74,7 @@
           "use_provider_logo": "Afficher le logo du fournisseur",
           "delay_threshold": "Seuil de retard (minutes)",
           "line_filter": "Filtre de lignes",
+          "destination_filter": "Filtre de destination",
           "walking_time": "Temps de marche (minutes)",
           "favorite_lines": "Lignes favorites"
         },
@@ -84,6 +85,7 @@
           "use_provider_logo": "Afficher le logo du fournisseur au lieu de l'icône du type de transport",
           "delay_threshold": "Retard minimum en minutes pour déclencher le capteur de retard (1-30)",
           "line_filter": "Afficher uniquement certaines lignes, séparées par des virgules (ex. U79, RE5, Bus 42). Vide = toutes les lignes",
+          "destination_filter": "Afficher uniquement les départs dont la destination correspond, séparés par des virgules, correspondance partielle (ex. Duisburg, Aéroport). Vide = toutes les destinations",
           "walking_time": "Temps de marche jusqu'à l'arrêt en minutes (0 = désactivé). Les départs qui ne peuvent plus être atteints sont masqués",
           "favorite_lines": "Lignes à afficher en premier, séparées par des virgules (ex. U79, RE5). Vide = pas de favoris"
         }
@@ -142,6 +144,7 @@
           "use_provider_logo": "Afficher le logo du fournisseur",
           "delay_threshold": "Seuil de retard (minutes)",
           "line_filter": "Filtre de lignes",
+          "destination_filter": "Filtre de destination",
           "walking_time": "Temps de marche (minutes)",
           "favorite_lines": "Lignes favorites"
         },
@@ -149,6 +152,7 @@
           "use_provider_logo": "Afficher le logo du fournisseur au lieu de l'icône du type de transport",
           "delay_threshold": "Retard minimum en minutes pour déclencher le capteur de retard (1-30)",
           "line_filter": "Afficher uniquement certaines lignes, séparées par des virgules (ex. U79, RE5, Bus 42). Vide = toutes les lignes",
+          "destination_filter": "Afficher uniquement les départs dont la destination correspond, séparés par des virgules, correspondance partielle (ex. Duisburg, Aéroport). Vide = toutes les destinations",
           "walking_time": "Temps de marche jusqu'à l'arrêt en minutes (0 = désactivé). Les départs qui ne peuvent plus être atteints sont masqués",
           "favorite_lines": "Lignes à afficher en premier, séparées par des virgules (ex. U79, RE5). Vide = pas de favoris"
         }

--- a/custom_components/openpublictransport/translations/it.json
+++ b/custom_components/openpublictransport/translations/it.json
@@ -74,6 +74,7 @@
           "use_provider_logo": "Mostra il logo del fornitore",
           "delay_threshold": "Soglia di ritardo (minuti)",
           "line_filter": "Filtro linee",
+          "destination_filter": "Filtro destinazione",
           "walking_time": "Tempo a piedi (minuti)",
           "favorite_lines": "Linee preferite"
         },
@@ -84,6 +85,7 @@
           "use_provider_logo": "Mostra il logo del fornitore al posto dell'icona del tipo di trasporto",
           "delay_threshold": "Ritardo minimo in minuti per attivare il sensore di ritardo (1-30)",
           "line_filter": "Mostra solo linee specifiche, separate da virgole (es. U79, RE5, Bus 42). Vuoto = tutte le linee",
+          "destination_filter": "Mostra solo le partenze con destinazione corrispondente, separate da virgola, corrispondenza parziale (es. Duisburg, Aeroporto). Vuoto = tutte le destinazioni",
           "walking_time": "Tempo a piedi fino alla fermata in minuti (0 = disattivato). Le partenze non più raggiungibili vengono nascoste",
           "favorite_lines": "Linee da mostrare per prime, separate da virgole (es. U79, RE5). Vuoto = nessun preferito"
         }
@@ -142,6 +144,7 @@
           "use_provider_logo": "Mostra il logo del fornitore",
           "delay_threshold": "Soglia di ritardo (minuti)",
           "line_filter": "Filtro linee",
+          "destination_filter": "Filtro destinazione",
           "walking_time": "Tempo a piedi (minuti)",
           "favorite_lines": "Linee preferite"
         },
@@ -149,6 +152,7 @@
           "use_provider_logo": "Mostra il logo del fornitore al posto dell'icona del tipo di trasporto",
           "delay_threshold": "Ritardo minimo in minuti per attivare il sensore di ritardo (1-30)",
           "line_filter": "Mostra solo linee specifiche, separate da virgole (es. U79, RE5, Bus 42). Vuoto = tutte le linee",
+          "destination_filter": "Mostra solo le partenze con destinazione corrispondente, separate da virgola, corrispondenza parziale (es. Duisburg, Aeroporto). Vuoto = tutte le destinazioni",
           "walking_time": "Tempo a piedi fino alla fermata in minuti (0 = disattivato). Le partenze non più raggiungibili vengono nascoste",
           "favorite_lines": "Linee da mostrare per prime, separate da virgole (es. U79, RE5). Vuoto = nessun preferito"
         }

--- a/custom_components/openpublictransport/translations/nl.json
+++ b/custom_components/openpublictransport/translations/nl.json
@@ -74,6 +74,7 @@
           "use_provider_logo": "Logo van aanbieder tonen",
           "delay_threshold": "Vertragingsdrempel (minuten)",
           "line_filter": "Lijnfilter",
+          "destination_filter": "Bestemmingsfilter",
           "walking_time": "Looptijd (minuten)",
           "favorite_lines": "Favoriete lijnen"
         },
@@ -84,6 +85,7 @@
           "use_provider_logo": "Toon het logo van de aanbieder in plaats van het vervoerstypepictogram",
           "delay_threshold": "Minimale vertraging in minuten om de vertragingssensor te activeren (1-30)",
           "line_filter": "Toon alleen specifieke lijnen, gescheiden door komma's (bijv. U79, RE5, Bus 42). Leeg = alle lijnen",
+          "destination_filter": "Toon alleen vertrekken met overeenkomende bestemming, kommagescheiden, gedeeltelijke overeenkomst (bijv. Duisburg, Luchthaven). Leeg = alle bestemmingen",
           "walking_time": "Looptijd naar de halte in minuten (0 = uitgeschakeld). Vertrekken die niet meer gehaald kunnen worden, worden verborgen",
           "favorite_lines": "Lijnen die als eerste worden getoond, gescheiden door komma's (bijv. U79, RE5). Leeg = geen favorieten"
         }
@@ -142,6 +144,7 @@
           "use_provider_logo": "Logo van aanbieder tonen",
           "delay_threshold": "Vertragingsdrempel (minuten)",
           "line_filter": "Lijnfilter",
+          "destination_filter": "Bestemmingsfilter",
           "walking_time": "Looptijd (minuten)",
           "favorite_lines": "Favoriete lijnen"
         },
@@ -149,6 +152,7 @@
           "use_provider_logo": "Toon het logo van de aanbieder in plaats van het vervoerstypepictogram",
           "delay_threshold": "Minimale vertraging in minuten om de vertragingssensor te activeren (1-30)",
           "line_filter": "Toon alleen specifieke lijnen, gescheiden door komma's (bijv. U79, RE5, Bus 42). Leeg = alle lijnen",
+          "destination_filter": "Toon alleen vertrekken met overeenkomende bestemming, kommagescheiden, gedeeltelijke overeenkomst (bijv. Duisburg, Luchthaven). Leeg = alle bestemmingen",
           "walking_time": "Looptijd naar de halte in minuten (0 = uitgeschakeld). Vertrekken die niet meer gehaald kunnen worden, worden verborgen",
           "favorite_lines": "Lijnen die als eerste worden getoond, gescheiden door komma's (bijv. U79, RE5). Leeg = geen favorieten"
         }

--- a/custom_components/openpublictransport/translations/pl.json
+++ b/custom_components/openpublictransport/translations/pl.json
@@ -74,6 +74,7 @@
           "use_provider_logo": "Pokaż logo dostawcy",
           "delay_threshold": "Próg opóźnienia (minuty)",
           "line_filter": "Filtr linii",
+          "destination_filter": "Filtr kierunku",
           "walking_time": "Czas dojścia (minuty)",
           "favorite_lines": "Ulubione linie"
         },
@@ -84,6 +85,7 @@
           "use_provider_logo": "Pokaż logo dostawcy zamiast ikony rodzaju transportu",
           "delay_threshold": "Minimalne opóźnienie w minutach, aby uruchomić czujnik opóźnień (1-30)",
           "line_filter": "Pokaż tylko określone linie, oddzielone przecinkami (np. U79, RE5, Bus 42). Puste = wszystkie linie",
+          "destination_filter": "Pokaż tylko odjazdy z pasującym kierunkiem, oddzielone przecinkami, częściowe dopasowanie (np. Duisburg, Lotnisko). Puste = wszystkie kierunki",
           "walking_time": "Czas dojścia do przystanku w minutach (0 = wyłączone). Odjazdy, na które nie można już zdążyć, są ukrywane",
           "favorite_lines": "Linie wyświetlane na początku, oddzielone przecinkami (np. U79, RE5). Puste = brak ulubionych"
         }
@@ -142,6 +144,7 @@
           "use_provider_logo": "Pokaż logo dostawcy",
           "delay_threshold": "Próg opóźnienia (minuty)",
           "line_filter": "Filtr linii",
+          "destination_filter": "Filtr kierunku",
           "walking_time": "Czas dojścia (minuty)",
           "favorite_lines": "Ulubione linie"
         },
@@ -149,6 +152,7 @@
           "use_provider_logo": "Pokaż logo dostawcy zamiast ikony rodzaju transportu",
           "delay_threshold": "Minimalne opóźnienie w minutach, aby uruchomić czujnik opóźnień (1-30)",
           "line_filter": "Pokaż tylko określone linie, oddzielone przecinkami (np. U79, RE5, Bus 42). Puste = wszystkie linie",
+          "destination_filter": "Pokaż tylko odjazdy z pasującym kierunkiem, oddzielone przecinkami, częściowe dopasowanie (np. Duisburg, Lotnisko). Puste = wszystkie kierunki",
           "walking_time": "Czas dojścia do przystanku w minutach (0 = wyłączone). Odjazdy, na które nie można już zdążyć, są ukrywane",
           "favorite_lines": "Linie wyświetlane na początku, oddzielone przecinkami (np. U79, RE5). Puste = brak ulubionych"
         }

--- a/custom_components/openpublictransport/translations/sv.json
+++ b/custom_components/openpublictransport/translations/sv.json
@@ -74,6 +74,7 @@
           "use_provider_logo": "Visa leverantörens logotyp",
           "delay_threshold": "Försenigströskel (minuter)",
           "line_filter": "Linjefilter",
+          "destination_filter": "Destinationsfilter",
           "walking_time": "Gångtid (minuter)",
           "favorite_lines": "Favoritlinjer"
         },
@@ -84,6 +85,7 @@
           "use_provider_logo": "Visa leverantörens logotyp istället för transporttypens ikon",
           "delay_threshold": "Minsta försening i minuter för att utlösa förseningssensorn (1-30)",
           "line_filter": "Visa bara specifika linjer, kommaseparerade (t.ex. U79, RE5, Bus 42). Tomt = alla linjer",
+          "destination_filter": "Visa endast avgångar med matchande destination, kommaseparerade, delvis matchning (t.ex. Duisburg, Flygplats). Tomt = alla destinationer",
           "walking_time": "Gångtid till hållplatsen i minuter (0 = inaktiverat). Avgångar som inte längre kan nås döljs",
           "favorite_lines": "Linjer som visas först, kommaseparerade (t.ex. U79, RE5). Tomt = inga favoriter"
         }
@@ -142,6 +144,7 @@
           "use_provider_logo": "Visa leverantörens logotyp",
           "delay_threshold": "Försenigströskel (minuter)",
           "line_filter": "Linjefilter",
+          "destination_filter": "Destinationsfilter",
           "walking_time": "Gångtid (minuter)",
           "favorite_lines": "Favoritlinjer"
         },
@@ -149,6 +152,7 @@
           "use_provider_logo": "Visa leverantörens logotyp istället för transporttypens ikon",
           "delay_threshold": "Minsta försening i minuter för att utlösa förseningssensorn (1-30)",
           "line_filter": "Visa bara specifika linjer, kommaseparerade (t.ex. U79, RE5, Bus 42). Tomt = alla linjer",
+          "destination_filter": "Visa endast avgångar med matchande destination, kommaseparerade, delvis matchning (t.ex. Duisburg, Flygplats). Tomt = alla destinationer",
           "walking_time": "Gångtid till hållplatsen i minuter (0 = inaktiverat). Avgångar som inte längre kan nås döljs",
           "favorite_lines": "Linjer som visas först, kommaseparerade (t.ex. U79, RE5). Tomt = inga favoriter"
         }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -241,3 +241,79 @@ async def test_sensor_transportation_type_filtering(hass: HomeAssistant, mock_co
     departures = sensor._attributes.get("departures", [])
     assert len(departures) == 1
     assert departures[0]["transportation_type"] == "tram"
+
+
+async def test_sensor_destination_filtering(hass: HomeAssistant):
+    """Test filtering departures by destination (case-insensitive substring)."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.openpublictransport.const import (
+        CONF_DESTINATION_FILTER,
+        CONF_PROVIDER,
+        CONF_STATION_ID,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Station",
+        data={
+            CONF_PROVIDER: PROVIDER_VRR,
+            "place_dm": "Düsseldorf",
+            "name_dm": "Hauptbahnhof",
+            CONF_STATION_ID: None,
+        },
+        options={CONF_DESTINATION_FILTER: "duisburg"},
+        unique_id="vrr_dest_filter",
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = MagicMock()
+    coordinator.data = {
+        "stopEvents": [
+            {
+                "departureTimePlanned": "2025-01-15T10:00:00Z",
+                "departureTimeEstimated": "2025-01-15T10:00:00Z",
+                "transportation": {
+                    "number": "U79",
+                    "destination": {"name": "Duisburg Hbf"},
+                    "description": "Tram",
+                    "product": {"class": 4, "name": "Tram"},
+                },
+                "platform": {"name": "2"},
+                "realtimeStatus": ["MONITORED"],
+            },
+            {
+                "departureTimePlanned": "2025-01-15T10:05:00Z",
+                "departureTimeEstimated": "2025-01-15T10:05:00Z",
+                "transportation": {
+                    "number": "721",
+                    "destination": {"name": "Krefeld"},
+                    "description": "Bus",
+                    "product": {"class": 5, "name": "Bus"},
+                },
+                "platform": {"name": "5"},
+                "realtimeStatus": ["MONITORED"],
+            },
+        ]
+    }
+    coordinator.last_update_success = True
+    coordinator.provider = PROVIDER_VRR
+    coordinator.place_dm = "Düsseldorf"
+    coordinator.name_dm = "Hauptbahnhof"
+    coordinator.station_id = None
+    coordinator.departures_limit = 10
+
+    from openpublictransport import get_provider
+
+    coordinator.provider_instance = get_provider(PROVIDER_VRR, hass)
+
+    sensor = MultiProviderSensor(coordinator, entry, ["bus", "tram"])
+
+    with patch("custom_components.openpublictransport.sensor.dt_util.now") as mock_now:
+        mock_now.return_value = dt_util.parse_datetime("2025-01-15T09:55:00Z")
+        sensor._process_departure_data(coordinator.data)
+
+    # Only the "Duisburg Hbf" departure matches the "duisburg" substring filter
+    departures = sensor._attributes.get("departures", [])
+    assert len(departures) == 1
+    assert departures[0]["destination"] == "Duisburg Hbf"


### PR DESCRIPTION
## Summary

Adds an optional **destination filter** to the sensor, mirroring the existing line filter. Resolves the request in #32 to show only departures heading toward one direction/destination.

- New `CONF_DESTINATION_FILTER` constant
- `sensor.py`: read the option in `__init__`, apply substring filter in `_process_departure_data`
- `config_flow.py`: exposed in both the setup `settings` step and the `OptionsFlow` (editable after setup, like `line_filter`)
- `strings.json` + all 7 `translations/*.json`: label + description, kept in sync

## Behavior

- Comma-separated, **case-insensitive substring** match (OR).
- Example: `Duisburg, Flughafen` → keeps "Duisburg Hbf", "Duisburg Hbf via Stadtmitte", "Flughafen Terminal 1".
- Empty = show all (no change for existing entries).

## Testing

- Added `test_sensor_destination_filtering`.
- Full sensor + config-flow suite green (30 passed).
- `manifest.json` bumped to `2026.6.14`.
- Pre-release published for manual testing: `v2026.6.14-beta.1`.

## Note

This mirrors the existing `line_filter` behavior exactly: the filter takes effect via the **Options** dialog. The initial-setup `settings` step defines it in the schema but (like `line_filter` today) does not persist filter values to `entry.data` — left unchanged to avoid scope creep, happy to fix separately.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)