### PR TITLE
Release 2026.7.2 — National Rail departure board fix (#39)

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,9 +14,9 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.8",
+    "python-openpublictransport==0.1.9",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.7.1"
+  "version": "2026.7.2"
 }


### PR DESCRIPTION
Bumps the bundled library to **python-openpublictransport==0.1.9** and the integration to **2026.7.2**.

### What this fixes
National Rail departures previously **never loaded** — adding any station produced *"Invalid or empty API response"*, regardless of the API key. Real OpenLDBWS responses use namespace prefixes containing digits (`lt4:`, `lt5:`, `lt7:` …); the library's namespace-stripping step only handled letter-only prefixes, so parsing failed with an `unbound prefix` error and the board came back empty. Fixed in 0.1.9 (verified end-to-end against a real LDBWS response, with a regression test).

### Notes
- The API key was passed through correctly all along — this was purely response parsing.
- Library 0.1.9 is live on PyPI.
- No integration-side code changes.

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)