### PR TITLE
Release 2026.7.4 — National Rail departures HTTP 500 fix

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,9 +14,9 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.11",
+    "python-openpublictransport==0.1.12",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.7.3"
+  "version": "2026.7.4"
 }


### PR DESCRIPTION
Bumps the bundled library to **python-openpublictransport==0.1.12** and the integration to **2026.7.4**.

### What this fixes (from user logs on #39)
- **Departures returned HTTP 500 for every station.** The LDBWS SOAPAction was version-mismatched; aligned the endpoint/namespace/SOAPAction triple with reference OpenLDBWS clients (`ldb12.asmx` / `2021-11-01` body / `2012-01-13` SOAPAction).
- **Blocking file read in the event loop.** The offline station snapshot is now loaded off-loop (HA flagged the sync read).
- Non-200 SOAP responses now log the fault reason.

### Note
The HTTP 500 fix is verified against a working reference integration using the same API key, but not end-to-end here (no UK token available). Awaiting reporter confirmation on #39.

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)