### PR TITLE
Release 2026.7.1 — National Rail CRS code search (#39)

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,9 +14,9 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.7",
+    "python-openpublictransport==0.1.8",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.6.18"
+  "version": "2026.7.1"
 }


### PR DESCRIPTION
Bumps the bundled library to **python-openpublictransport==0.1.8** and the integration version to **2026.7.1**.

### What this fixes
National Rail (UK) station search now accepts a **3-letter CRS code** (e.g. `WIN`, `RDG`) and matches it directly against the OSM `ref:crs` tag. Previously only station *names* matched, so searching by code returned no results — see #39.

### Notes
- Library 0.1.8 is live on PyPI.
- No integration-side code changes; the fix lives in the library dependency.

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)