### PR TITLE
trip(otp2): route stop-to-stop via planConnection (stopLocationId), no coordinates

### DIFF
--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -35,32 +35,31 @@ EFA_TRIP_ENDPOINTS = {
     "nwl": "https://westfalenfahrplan.de/nwl-efa/XML_TRIP_REQUEST2",
 }
 
-_GRAPHQL_STOP_COORDS = '{ stop(id: "%s") { lat lon name } }'
-
-_GRAPHQL_PLAN = """{
-  plan(
-    from: { lat: %f, lon: %f, place: "%s" }
-    to: { lat: %f, lon: %f, place: "%s" }
-    date: "%s"
-    time: "%s"
-    numItineraries: 3
+# OTP 2.x planConnection query — routes stop-to-stop via stopLocationId, so no
+# coordinates and no street-network access/egress are needed (works on a
+# transit-only graph). %s = origin id, dest id, optional dateTime clause.
+_GRAPHQL_PLAN_CONNECTION = """{
+  planConnection(
+    origin:      { location: { stopLocation: { stopLocationId: "%s" } } }
+    destination: { location: { stopLocation: { stopLocationId: "%s" } } }
+    %s
+    first: 3
   ) {
-    itineraries {
+    edges { node {
       duration
       numberOfTransfers
       legs {
         mode
-        startTime
-        endTime
+        transitLeg
+        duration
         from { name }
         to   { name }
-        departureDelay
-        arrivalDelay
-        transitLeg
+        start { scheduledTime estimated { time delay } }
+        end   { scheduledTime estimated { time delay } }
         trip { route { shortName } }
-        duration
+        route { shortName }
       }
-    }
+    } }
   }
 }"""
 
@@ -175,60 +174,42 @@ async def _async_plan_trip_otp2_graphql(
     departure_time: Optional[datetime],
     provider_instance,
 ) -> Optional[List[Dict[str, Any]]]:
-    """Plan a trip via OTP2 GraphQL plan query (community server + custom instances).
+    """Plan a trip via the OTP2 planConnection query (community server + custom instances).
 
-    Routes stop-to-stop: `place` is set to the GTFS stop id so OTP2 uses the
-    transit stop directly as origin/egress — no street-network access/egress.
-    This is what allows the graph to be built transit-only (no OSM). lat/lon are
-    still sent because InputCoordinates requires them; when `place` resolves to a
-    stop they only serve as a fallback.
+    Routes stop-to-stop using `stopLocationId`, so OTP takes the transit stops
+    directly as origin/destination — no coordinates, no street-network
+    access/egress. This is what lets the OTP graph be built transit-only (no
+    OSM). Requires an OTP 2.x server exposing the planConnection API.
     """
     now = departure_time or dt_util.now()
     # Compound stop IDs are pipe-separated — use the first platform ID
     from_id = origin_id.split("|")[0]
     to_id = dest_id.split("|")[0]
 
-    # Fetch stop coordinates — InputCoordinates requires lat/lon alongside place
-    from_body, to_body = await asyncio.gather(
-        provider_instance._graphql(_GRAPHQL_STOP_COORDS % from_id.replace('"', '\\"')),
-        provider_instance._graphql(_GRAPHQL_STOP_COORDS % to_id.replace('"', '\\"')),
-    )
-    from_stop = ((from_body or {}).get("data") or {}).get("stop") or {}
-    to_stop = ((to_body or {}).get("data") or {}).get("stop") or {}
+    # Only pin the departure time when the caller asked for one; otherwise let
+    # OTP default to "now" (a live server tracks the clock better than we do).
+    dt_clause = ""
+    if departure_time is not None:
+        dt_clause = 'dateTime: { earliestDeparture: "%s" }' % now.isoformat()
 
