### PR TITLE
fix: pass API key to coordinator for Rejseplanen + National Rail (v2026.6.16)

### DIFF
--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -14,12 +14,14 @@ from homeassistant.helpers import entity_registry as er
 
 from .const import (
     CONF_DEPARTURES,
+    CONF_NATIONAL_RAIL_API_KEY,
     CONF_NTA_API_KEY,
     CONF_NTA_API_KEY_SECONDARY,
     CONF_OPT_API_KEY,
     CONF_OTP_BASE_URL,
     CONF_OTP_CUSTOM_API_KEY,
     CONF_PROVIDER,
+    CONF_REJSEPLANEN_API_KEY,
     CONF_RMV_API_KEY,
     CONF_SCAN_INTERVAL,
     CONF_STATION_ID,
@@ -28,9 +30,11 @@ from .const import (
     DEFAULT_DEPARTURES,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    PROVIDER_NATIONAL_RAIL,
     PROVIDER_NTA_IE,
     PROVIDER_OPT,
     PROVIDER_OTP_CUSTOM,
+    PROVIDER_REJSEPLANEN,
     PROVIDER_RMV,
     PROVIDER_TRAFIKLAB_SE,
     PROVIDER_VBN_OTP,
@@ -113,6 +117,8 @@ async def _async_migrate_credential(hass: HomeAssistant, entry: ConfigEntry) -> 
         PROVIDER_VBN_OTP: (CONF_VBN_API_KEY, ""),
         PROVIDER_VBN_TRIAS: (CONF_VBN_API_KEY, ""),
         PROVIDER_NTA_IE: (CONF_NTA_API_KEY, CONF_NTA_API_KEY_SECONDARY),
+        PROVIDER_REJSEPLANEN: (CONF_REJSEPLANEN_API_KEY, ""),
+        PROVIDER_NATIONAL_RAIL: (CONF_NATIONAL_RAIL_API_KEY, ""),
     }
 
     if provider not in key_map:
@@ -344,6 +350,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     vbn_api_key = entry.data.get(CONF_VBN_API_KEY)  # For VBN (OTP + TRIAS)
     opt_api_key = entry.data.get(CONF_OPT_API_KEY)  # For community OTP server
     otp_custom_api_key = entry.data.get(CONF_OTP_CUSTOM_API_KEY)  # For custom OTP instance
+    rejseplanen_api_key = entry.data.get(CONF_REJSEPLANEN_API_KEY)  # For Rejseplanen (DK)
+    national_rail_api_key = entry.data.get(CONF_NATIONAL_RAIL_API_KEY)  # For National Rail (UK)
     otp_custom_url = entry.data.get(CONF_OTP_BASE_URL)  # For custom OTP instance
 
     # Use appropriate API key (and URL) based on provider
@@ -362,6 +370,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     elif provider == PROVIDER_OTP_CUSTOM:
         api_key = otp_custom_api_key
         custom_url = otp_custom_url
+    elif provider == PROVIDER_REJSEPLANEN:
+        api_key = rejseplanen_api_key
+    elif provider == PROVIDER_NATIONAL_RAIL:
+        api_key = national_rail_api_key
 
     departures = entry.options.get(CONF_DEPARTURES, entry.data.get(CONF_DEPARTURES, DEFAULT_DEPARTURES))
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.15"
+  "version": "2026.6.16"
 }

--- a/tests/test_init_api_key_providers.py
+++ b/tests/test_init_api_key_providers.py
@@ -1,0 +1,58 @@
+"""Regression: API-key providers must pass their key to the coordinator at setup.
+
+Rejseplanen and National Rail were added to the config flow but were missing
+from the runtime api_key resolution in async_setup_entry, so the provider was
+instantiated without a key ("API key required"). These tests guard that path.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.openpublictransport import async_setup_entry
+from custom_components.openpublictransport.const import (
+    CONF_NATIONAL_RAIL_API_KEY,
+    CONF_PROVIDER,
+    CONF_REJSEPLANEN_API_KEY,
+    CONF_STATION_ID,
+    DOMAIN,
+    PROVIDER_NATIONAL_RAIL,
+    PROVIDER_REJSEPLANEN,
+)
+
+
+@pytest.mark.parametrize(
+    ("provider", "conf_key"),
+    [
+        (PROVIDER_REJSEPLANEN, CONF_REJSEPLANEN_API_KEY),
+        (PROVIDER_NATIONAL_RAIL, CONF_NATIONAL_RAIL_API_KEY),
+    ],
+)
+async def test_api_key_reaches_coordinator(hass: HomeAssistant, provider, conf_key):
+    """The configured API key must be resolved and handed to the coordinator."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROVIDER: provider,
+            conf_key: "the-secret-key",
+            "place_dm": "",
+            "name_dm": "",
+            CONF_STATION_ID: "8600626",
+        },
+        unique_id=f"{provider}_test",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.openpublictransport.PublicTransportDataUpdateCoordinator.async_config_entry_first_refresh",
+        new_callable=AsyncMock,
+    ), patch(
+        "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
+        new_callable=AsyncMock,
+    ):
+        assert await async_setup_entry(hass, entry) is True
+
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.api_key == "the-secret-key"


### PR DESCRIPTION
## Problem
Nach v2026.6.15 schlägt Rejseplanen (und National Rail) zur Laufzeit fehl:
```
Rejseplanen (Denmark): API key required
rejseplanen: invalid or empty API response — will retry
```
Der config_flow speichert den Key (`CONF_REJSEPLANEN_API_KEY`), aber `async_setup_entry` löst `api_key` über eine `if/elif provider == …`-Kette auf, in der **Rejseplanen und National Rail fehlten** → der Provider wurde mit `api_key=None` instanziiert.

## Fix
- `async_setup_entry`: `api_key` für `PROVIDER_REJSEPLANEN` und `PROVIDER_NATIONAL_RAIL` auflösen
- beide auch in die Application-Credentials-`key_map` aufgenommen
- **Regressionstest** (`test_init_api_key_providers.py`): der konfigurierte Key erreicht den Coordinator (`runtime_data.api_key`) — parametrisiert für beide Provider

## Version
`2026.6.15 → 2026.6.16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)