### PR TITLE
Fix trip-planner delay crash + persist sensor state across restarts (2026.7.8)

### DIFF
--- a/custom_components/openpublictransport/binary_sensor.py
+++ b/custom_components/openpublictransport/binary_sensor.py
@@ -7,10 +7,11 @@ from typing import Any, Callable
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 from openpublictransport.models import UnifiedDeparture
@@ -26,7 +27,7 @@ from .const import (
     PROVIDER_VRR,
     TRANSPORTATION_TYPES,
 )
-from .sensor import PublicTransportDataUpdateCoordinator
+from .sensor import PublicTransportDataUpdateCoordinator, _RESTORE_SKIP_ATTRS
 
 PARALLEL_UPDATES = 0
 
@@ -51,7 +52,7 @@ async def async_setup_entry(
     async_add_entities([PublicTransportDelayBinarySensor(coordinator, config_entry, transportation_types)])
 
 
-class PublicTransportDelayBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class PublicTransportDelayBinarySensor(CoordinatorEntity, RestoreEntity, BinarySensorEntity):
     """Binary sensor for public transport delays."""
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
@@ -97,6 +98,22 @@ class PublicTransportDelayBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional attributes."""
         return self._attributes
+
+    async def async_added_to_hass(self) -> None:
+        """Show state immediately on add, restoring from disk if needed."""
+        await super().async_added_to_hass()
+        if self.coordinator.data:
+            self._handle_coordinator_update()
+            return
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._attr_is_on = last_state.state == "on"
+            self._attributes = {
+                key: value
+                for key, value in last_state.attributes.items()
+                if key not in _RESTORE_SKIP_ATTRS
+            }
+            self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/openpublictransport/binary_sensor.py
+++ b/custom_components/openpublictransport/binary_sensor.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -27,7 +27,7 @@ from .const import (
     PROVIDER_VRR,
     TRANSPORTATION_TYPES,
 )
-from .sensor import PublicTransportDataUpdateCoordinator, _RESTORE_SKIP_ATTRS
+from .sensor import _RESTORE_SKIP_ATTRS, PublicTransportDataUpdateCoordinator
 
 PARALLEL_UPDATES = 0
 
@@ -109,9 +109,7 @@ class PublicTransportDelayBinarySensor(CoordinatorEntity, RestoreEntity, BinaryS
         if last_state and last_state.state not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._attr_is_on = last_state.state == "on"
             self._attributes = {
-                key: value
-                for key, value in last_state.attributes.items()
-                if key not in _RESTORE_SKIP_ATTRS
+                key: value for key, value in last_state.attributes.items() if key not in _RESTORE_SKIP_ATTRS
             }
             self.async_write_ha_state()
 

--- a/custom_components/openpublictransport/calendar.py
+++ b/custom_components/openpublictransport/calendar.py
@@ -92,6 +92,12 @@ class DepartureCalendar(CoordinatorEntity, CalendarEntity):
         """Return events in a specific time range."""
         return [e for e in self._events if e.start >= start_date and e.start <= end_date]
 
+    async def async_added_to_hass(self) -> None:
+        """Populate events on add so the calendar isn't empty after a restart."""
+        await super().async_added_to_hass()
+        if self.coordinator.data:
+            self._handle_coordinator_update()
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/openpublictransport/camera.py
+++ b/custom_components/openpublictransport/camera.py
@@ -217,6 +217,12 @@ class DepartureBoardCamera(CoordinatorEntity, Camera):
         """Return the departure board image."""
         return self._image
 
+    async def async_added_to_hass(self) -> None:
+        """Render the board on add so it isn't blank after a restart."""
+        await super().async_added_to_hass()
+        if self.coordinator.data:
+            self._handle_coordinator_update()
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Re-render the board when data updates."""

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.7.7"
+  "version": "2026.7.8"
 }

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -467,9 +467,7 @@ class MultiProviderSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         if last_state and last_state.state not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._state = last_state.state
             self._attributes = {
-                key: value
-                for key, value in last_state.attributes.items()
-                if key not in _RESTORE_SKIP_ATTRS
+                key: value for key, value in last_state.attributes.items() if key not in _RESTORE_SKIP_ATTRS
             }
             self.async_write_ha_state()
 

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -6,12 +6,14 @@ from typing import Any, Dict, List, Optional
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 from openpublictransport import AuthenticationError, get_provider
@@ -39,6 +41,21 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
+
+# HA-managed attribute keys to drop when restoring our own extra_state_attributes
+# from a persisted state (they are re-derived by HA / our properties).
+_RESTORE_SKIP_ATTRS = frozenset(
+    {
+        "friendly_name",
+        "icon",
+        "entity_picture",
+        "attribution",
+        "device_class",
+        "unit_of_measurement",
+        "state_class",
+        "supported_features",
+    }
+)
 INTEGRATION_VERSION = json.loads((Path(__file__).parent / "manifest.json").read_text()).get("version", "unknown")
 
 
@@ -306,7 +323,7 @@ async def async_setup_entry(
     )
 
 
-class MultiProviderSensor(CoordinatorEntity, SensorEntity):
+class MultiProviderSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
     _attr_has_entity_name = True
     """Sensor für VRR/KVV/HVV using DataUpdateCoordinator."""
 
@@ -429,6 +446,32 @@ class MultiProviderSensor(CoordinatorEntity, SensorEntity):
         if self._use_provider_logo:
             return PROVIDER_ENTITY_PICTURES.get(self._provider)
         return None
+
+    async def async_added_to_hass(self) -> None:
+        """Populate state immediately on add, restoring from disk if needed.
+
+        Chains CoordinatorEntity (registers the coordinator listener) and
+        RestoreEntity (state persistence). Without this, the push-style entity
+        would show ``unknown`` after a restart until the next poll (up to
+        ``scan_interval``), even though ``coordinator.data`` is already populated
+        by the blocking first refresh.
+        """
+        await super().async_added_to_hass()
+        if self.coordinator.data:
+            # Fresh data was already fetched during setup — show it now.
+            self._handle_coordinator_update()
+            return
+        # No data yet (e.g. degraded startup): fall back to the last known state
+        # so the sensor isn't empty until the first successful fetch.
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._state = last_state.state
+            self._attributes = {
+                key: value
+                for key, value in last_state.attributes.items()
+                if key not in _RESTORE_SKIP_ATTRS
+            }
+            self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -6,6 +6,7 @@ route planning from A to B with connections and transfers.
 
 import asyncio
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
@@ -409,6 +410,47 @@ def _iso_to_epoch(iso: Optional[str]) -> float:
     return dt.timestamp() if dt else 0.0
 
 
+_ISO_DURATION_RE = re.compile(
+    r"^(?P<sign>-)?P(?:(?P<days>\d+)D)?T(?:(?P<h>\d+)H)?(?:(?P<m>\d+)M)?(?:(?P<s>\d+(?:\.\d+)?)S)?$",
+    re.IGNORECASE,
+)
+
+
+def _duration_to_seconds(value: Any) -> int:
+    """Coerce an OTP2 ``Duration`` value to whole seconds.
+
+    OTP2's ``planConnection`` returns durations (leg/itinerary ``duration`` and
+    realtime ``delay``) as the ``Duration`` scalar, serialised as an ISO-8601
+    string like ``"PT3M"`` / ``"-PT90S"``. Older/other schemas return a plain
+    number of seconds. Handle both (and ``None``) so a real-time delay no longer
+    crashes the trip planner.
+    """
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        return 0
+    try:
+        return int(float(text))  # plain numeric string (seconds)
+    except ValueError:
+        pass
+    match = _ISO_DURATION_RE.match(text)
+    if not match:
+        return 0
+    parts = match.groupdict()
+    total = (
+        int(parts["days"] or 0) * 86400
+        + int(parts["h"] or 0) * 3600
+        + int(parts["m"] or 0) * 60
+        + int(float(parts["s"] or 0))
+    )
+    return -total if parts["sign"] else total
+
+
 def _parse_otp_plan_connection(nodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Parse OTP2 planConnection nodes into the unified journey dict format."""
     results = []
