### PR TITLE
chore: bump lib to 0.1.7 — KVV class 6 fix (#34) (v2026.6.18)

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,9 +14,9 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.6",
+    "python-openpublictransport==0.1.7",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.17"
+  "version": "2026.6.18"
 }


### PR DESCRIPTION
Bumps `python-openpublictransport` to **0.1.7**, which fixes **#34**: KVV Regionalbus (`product.class 6`) was mapped to `unknown` and filtered out.

The lib now maps KVV class 6/7 → bus and falls back to the product name for any unmapped EFA class (live-verified against KVV: 0× unknown).

- `manifest.json`: pin `==0.1.7`, version `2026.6.17 → 2026.6.18`

Closes #34.

> Note: `custom_components/openpublictransport/const.py` still contains vestigial `*_TRANSPORTATION_TYPES` maps (KVV/HVV/…) that are unused — the live mapping lives in the lib. A separate cleanup could remove them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)