### PR TITLE
Release 2026.7.6 — announce stable stop IDs (openpublictransport.net users)

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.7.5"
+  "version": "2026.7.6"
 }


### PR DESCRIPTION
Version bump only — **no code changes**. This release exists to deliver a one-time notice via the changelog.

### Who this affects
**Only users of the `openpublictransport.net (Deutschlandweit)` provider** (the `api.openpublictransport.net` community server). Every other provider (VRR, KVV, HVV, MVV, …, NTA, National Rail, Trafiklab, your own OTP2 instance) is unaffected.

### Why
The openpublictransport.net API now issues **stable stop IDs** that no longer change on the weekly graph rebuild (previously the underlying gtfs.de data reassigned stop IDs every week, silently breaking configured stops). Because the IDs changed one final time to the new stable scheme, affected users must **re-create their stops once**; afterwards they stay valid across all future rebuilds.

Bumps integration to **2026.7.6**.