@@ -425,7 +467,7 @@ def _parse_otp_plan_connection(nodes: List[Dict[str, Any]]) -> List[Dict[str, An
             dep_estimated = ((start.get("estimated") or {}).get("time")) or dep_planned
             arr_planned = end.get("scheduledTime")
             arr_estimated = ((end.get("estimated") or {}).get("time")) or arr_planned
-            delay_s = (start.get("estimated") or {}).get("delay") or 0
+            delay_s = (start.get("estimated") or {}).get("delay")
             route = (leg.get("trip") or {}).get("route") or leg.get("route") or {}
 
             transit_legs.append(
@@ -438,8 +480,8 @@ def _parse_otp_plan_connection(nodes: List[Dict[str, Any]]) -> List[Dict[str, An
                     "departure_estimated": _iso_to_hhmm(dep_estimated),
                     "arrival_planned": _iso_to_hhmm(arr_planned),
                     "arrival_estimated": _iso_to_hhmm(arr_estimated),
-                    "delay": int(delay_s // 60),
-                    "duration_minutes": round((leg.get("duration") or 0) / 60),
+                    "delay": _duration_to_seconds(delay_s) // 60,
+                    "duration_minutes": round(_duration_to_seconds(leg.get("duration")) / 60),
                     "platform": "",
                     # Internal epoch seconds for transfer-gap calculation
                     "_arrival_s": _iso_to_epoch(arr_estimated),
@@ -477,7 +519,7 @@ def _parse_otp_plan_connection(nodes: List[Dict[str, Any]]) -> List[Dict[str, An
             {
                 "departure": first_dep,
                 "arrival": last_arr,
-                "duration_minutes": round((node.get("duration") or 0) / 60),
+                "duration_minutes": round(_duration_to_seconds(node.get("duration")) / 60),
                 "transfers": node.get("numberOfTransfers", len(transit_legs) - 1),
                 "connection_feasible": connection_feasible,
                 "transfer_risk": transfer_risk,

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -10,10 +10,14 @@ from typing import Any, Dict, List, Optional
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+
+from .sensor import _RESTORE_SKIP_ATTRS
 
 from .const import (
     CONF_OPT_API_KEY,
@@ -153,7 +157,7 @@ async def async_setup_entry(
     async_add_entities([TripSensor(coordinator, config_entry)])
 
 
-class TripSensor(CoordinatorEntity, SensorEntity):
+class TripSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
     """Sensor showing the next best trip from A to B."""
 
     _attr_has_entity_name = True
@@ -167,6 +171,8 @@ class TripSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._config_entry = config_entry
         self._attr_icon = "mdi:routes"
+        self._restored_state: str | None = None
+        self._restored_attributes: dict[str, Any] = {}
 
         origin = coordinator.origin
         origin_city = coordinator.origin_city
@@ -184,10 +190,32 @@ class TripSensor(CoordinatorEntity, SensorEntity):
             model="Trip Planner",
         )
 
+    async def async_added_to_hass(self) -> None:
+        """Restore the last trip so the sensor isn't blank right after a restart.
+
+        Only used while the coordinator has no data yet (``data is None``); a
+        valid empty result (``[]``) still shows "No connections" rather than a
+        stale connection.
+        """
+        await super().async_added_to_hass()
+        if self.coordinator.data is not None:
+            return
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._restored_state = last_state.state
+            self._restored_attributes = {
+                key: value
+                for key, value in last_state.attributes.items()
+                if key not in _RESTORE_SKIP_ATTRS
+            }
+            self.async_write_ha_state()
+
     @property
     def native_value(self) -> str | None:
         """Return the next trip as state."""
         journeys = self.coordinator.data
+        if journeys is None and self._restored_state is not None:
+            return self._restored_state
         if not journeys:
             return "No connections"
 
@@ -205,6 +233,8 @@ class TripSensor(CoordinatorEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return trip details as attributes."""
         journeys = self.coordinator.data
+        if journeys is None and self._restored_attributes:
+            return self._restored_attributes
         if not journeys:
             return {}
 

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -17,8 +17,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
-from .sensor import _RESTORE_SKIP_ATTRS
-
 from .const import (
     CONF_OPT_API_KEY,
     CONF_OTP_BASE_URL,
@@ -28,6 +26,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
+from .sensor import _RESTORE_SKIP_ATTRS
 from .trip import async_plan_trip
 
 PARALLEL_UPDATES = 0
@@ -204,9 +203,7 @@ class TripSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         if last_state and last_state.state not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._restored_state = last_state.state
             self._restored_attributes = {
-                key: value
-                for key, value in last_state.attributes.items()
-                if key not in _RESTORE_SKIP_ATTRS
+                key: value for key, value in last_state.attributes.items() if key not in _RESTORE_SKIP_ATTRS
             }
             self.async_write_ha_state()
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -182,3 +182,41 @@ async def test_async_setup_entry(hass: HomeAssistant, mock_config_entry, mock_co
 
     assert len(entities) == 1
     assert isinstance(entities[0], PublicTransportDelayBinarySensor)
+
+
+# ── restore state across restart ──────────────────────────────────────────────
+
+from homeassistant.core import State
+from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+
+def _delay_coordinator():
+    coordinator = MagicMock()
+    coordinator.data = None
+    coordinator.last_update_success = True
+    coordinator.provider = PROVIDER_VRR
+    coordinator.place_dm = "Düsseldorf"
+    coordinator.name_dm = "Hauptbahnhof"
+    coordinator.station_id = None
+    coordinator.agency_name = "VRR"
+    return coordinator
+
+
+async def test_binary_sensor_restores_last_state(hass: HomeAssistant, mock_config_entry):
+    """With no coordinator data yet, restore is_on and attributes from disk."""
+    coordinator = _delay_coordinator()
+    entity_id = "binary_sensor.opt_delays_restore"
+    mock_restore_cache(
+        hass,
+        (State(entity_id, "on", {"max_delay": 12, "delayed_departures": 2, "friendly_name": "X"}),),
+    )
+    sensor = PublicTransportDelayBinarySensor(coordinator, mock_config_entry, ["bus", "train", "tram"])
+    sensor.hass = hass
+    sensor.entity_id = entity_id
+    sensor.async_write_ha_state = MagicMock()
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.is_on is True
+    assert sensor.extra_state_attributes["max_delay"] == 12
+    assert "friendly_name" not in sensor.extra_state_attributes

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -317,3 +317,58 @@ async def test_sensor_destination_filtering(hass: HomeAssistant):
     departures = sensor._attributes.get("departures", [])
     assert len(departures) == 1
     assert departures[0]["destination"] == "Duisburg Hbf"
+
+
+# ── restore state across restart ──────────────────────────────────────────────
+# Regression: after a restart the push-style sensor showed `unknown` until the
+# next poll. It should now populate on add — from fresh coordinator data if
+# present, else from the last persisted state.
+
+from homeassistant.core import State
+from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+from openpublictransport import get_provider
+
+
+def _build_sensor(hass, coordinator, mock_config_entry, entity_id="sensor.opt_test"):
+    coordinator.agency_name = "VRR"
+    sensor = MultiProviderSensor(coordinator, mock_config_entry, ["bus", "train", "tram"])
+    sensor.hass = hass
+    sensor.entity_id = entity_id
+    sensor.async_write_ha_state = MagicMock()
+    return sensor
+
+
+async def test_sensor_hydrates_on_add_from_coordinator(hass, mock_coordinator, mock_config_entry):
+    """With fresh coordinator data present, state is set immediately on add
+    (no waiting for the next poll)."""
+    mock_coordinator.provider_instance = get_provider(PROVIDER_VRR, hass)
+    sensor = _build_sensor(hass, mock_coordinator, mock_config_entry)
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.state is not None          # was None (unknown) before the fix
+    assert isinstance(sensor.extra_state_attributes, dict)
+    assert "total_departures" in sensor.extra_state_attributes
+
+
+async def test_sensor_restores_last_state_when_no_data(hass, mock_coordinator, mock_config_entry):
+    """With no coordinator data yet, the last persisted state/attributes are restored."""
+    mock_coordinator.data = None
+    entity_id = "sensor.opt_restore"
+    mock_restore_cache(
+        hass,
+        (State(entity_id, "14:37", {"departures": [{"line": "U1"}], "total_departures": 3, "friendly_name": "X"}),),
+    )
+    sensor = _build_sensor(hass, mock_coordinator, mock_config_entry, entity_id)
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.state == "14:37"
+    assert sensor.extra_state_attributes["total_departures"] == 3
+    assert "friendly_name" not in sensor.extra_state_attributes   # HA-managed key dropped
+
+    # A subsequent coordinator update overwrites the restored value.
+    mock_coordinator.data = {"stopEvents": []}
+    sensor._handle_coordinator_update()
+    assert sensor.state == "No departures"

--- a/tests/test_trip_extended.py
+++ b/tests/test_trip_extended.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from custom_components.openpublictransport.trip import (
     _async_plan_trip_otp,
     _async_plan_trip_otp2_graphql,
+    _duration_to_seconds,
     async_plan_trip,
 )
 
@@ -112,6 +113,38 @@ async def test_otp2_graphql_itineraries_returned(hass: HomeAssistant):
     assert result is not None
     assert len(result) == 1
     assert result[0]["legs"][0]["line"] == "ICE 1"
+
+
+def test_duration_to_seconds_variants():
+    """OTP2 Duration scalar (ISO-8601 string), numbers and None all coerce."""
+    assert _duration_to_seconds(None) == 0
+    assert _duration_to_seconds(0) == 0
+    assert _duration_to_seconds(180) == 180
+    assert _duration_to_seconds(90.0) == 90
+    assert _duration_to_seconds("120") == 120          # numeric string
+    assert _duration_to_seconds("PT3M") == 180
+    assert _duration_to_seconds("PT1H2M3S") == 3723
+    assert _duration_to_seconds("-PT90S") == -90       # running early
+    assert _duration_to_seconds("PT0S") == 0
+    assert _duration_to_seconds("garbage") == 0
+
+
+async def test_otp2_graphql_iso8601_delay_does_not_crash(hass: HomeAssistant):
+    """Regression: a real-time delay comes back as an ISO-8601 Duration string
+    (e.g. "PT3M"), which used to crash with `str // int`. See issue #50 follow-up."""
+    node = _make_pc_node()
+    node["duration"] = "PT1H"
+    node["legs"][0]["duration"] = "PT1H"
+    node["legs"][0]["start"]["estimated"]["delay"] = "PT3M"
+
+    provider = MagicMock()
+    provider._graphql = AsyncMock(return_value=_pc_response([node]))
+
+    result = await _async_plan_trip_otp2_graphql("stop:1", "stop:2", None, provider)
+    assert result is not None and len(result) == 1
+    assert result[0]["legs"][0]["delay"] == 3
+    assert result[0]["legs"][0]["duration_minutes"] == 60
+    assert result[0]["duration_minutes"] == 60
 
 
 async def test_otp2_graphql_no_edges(hass: HomeAssistant):

--- a/tests/test_trip_sensor.py
+++ b/tests/test_trip_sensor.py
@@ -271,3 +271,50 @@ def test_trip_sensor_extra_attributes_multiple_journeys(hass: HomeAssistant):
     assert attrs["alternative_journeys"] == 2
     assert "next_journeys" in attrs
     assert len(attrs["next_journeys"]) == 2
+
+
+# ── restore state across restart ──────────────────────────────────────────────
+
+from homeassistant.core import State
+from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+
+async def test_trip_sensor_restores_last_state_when_no_data(hass: HomeAssistant):
+    """With coordinator.data None, native_value/attrs fall back to the restored trip."""
+    coordinator = _make_trip_coordinator(hass)
+    # coordinator.data defaults to None before any refresh
+    entry = _make_trip_entry()
+    entity_id = "sensor.opt_trip_restore"
+    mock_restore_cache(
+        hass,
+        (State(entity_id, "10:00 → 11:00 (60 min, 0 transfers)", {"transfers": 0, "duration_minutes": 60}),),
+    )
+    sensor = TripSensor(coordinator, entry)
+    sensor.hass = hass
+    sensor.entity_id = entity_id
+    sensor.async_write_ha_state = MagicMock()
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.native_value == "10:00 → 11:00 (60 min, 0 transfers)"
+    assert sensor.extra_state_attributes["duration_minutes"] == 60
+
+
+async def test_trip_sensor_empty_result_not_stale(hass: HomeAssistant):
+    """A valid empty result ([]) shows 'No connections', never the restored trip."""
+    coordinator = _make_trip_coordinator(hass)
+    entry = _make_trip_entry()
+    entity_id = "sensor.opt_trip_empty"
+    mock_restore_cache(
+        hass,
+        (State(entity_id, "10:00 → 11:00 (60 min, 0 transfers)", {"transfers": 0}),),
+    )
+    sensor = TripSensor(coordinator, entry)
+    sensor.hass = hass
+    sensor.entity_id = entity_id
+    sensor.async_write_ha_state = MagicMock()
+
+    await sensor.async_added_to_hass()          # restores (data is None)
+    coordinator.data = []                        # valid empty result arrives
+    assert sensor.native_value == "No connections"
+    assert sensor.extra_state_attributes == {}

--- a/tests/test_trip_sensor.py
+++ b/tests/test_trip_sensor.py
@@ -279,10 +279,22 @@ from homeassistant.core import State
 from pytest_homeassistant_custom_component.common import mock_restore_cache
 
 
+def _mock_trip_coordinator(data=None):
+    """A MagicMock trip coordinator (no real refresh timer to leave lingering)."""
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.last_update_success = True
+    coordinator.provider = "vrr"
+    coordinator.origin = "Düsseldorf Hbf"
+    coordinator.origin_city = "Düsseldorf"
+    coordinator.destination = "Köln Hbf"
+    coordinator.destination_city = "Köln"
+    return coordinator
+
+
 async def test_trip_sensor_restores_last_state_when_no_data(hass: HomeAssistant):
     """With coordinator.data None, native_value/attrs fall back to the restored trip."""
-    coordinator = _make_trip_coordinator(hass)
-    # coordinator.data defaults to None before any refresh
+    coordinator = _mock_trip_coordinator(data=None)
     entry = _make_trip_entry()
     entity_id = "sensor.opt_trip_restore"
     mock_restore_cache(
@@ -302,7 +314,7 @@ async def test_trip_sensor_restores_last_state_when_no_data(hass: HomeAssistant)
 
 async def test_trip_sensor_empty_result_not_stale(hass: HomeAssistant):
     """A valid empty result ([]) shows 'No connections', never the restored trip."""
-    coordinator = _make_trip_coordinator(hass)
+    coordinator = _mock_trip_coordinator(data=None)
     entry = _make_trip_entry()
     entity_id = "sensor.opt_trip_empty"
     mock_restore_cache(
@@ -314,7 +326,7 @@ async def test_trip_sensor_empty_result_not_stale(hass: HomeAssistant):
     sensor.entity_id = entity_id
     sensor.async_write_ha_state = MagicMock()
 
-    await sensor.async_added_to_hass()          # restores (data is None)
-    coordinator.data = []                        # valid empty result arrives
+    await sensor.async_added_to_hass()  # restores (data is None)
+    coordinator.data = []  # valid empty result arrives
     assert sensor.native_value == "No connections"
     assert sensor.extra_state_attributes == {}


### PR DESCRIPTION
Two fixes shipping together as **2026.7.8**.

## 1. Trip-planner crash on real-time delay

Trip sensors on an OTP2 provider crashed continuously whenever a leg had a delay:

```
File ".../trip.py", line 441, in _parse_otp_plan_connection
    "delay": int(delay_s // 60),
TypeError: unsupported operand type(s) for //: 'str' and 'int'
```

OTP2 `planConnection` returns `estimated.delay` (and `duration`) as the **`Duration` scalar** — an ISO-8601 string like `"PT3M"`. The parser assumed seconds. Added `_duration_to_seconds()` (handles ISO-8601 strings incl. negative, numeric strings, numbers, `None`) and routed `delay` + both `duration` reads through it.

## 2. Sensor state persists across restarts

**Symptom:** after a Home Assistant restart, sensors showed `unknown`/empty for up to `scan_interval` (60 s) until the first poll.

**Cause:** the entities use a *push* pattern (value cached in `self._state`, written only in `_handle_coordinator_update`), and `CoordinatorEntity.async_added_to_hass` only registers a listener — it never pushes an initial update. So the entity wrote its empty `__init__` value on add and stayed there until the next poll, even though `coordinator.data` was already fetched by the blocking first refresh.

**Fix:**
- Each push entity now populates on add — reflecting the already-fetched `coordinator.data` immediately (fresh values, no 60 s gap).
- `MultiProviderSensor`, `PublicTransportDelayBinarySensor` and `TripSensor` are now `RestoreEntity`: HA persists the last state, it's restored on add as a fallback, and overwritten on the next update. `TripSensor` (pull) only falls back while `coordinator.data is None`, so a valid empty result still shows "No connections" rather than a stale trip.
- Calendar and camera hydrate on add (no persistence — events/images are heavy). `PunctualitySensor` (own `Store`) and the disruption event entity are unchanged.

## Tests

- Trip: `_duration_to_seconds` value shapes + a regression test with `delay="PT3M"`.
- Restore/hydrate: main sensor hydrates from coordinator data on add and restores last state when data is absent; binary-sensor `is_on` restore; trip-sensor restore + "valid empty ≠ stale".
- Full suite: **492 passed**.

Bumps to **2026.7.8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)