### PR TITLE
fix(config_flow): persist API key for Rejseplanen + National Rail (v2026.6.17)

### DIFF
--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -772,6 +772,22 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                         errors={"base": "vbn_api_key_required"},
                     )
                 data[CONF_VBN_API_KEY] = self._api_key
+            elif self._provider == PROVIDER_NATIONAL_RAIL:
+                if not self._api_key:
+                    return self.async_show_form(
+                        step_id="settings",
+                        data_schema=schema,
+                        errors={"base": "national_rail_api_key_required"},
+                    )
+                data[CONF_NATIONAL_RAIL_API_KEY] = self._api_key
+            elif self._provider == PROVIDER_REJSEPLANEN:
+                if not self._api_key:
+                    return self.async_show_form(
+                        step_id="settings",
+                        data_schema=schema,
+                        errors={"base": "rejseplanen_api_key_required"},
+                    )
+                data[CONF_REJSEPLANEN_API_KEY] = self._api_key
             elif self._provider == PROVIDER_OPT:
                 if self._api_key:
                     data[CONF_OPT_API_KEY] = self._api_key

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.16"
+  "version": "2026.6.17"
 }

--- a/tests/test_config_flow_apikey_persist.py
+++ b/tests/test_config_flow_apikey_persist.py
@@ -1,0 +1,68 @@
+"""Regression: the API key entered in the config flow must be persisted in the
+entry data for Rejseplanen + National Rail.
+
+Behind the v2026.6.15/.16 "API key required" failures: the settings step built
+the entry data without writing the key for these two providers, so it was never
+stored and never reached the provider at runtime.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.openpublictransport.config_flow import OpenPublicTransportConfigFlow
+from custom_components.openpublictransport.const import (
+    CONF_NATIONAL_RAIL_API_KEY,
+    CONF_PROVIDER,
+    CONF_REJSEPLANEN_API_KEY,
+    CONF_SCAN_INTERVAL,
+    DOMAIN,
+    PROVIDER_NATIONAL_RAIL,
+    PROVIDER_REJSEPLANEN,
+)
+
+
+@pytest.mark.parametrize(
+    ("provider", "conf_key"),
+    [
+        (PROVIDER_REJSEPLANEN, CONF_REJSEPLANEN_API_KEY),
+        (PROVIDER_NATIONAL_RAIL, CONF_NATIONAL_RAIL_API_KEY),
+    ],
+)
+async def test_api_key_persisted_in_entry_data(hass: HomeAssistant, provider, conf_key):
+    """Entering the key in the flow stores it under the provider's CONF_*_API_KEY."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"},
+        data={"entry_type": "departures", CONF_PROVIDER: provider},
+    )
+    assert result["step_id"] == "api_key"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={conf_key: "the-secret-key"}
+    )
+    assert result2["step_id"] == "stop_search"
+
+    one_stop = [{"id": "8600626", "name": "København H", "place": ""}]
+    with patch("custom_components.openpublictransport.config_flow.get_provider") as mock_gp:
+        mock_provider = AsyncMock()
+        mock_provider.search_stops = AsyncMock(return_value=one_stop)
+        mock_gp.return_value = mock_provider
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], user_input={"stop_search": "København"}
+        )
+
+    # A single search result may auto-select (→ settings) or show stop_select.
+    if result3["step_id"] == "stop_select":
+        result3 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"], user_input={"stop": "8600626"}
+        )
+    assert result3["step_id"] == "settings"
+
+    with patch.object(OpenPublicTransportConfigFlow, "_async_store_credential", new_callable=AsyncMock):
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"], user_input={CONF_SCAN_INTERVAL: 60}
+        )
+
+    assert result4["type"] == "create_entry"
+    assert result4["data"].get(conf_key) == "the-secret-key"


### PR DESCRIPTION
## Root cause (the real one)
Rejseplanen/National Rail still failed at runtime with `API key required` after v2026.6.16. Reason: the **config-flow settings step** builds the entry `data` and writes the key per provider (Trafiklab/NTA/RMV/VBN/OPT/OTP) — but had **no branch for Rejseplanen or National Rail**. So the key was *never stored* in the entry, and `async_setup_entry` (fixed in 2026.6.16) read `None`.

This was the missing 3rd of three required wiring points for a new API-key provider (config_flow create-data → async_setup_entry resolve → provider).

## Fix
- settings step now stores `CONF_REJSEPLANEN_API_KEY` / `CONF_NATIONAL_RAIL_API_KEY` in entry data
- **regression test** drives the full flow to `create_entry` and asserts the key is persisted — verified to FAIL without this fix and PASS with it

## Version
`2026.6.16 → 2026.6.17`

🤖 Generated with [Claude Code](https://claude.com/claude-code)