### PR TITLE
Fix #43: over-fetch departures when a line/destination filter is active

### DIFF
--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -4,6 +4,10 @@ DEFAULT_NAME = "Elbruchstrasse"
 DEFAULT_DEPARTURES = 10
 DEFAULT_SCAN_INTERVAL = 60
 
+# When a line/destination filter is active, fetch a larger raw board from the API
+# so client-side filtering isn't starved before truncating to the display count (issue #43).
+FILTERED_FETCH_LIMIT = 100
+
 # Configuration keys
 CONF_PROVIDER = "provider"  # NEU
 CONF_STATION_ID = "station_id"

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.7.4"
+  "version": "2026.7.5"
 }

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -31,6 +31,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_WALKING_TIME,
     DOMAIN,
+    FILTERED_FETCH_LIMIT,
     PROVIDER_ENTITY_PICTURES,
     PROVIDER_NTA_IE,
     TRANSPORTATION_TYPES,
@@ -236,6 +237,22 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
             )
             raise UpdateFailed(f"Error fetching data: {err}")
 
+    def _compute_fetch_limit(self) -> int:
+        """Over-fetch a larger board when a line/destination filter is active.
+
+        Filters are applied client-side after the fetch, so requesting only
+        ``departures_limit`` starves filtered results at busy stops (issue #43).
+        The display count is unchanged — the sensor still truncates to
+        ``departures_limit`` after filtering.
+        """
+        entry = self._config_entry
+        if entry is not None:
+            line = entry.options.get(CONF_LINE_FILTER, entry.data.get(CONF_LINE_FILTER, ""))
+            dest = entry.options.get(CONF_DESTINATION_FILTER, entry.data.get(CONF_DESTINATION_FILTER, ""))
+            if (line or "").strip() or (dest or "").strip():
+                return max(self.departures_limit, FILTERED_FETCH_LIMIT)
+        return self.departures_limit
+
     async def _fetch_departures(self) -> Optional[Dict[str, Any]]:
         """Fetch departure data from the API."""
         self._ensure_provider()
@@ -243,7 +260,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"No provider instance for {self.provider}")
 
         return await self.provider_instance.fetch_departures(
-            self.station_id, self.place_dm, self.name_dm, self.departures_limit
+            self.station_id, self.place_dm, self.name_dm, self._compute_fetch_limit()
         )
 
 

--- a/tests/test_fetch_limit.py
+++ b/tests/test_fetch_limit.py
@@ -1,0 +1,85 @@
+"""Tests for the departures over-fetch behaviour (issue #43).
+
+When a line/destination filter is active, the coordinator must request a larger
+raw board from the API so client-side filtering isn't starved before the list is
+truncated to the user's display count.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.openpublictransport.const import (
+    CONF_DESTINATION_FILTER,
+    CONF_LINE_FILTER,
+    DOMAIN,
+    FILTERED_FETCH_LIMIT,
+    PROVIDER_VRR,
+)
+from custom_components.openpublictransport.sensor import (
+    PublicTransportDataUpdateCoordinator,
+)
+
+
+def _coordinator(hass, entry=None, departures_limit=20):
+    return PublicTransportDataUpdateCoordinator(
+        hass,
+        provider=PROVIDER_VRR,
+        place_dm="Düsseldorf",
+        name_dm="Hauptbahnhof",
+        station_id=None,
+        departures_limit=departures_limit,
+        scan_interval=60,
+        config_entry=entry,
+    )
+
+
+def _entry(hass, **options):
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options=options)
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_no_config_entry_uses_display_limit(hass):
+    coordinator = _coordinator(hass, entry=None, departures_limit=20)
+    assert coordinator._compute_fetch_limit() == 20
+
+
+async def test_no_filter_uses_display_limit(hass):
+    entry = _entry(hass, **{CONF_LINE_FILTER: "", CONF_DESTINATION_FILTER: ""})
+    coordinator = _coordinator(hass, entry=entry, departures_limit=20)
+    assert coordinator._compute_fetch_limit() == 20
+
+
+async def test_line_filter_triggers_overfetch(hass):
+    entry = _entry(hass, **{CONF_LINE_FILTER: "U79,708"})
+    coordinator = _coordinator(hass, entry=entry, departures_limit=20)
+    assert coordinator._compute_fetch_limit() == FILTERED_FETCH_LIMIT
+
+
+async def test_destination_filter_triggers_overfetch(hass):
+    entry = _entry(hass, **{CONF_DESTINATION_FILTER: "Airport"})
+    coordinator = _coordinator(hass, entry=entry, departures_limit=20)
+    assert coordinator._compute_fetch_limit() == FILTERED_FETCH_LIMIT
+
+
+async def test_overfetch_never_below_display_limit(hass):
+    """A display count above the over-fetch constant is preserved."""
+    entry = _entry(hass, **{CONF_LINE_FILTER: "U79"})
+    coordinator = _coordinator(hass, entry=entry, departures_limit=150)
+    assert coordinator._compute_fetch_limit() == 150
+
+
+async def test_fetch_departures_passes_overfetch_limit(hass):
+    """With a filter set, the API is queried with the larger board size."""
+    entry = _entry(hass, **{CONF_LINE_FILTER: "U79"})
+    coordinator = _coordinator(hass, entry=entry, departures_limit=20)
+
+    provider = MagicMock()
+    provider.fetch_departures = AsyncMock(return_value={"stopEvents": []})
+    coordinator.provider_instance = provider  # pre-set so _ensure_provider is a no-op
+
+    await coordinator._fetch_departures()
+
+    _, _, _, limit = provider.fetch_departures.await_args.args
+    assert limit == FILTERED_FETCH_LIMIT


### PR DESCRIPTION
### Problem
At a busy hub, setting "Number of Departures" = 20 and filtering to a few lines showed only 1–2 results (#43). The coordinator requested exactly the display count from the API, and the line/destination filters were applied **client-side afterwards** — so unfiltered lines filled the board before filtering. No provider supports server-side line filtering.

### Fix
Decouple the **API fetch size** from the **display count**, contained entirely in `PublicTransportDataUpdateCoordinator`:
- New `_compute_fetch_limit()` returns `max(departures_limit, FILTERED_FETCH_LIMIT=100)` when a `line_filter` or `destination_filter` is set, else the display count. It reads the filters live from the config entry, so options changes take effect immediately.
- `_fetch_departures` uses that limit for the API request.
- The sensor still filters and then truncates to the user's `departures_limit` — **display cap unchanged (max 20)**.

No change when no filter is active (same fetch size / latency as before). No library change needed — providers already pass the limit to the API (National Rail caps at 150, so 100 is safe).

### Tests
- New `tests/test_fetch_limit.py` (6 tests): no entry → display limit; no filter → display limit; line filter → 100; destination filter → 100; display count above 100 preserved; `_fetch_departures` queries the API with 100 when a filter is set.
- Existing sensor suite still green — no regression.

Bumps integration to **2026.7.5** (library stays 0.1.12).

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)