### PR TITLE
Release 2026.7.3 — National Rail offline search fallback

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,9 +14,9 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.9",
+    "python-openpublictransport==0.1.10",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.7.2"
+  "version": "2026.7.3"
 }

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,7 +14,7 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.10",
+    "python-openpublictransport==0.1.11",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],

--- a/docs/providers/national_rail.md
+++ b/docs/providers/national_rail.md
@@ -86,6 +86,16 @@ partial). Direct CRS-code search requires **integration v2026.7.1 or newer**.
     If a name is ambiguous, add the city (e.g. `Manchester Piccadilly` rather
     than `Piccadilly`).
 
+!!! note "Offline fallback (v2026.7.3+)"
+    The Overpass API is occasionally rate-limited, which can make a search
+    return nothing on the first try. When that happens, the integration falls
+    back to a **bundled offline list** of UK stations so search still works.
+    This snapshot is a point-in-time extract and is **not continuously
+    updated** — a very new or recently renamed station may be missing until
+    the snapshot is refreshed. It is used **only** when the live lookup is
+    unavailable; normally Overpass is queried directly. If a search comes up
+    empty, simply try again in a moment.
+
 ## Transport Types
 
 National Rail is a **train-only** provider — every departure is classified as


### PR DESCRIPTION
Bumps the bundled library to **python-openpublictransport==0.1.10** and the integration to **2026.7.3**.

### What this improves
National Rail station search relies on the live Overpass (OSM) API, which is rate-limited and sometimes returns nothing on the first try (users saw stations intermittently fail to appear — see #39). This adds a **bundled offline snapshot** of UK stations as a fallback: Overpass is still queried first (source of truth), and the snapshot is used **only** when the live lookup is unavailable or empty.

- Library 0.1.10 ships the snapshot (~2,855 stations) as package data.
- The snapshot is a point-in-time extract and is **not continuously updated** — documented on the provider page and logged when used.

### Docs
`docs/providers/national_rail.md` gains a short "Offline fallback" note under Station Search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)