-    if not from_stop.get("lat") or not to_stop.get("lat"):
-        _LOGGER.warning("OTP2 plan: could not resolve stop coordinates for %s / %s", from_id, to_id)
-        return None
-
-    query = _GRAPHQL_PLAN % (
-        from_stop["lat"],
-        from_stop["lon"],
+    query = _GRAPHQL_PLAN_CONNECTION % (
         from_id.replace('"', '\\"'),
-        to_stop["lat"],
-        to_stop["lon"],
         to_id.replace('"', '\\"'),
-        now.strftime("%Y-%m-%d"),
-        now.strftime("%H:%M:%S"),
+        dt_clause,
     )
     body = await provider_instance._graphql(query)
     if body is None:
         return None
 
     if body.get("errors"):
-        _LOGGER.warning("OTP2 plan GraphQL errors: %s", body["errors"])
+        _LOGGER.warning("OTP2 planConnection GraphQL errors: %s", body["errors"])
 
-    itineraries = ((body.get("data") or {}).get("plan") or {}).get("itineraries") or []
-    if not itineraries:
-        _LOGGER.warning(
-            "OTP2 plan: no itineraries for %s (%s) → %s (%s)",
-            from_stop.get("name", from_id),
-            from_id,
-            to_stop.get("name", to_id),
-            to_id,
-        )
+    edges = (((body.get("data") or {}).get("planConnection") or {}).get("edges")) or []
+    if not edges:
+        _LOGGER.warning("OTP2 planConnection: no itineraries for %s → %s", from_id, to_id)
         return None
 
-    return _parse_otp_itineraries(itineraries)
+    return _parse_otp_plan_connection([e["node"] for e in edges if e.get("node")])
 
 
 async def _async_plan_trip_otp(
@@ -388,6 +369,102 @@ def _ms_to_hhmm(ms: int) -> str:
         return dt_util.as_local(dt).strftime("%H:%M")
     except (ValueError, OSError):
         return ""
+
+
+def _iso_to_hhmm(iso: Optional[str]) -> str:
+    """Convert an ISO-8601 datetime string to HH:MM in local time."""
+    if not iso:
+        return ""
+    dt = dt_util.parse_datetime(iso)
+    return dt_util.as_local(dt).strftime("%H:%M") if dt else ""
+
+
+def _iso_to_epoch(iso: Optional[str]) -> float:
+    """Convert an ISO-8601 datetime string to a Unix timestamp (seconds)."""
+    if not iso:
+        return 0.0
+    dt = dt_util.parse_datetime(iso)
+    return dt.timestamp() if dt else 0.0
+
+
+def _parse_otp_plan_connection(nodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Parse OTP2 planConnection nodes into the unified journey dict format."""
+    results = []
+
+    for node in nodes:
+        transit_legs = []
+        for leg in node.get("legs", []):
+            if not leg.get("transitLeg", False):
+                continue
+
+            start = leg.get("start") or {}
+            end = leg.get("end") or {}
+            dep_planned = start.get("scheduledTime")
+            dep_estimated = ((start.get("estimated") or {}).get("time")) or dep_planned
+            arr_planned = end.get("scheduledTime")
+            arr_estimated = ((end.get("estimated") or {}).get("time")) or arr_planned
+            delay_s = (start.get("estimated") or {}).get("delay") or 0
+            route = (leg.get("trip") or {}).get("route") or leg.get("route") or {}
+
+            transit_legs.append(
+                {
+                    "origin": (leg.get("from") or {}).get("name", ""),
+                    "destination": (leg.get("to") or {}).get("name", ""),
+                    "line": route.get("shortName") or "",
+                    "product": _OTP_MODE_TO_PRODUCT.get(leg.get("mode", ""), (leg.get("mode") or "").lower()),
+                    "departure_planned": _iso_to_hhmm(dep_planned),
+                    "departure_estimated": _iso_to_hhmm(dep_estimated),
+                    "arrival_planned": _iso_to_hhmm(arr_planned),
+                    "arrival_estimated": _iso_to_hhmm(arr_estimated),
+                    "delay": int(delay_s // 60),
+                    "duration_minutes": round((leg.get("duration") or 0) / 60),
+                    "platform": "",
+                    # Internal epoch seconds for transfer-gap calculation
+                    "_arrival_s": _iso_to_epoch(arr_estimated),
+                    "_departure_s": _iso_to_epoch(dep_estimated),
+                }
+            )
+
+        if not transit_legs:
+            continue
+
+        connection_feasible = True
+        transfer_risk = "low"
+        min_transfer_time: Optional[int] = None
+
+        for i in range(len(transit_legs) - 1):
+            gap_min = int((transit_legs[i + 1]["_departure_s"] - transit_legs[i]["_arrival_s"]) // 60)
+            if min_transfer_time is None or gap_min < min_transfer_time:
+                min_transfer_time = gap_min
+            if gap_min <= 0:
+                connection_feasible = False
+                transfer_risk = "missed"
+            elif gap_min <= 3 and transfer_risk != "missed":
+                transfer_risk = "high"
+            elif gap_min <= 5 and transfer_risk not in ("missed", "high"):
+                transfer_risk = "medium"
+
+        for leg in transit_legs:
+            leg.pop("_arrival_s", None)
+            leg.pop("_departure_s", None)
+
+        first_dep = transit_legs[0].get("departure_estimated") or transit_legs[0].get("departure_planned", "")
+        last_arr = transit_legs[-1].get("arrival_estimated") or transit_legs[-1].get("arrival_planned", "")
+
+        results.append(
+            {
+                "departure": first_dep,
+                "arrival": last_arr,
+                "duration_minutes": round((node.get("duration") or 0) / 60),
+                "transfers": node.get("numberOfTransfers", len(transit_legs) - 1),
+                "connection_feasible": connection_feasible,
+                "transfer_risk": transfer_risk,
+                "min_transfer_time": min_transfer_time,
+                "legs": transit_legs,
+            }
+        )
+
+    return results
 
 
 def _parse_journeys(journeys: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -168,6 +168,21 @@ async def async_plan_trip(
         return None
 
 
+_GRAPHQL_PARENT = '{ stop(id: "%s") { parentStation { gtfsId } } }'
+
+
+async def _resolve_station_id(provider_instance, stop_id: str) -> str:
+    """Return a stop's parent-station id, or the stop id itself if it has none.
+
+    A multi-platform station (e.g. a Hauptbahnhof) has one stop id per platform.
+    Routing from the parent station lets OTP consider every platform; pinning an
+    arbitrary single platform can yield a slower or wrong-direction journey.
+    """
+    body = await provider_instance._graphql(_GRAPHQL_PARENT % stop_id.replace('"', '\\"'))
+    parent = (((body or {}).get("data") or {}).get("stop") or {}).get("parentStation") or {}
+    return parent.get("gtfsId") or stop_id
+
+
 async def _async_plan_trip_otp2_graphql(
     origin_id: str,
     dest_id: str,
@@ -185,6 +200,13 @@ async def _async_plan_trip_otp2_graphql(
     # Compound stop IDs are pipe-separated — use the first platform ID
     from_id = origin_id.split("|")[0]
     to_id = dest_id.split("|")[0]
+
+    # Route from the parent station rather than a single platform, so OTP
+    # considers every platform of a multi-platform station.
+    from_id, to_id = await asyncio.gather(
+        _resolve_station_id(provider_instance, from_id),
+        _resolve_station_id(provider_instance, to_id),
+    )
 
     # Only pin the departure time when the caller asked for one; otherwise let
     # OTP default to "now" (a live server tracks the clock better than we do).

--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -39,8 +39,8 @@ _GRAPHQL_STOP_COORDS = '{ stop(id: "%s") { lat lon name } }'
 
 _GRAPHQL_PLAN = """{
   plan(
-    from: { lat: %f, lon: %f }
-    to: { lat: %f, lon: %f }
+    from: { lat: %f, lon: %f, place: "%s" }
+    to: { lat: %f, lon: %f, place: "%s" }
     date: "%s"
     time: "%s"
     numItineraries: 3
@@ -177,15 +177,18 @@ async def _async_plan_trip_otp2_graphql(
 ) -> Optional[List[Dict[str, Any]]]:
     """Plan a trip via OTP2 GraphQL plan query (community server + custom instances).
 
-    lat/lon are required by the plan API; stopId is passed alongside so OTP2
-    uses the exact transit stop without needing a street-network snap.
+    Routes stop-to-stop: `place` is set to the GTFS stop id so OTP2 uses the
+    transit stop directly as origin/egress — no street-network access/egress.
+    This is what allows the graph to be built transit-only (no OSM). lat/lon are
+    still sent because InputCoordinates requires them; when `place` resolves to a
+    stop they only serve as a fallback.
     """
     now = departure_time or dt_util.now()
     # Compound stop IDs are pipe-separated — use the first platform ID
     from_id = origin_id.split("|")[0]
     to_id = dest_id.split("|")[0]
 
-    # Fetch stop coordinates — required by the plan API alongside stopId
+    # Fetch stop coordinates — InputCoordinates requires lat/lon alongside place
     from_body, to_body = await asyncio.gather(
         provider_instance._graphql(_GRAPHQL_STOP_COORDS % from_id.replace('"', '\\"')),
         provider_instance._graphql(_GRAPHQL_STOP_COORDS % to_id.replace('"', '\\"')),
@@ -200,8 +203,10 @@ async def _async_plan_trip_otp2_graphql(
     query = _GRAPHQL_PLAN % (
         from_stop["lat"],
         from_stop["lon"],
+        from_id.replace('"', '\\"'),
         to_stop["lat"],
         to_stop["lon"],
+        to_id.replace('"', '\\"'),
         now.strftime("%Y-%m-%d"),
         now.strftime("%H:%M:%S"),
     )

--- a/tests/test_trip_extended.py
+++ b/tests/test_trip_extended.py
@@ -237,12 +237,13 @@ async def test_otp_rest_plan_data_none(hass: HomeAssistant):
 
 async def test_plan_trip_otp2_with_ids(hass: HomeAssistant):
     """Test async_plan_trip dispatches to OTP2 path when stop IDs provided."""
-    from_data = {"data": {"stop": {"lat": 51.2, "lon": 6.7, "name": "A"}}}
-    to_data = {"data": {"stop": {"lat": 50.9, "lon": 6.9, "name": "B"}}}
-    plan_data = {"data": {"plan": {"itineraries": [_make_otp_itinerary()]}}}
+    # OTP2 path now does: 2 parentStation lookups (fall back to the stop id) +
+    # the planConnection query.
+    parent_resp = {"data": {"stop": {"parentStation": None}}}
+    plan_data = _pc_response([_make_pc_node()])
 
     mock_provider = MagicMock()
-    mock_provider._graphql = AsyncMock(side_effect=[from_data, to_data, plan_data])
+    mock_provider._graphql = AsyncMock(side_effect=[parent_resp, parent_resp, plan_data])
 
     with patch("openpublictransport.get_provider", return_value=mock_provider):
         with patch("custom_components.openpublictransport.trip.async_get_clientsession"):

--- a/tests/test_trip_extended.py
+++ b/tests/test_trip_extended.py
@@ -34,84 +34,123 @@ def _make_otp_itinerary(dep_ms=1705312200000, dur_s=3600, transfers=0):
     }
 
 
-# ── _async_plan_trip_otp2_graphql ─────────────────────────────────────────────
+# ── _async_plan_trip_otp2_graphql (planConnection) ────────────────────────────
 
-async def test_otp2_graphql_no_coordinates(hass: HomeAssistant):
-    """Test OTP2 GraphQL returns None when stop coordinates unavailable."""
+def _make_pc_node(transfers=0):
+    """A planConnection node with one transit leg."""
+    return {
+        "duration": 3600,
+        "numberOfTransfers": transfers,
+        "legs": [
+            {
+                "transitLeg": True,
+                "mode": "RAIL",
+                "duration": 3600,
+                "from": {"name": "A"},
+                "to": {"name": "B"},
+                "start": {
+                    "scheduledTime": "2026-01-15T10:00:00+01:00",
+                    "estimated": {"time": "2026-01-15T10:00:00+01:00", "delay": 0},
+                },
+                "end": {
+                    "scheduledTime": "2026-01-15T11:00:00+01:00",
+                    "estimated": {"time": "2026-01-15T11:00:00+01:00", "delay": 0},
+                },
+                "trip": {"route": {"shortName": "ICE 1"}},
+                "route": {"shortName": "ICE 1"},
+            }
+        ],
+    }
+
+
+def _make_pc_two_leg():
+    """A planConnection node with two transit legs and a 4-minute transfer."""
+    return {
+        "duration": 5400,
+        "numberOfTransfers": 1,
+        "legs": [
+            {
+                "transitLeg": True, "mode": "RAIL", "duration": 1800,
+                "from": {"name": "A"}, "to": {"name": "B"},
+                "start": {"scheduledTime": "2026-01-15T10:00:00+01:00"},
+                "end": {"scheduledTime": "2026-01-15T10:30:00+01:00"},
+                "route": {"shortName": "RE1"},
+            },
+            {
+                "transitLeg": True, "mode": "BUS", "duration": 1800,
+                "from": {"name": "B"}, "to": {"name": "C"},
+                "start": {"scheduledTime": "2026-01-15T10:34:00+01:00"},
+                "end": {"scheduledTime": "2026-01-15T11:04:00+01:00"},
+                "route": {"shortName": "42"},
+            },
+        ],
+    }
+
+
+def _pc_response(nodes):
+    return {"data": {"planConnection": {"edges": [{"node": n} for n in nodes]}}}
+
+
+async def test_otp2_graphql_no_response(hass: HomeAssistant):
+    """planConnection returns None when the request fails."""
     provider = MagicMock()
     provider._graphql = AsyncMock(return_value=None)
 
-    result = await _async_plan_trip_otp2_graphql(
-        "stop:1", "stop:2", None, provider
-    )
+    result = await _async_plan_trip_otp2_graphql("stop:1", "stop:2", None, provider)
     assert result is None
 
 
-async def test_otp2_graphql_coordinates_returned(hass: HomeAssistant):
-    """Test OTP2 GraphQL returns itineraries when coords available."""
-    from_data = {"data": {"stop": {"lat": 51.2, "lon": 6.7, "name": "A"}}}
-    to_data = {"data": {"stop": {"lat": 50.9, "lon": 6.9, "name": "B"}}}
-    plan_data = {"data": {"plan": {"itineraries": [_make_otp_itinerary()]}}}
-
+async def test_otp2_graphql_itineraries_returned(hass: HomeAssistant):
+    """planConnection returns parsed journeys when edges are present."""
     provider = MagicMock()
-    provider._graphql = AsyncMock(side_effect=[from_data, to_data, plan_data])
+    provider._graphql = AsyncMock(return_value=_pc_response([_make_pc_node()]))
 
-    result = await _async_plan_trip_otp2_graphql("stop:1", "stop:2", None, provider)
+    # departure_time set → exercises the dateTime clause branch too
+    result = await _async_plan_trip_otp2_graphql(
+        "stop:1", "stop:2", datetime(2026, 1, 15, 9, 0, tzinfo=timezone.utc), provider
+    )
     assert result is not None
     assert len(result) == 1
+    assert result[0]["legs"][0]["line"] == "ICE 1"
 
 
-async def test_otp2_graphql_plan_query_none(hass: HomeAssistant):
-    """Test OTP2 GraphQL returns None when plan query fails."""
-    from_data = {"data": {"stop": {"lat": 51.2, "lon": 6.7, "name": "A"}}}
-    to_data = {"data": {"stop": {"lat": 50.9, "lon": 6.9, "name": "B"}}}
-
+async def test_otp2_graphql_no_edges(hass: HomeAssistant):
+    """planConnection returns None when there are no edges."""
     provider = MagicMock()
-    provider._graphql = AsyncMock(side_effect=[from_data, to_data, None])
-
-    result = await _async_plan_trip_otp2_graphql("stop:1", "stop:2", None, provider)
-    assert result is None
-
-
-async def test_otp2_graphql_no_itineraries(hass: HomeAssistant):
-    """Test OTP2 GraphQL returns None when no itineraries."""
-    from_data = {"data": {"stop": {"lat": 51.2, "lon": 6.7, "name": "A"}}}
-    to_data = {"data": {"stop": {"lat": 50.9, "lon": 6.9, "name": "B"}}}
-    plan_data = {"data": {"plan": {"itineraries": []}}}
-
-    provider = MagicMock()
-    provider._graphql = AsyncMock(side_effect=[from_data, to_data, plan_data])
+    provider._graphql = AsyncMock(return_value=_pc_response([]))
 
     result = await _async_plan_trip_otp2_graphql("stop:1", "stop:2", None, provider)
     assert result is None
 
 
 async def test_otp2_graphql_with_graphql_errors(hass: HomeAssistant):
-    """Test OTP2 GraphQL logs errors but returns itineraries if available."""
-    from_data = {"data": {"stop": {"lat": 51.2, "lon": 6.7, "name": "A"}}}
-    to_data = {"data": {"stop": {"lat": 50.9, "lon": 6.9, "name": "B"}}}
-    plan_data = {
-        "errors": [{"message": "Some warning"}],
-        "data": {"plan": {"itineraries": [_make_otp_itinerary()]}},
-    }
-
+    """planConnection logs errors but still returns edges if present."""
+    resp = _pc_response([_make_pc_node()])
+    resp["errors"] = [{"message": "Some warning"}]
     provider = MagicMock()
-    provider._graphql = AsyncMock(side_effect=[from_data, to_data, plan_data])
+    provider._graphql = AsyncMock(return_value=resp)
 
     result = await _async_plan_trip_otp2_graphql("stop:1", "stop:2", None, provider)
     assert result is not None
 
 
-async def test_otp2_graphql_pipe_separated_stop_id(hass: HomeAssistant):
-    """Test OTP2 GraphQL handles pipe-separated compound stop IDs."""
-    from_data = {"data": {"stop": {"lat": 51.2, "lon": 6.7, "name": "A"}}}
-    to_data = {"data": {"stop": {"lat": 50.9, "lon": 6.9, "name": "B"}}}
-    plan_data = {"data": {"plan": {"itineraries": [_make_otp_itinerary()]}}}
-
+async def test_otp2_graphql_multileg_transfer(hass: HomeAssistant):
+    """Two-leg journey computes transfers and transfer risk."""
     provider = MagicMock()
-    provider._graphql = AsyncMock(side_effect=[from_data, to_data, plan_data])
+    provider._graphql = AsyncMock(return_value=_pc_response([_make_pc_two_leg()]))
 
-    # Pipe-separated stop IDs — should use only the first part
+    result = await _async_plan_trip_otp2_graphql("stop:1", "stop:2", None, provider)
+    assert result is not None
+    assert result[0]["transfers"] == 1
+    assert len(result[0]["legs"]) == 2
+    assert result[0]["transfer_risk"] == "medium"  # 4-minute gap
+
+
+async def test_otp2_graphql_pipe_separated_stop_id(hass: HomeAssistant):
+    """Compound pipe-separated stop IDs use only the first platform."""
+    provider = MagicMock()
+    provider._graphql = AsyncMock(return_value=_pc_response([_make_pc_node()]))
+
     result = await _async_plan_trip_otp2_graphql(
         "stop:1|platform:A", "stop:2|platform:B", None, provider
     )

--- a/tests/test_trip_extended.py
+++ b/tests/test_trip_extended.py
@@ -146,6 +146,24 @@ async def test_otp2_graphql_multileg_transfer(hass: HomeAssistant):
     assert result[0]["transfer_risk"] == "medium"  # 4-minute gap
 
 
+async def test_otp2_graphql_uses_parent_station(hass: HomeAssistant):
+    """A platform id is resolved to its parent station in the plan query."""
+    captured = {}
+
+    async def fake_graphql(query):
+        if "parentStation" in query:
+            return {"data": {"stop": {"parentStation": {"gtfsId": "station:PARENT"}}}}
+        captured["plan"] = query
+        return _pc_response([_make_pc_node()])
+
+    provider = MagicMock()
+    provider._graphql = fake_graphql
+
+    result = await _async_plan_trip_otp2_graphql("plat:1", "plat:2", None, provider)
+    assert result is not None
+    assert 'stopLocationId: "station:PARENT"' in captured["plan"]
+
+
 async def test_otp2_graphql_pipe_separated_stop_id(hass: HomeAssistant):
     """Compound pipe-separated stop IDs use only the first platform."""
     provider = MagicMock()


### PR DESCRIPTION
## Why
For the community/custom OTP2 servers, trip planning sent `plan(from/to: { lat, lon })` — the stop's coordinates — which forces OTP to snap to the street network for access/egress. That is why the server must hold the full OSM street graph in RAM (~24.5M vertices, the bulk of ~26.7 GB).

## What
Route stop-to-stop via the OTP2 **`planConnection`** query using `stopLocationId`, so OTP uses the transit stops directly — no coordinates, no street-network access/egress:
```graphql
planConnection(
  origin:      { location: { stopLocation: { stopLocationId: "gtfsde:<id>" } } }
  destination: { location: { stopLocation: { stopLocationId: "gtfsde:<id>" } } }
  first: 3
) { edges { node { duration numberOfTransfers legs { … } } } }
```
- **Route from the parent station, not a single platform.** A multi-platform station (e.g. a Hauptbahnhof) has one stop id per platform, and the compound stop id joins them in arbitrary order. Each endpoint's `parentStation` is resolved (falling back to the stop id if none) so OTP considers every platform.
- Drops the stop-coordinate lookup; new `_parse_otp_plan_connection` + ISO helpers produce the same unified journey dicts (downstream sensor code unchanged).
- The legacy `plan` REST path (`vbn_otp`) and its parser are untouched.

> An earlier commit tried adding `place` to `InputCoordinates`, but OTP 2.9 rejects it. `planConnection` is the correct stop-based API in 2.9.

## Verified live (api.openpublictransport.net, current OSM graph)
D-Elbruchstraße → Düsseldorf Hbf:
- platform → platform (arbitrary first platform): **23 min** U76 ❌
- parent station → parent station: **14 min** U76 ✅ (matches the fastest direct connection)

So parent-station routing is both the enabler for dropping OSM **and** a correctness fix.

## Effect
- Behaviour improved (correct platform selection) against the current (OSM) graph.
- Removes the street-network dependency from trip planning → prerequisite for building the OTP graph transit-only (no OSM), collapsing serve RAM from ~26.7 GB to a few GB.

## Tests
`test_trip_extended.py` OTP2 cases updated to the planConnection response shape, incl. a two-leg transfer-risk case and a test asserting the resolved parent id reaches the plan query. `py_compile` clean. (HA test env not available locally — run `pytest tests/test_trip_extended.py` in CI.)

## Next step (separate)
Transit-only test build on the gtfsde server to confirm (1) planConnection returns itineraries without a street network and (2) stop-to-stop transfers are generated without OSM (straight-line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)