### PR TITLE
fix(trip): drop stray session arg breaking VBN OTP stop lookup

### DIFF
--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -117,7 +117,7 @@ async def async_plan_trip(
             return None
         session = async_get_clientsession(hass)
         provider_instance = get_provider(provider, session, api_key=api_key)
-        return await _async_plan_trip_otp(hass, origin_id, dest_id, departure_time, provider_instance)
+        return await _async_plan_trip_otp(origin_id, dest_id, departure_time, provider_instance)
 
     # EFA providers
     base_url = EFA_TRIP_ENDPOINTS.get(provider)
@@ -236,7 +236,6 @@ async def _async_plan_trip_otp2_graphql(
 
 
 async def _async_plan_trip_otp(
-    hass: HomeAssistant,
     origin_id: str,
     dest_id: str,
     departure_time: Optional[datetime],
@@ -244,13 +243,12 @@ async def _async_plan_trip_otp(
 ) -> Optional[List[Dict[str, Any]]]:
     """Plan a trip using the OTP 2.x REST /plan endpoint."""
     now = departure_time or dt_util.now()
-    session = async_get_clientsession(hass)
     base_url = provider_instance.otp_base_url
 
     # Resolve stop coordinates concurrently — OTP /plan needs lat,lon not stop IDs
     origin_stop, dest_stop = await asyncio.gather(
-        provider_instance._get(session, f"{base_url}/index/stops/{quote(origin_id, safe='')}"),
-        provider_instance._get(session, f"{base_url}/index/stops/{quote(dest_id, safe='')}"),
+        provider_instance._get(f"{base_url}/index/stops/{quote(origin_id, safe='')}"),
+        provider_instance._get(f"{base_url}/index/stops/{quote(dest_id, safe='')}"),
     )
     if not origin_stop or not dest_stop:
         _LOGGER.warning("VBN OTP trip: could not resolve stop coordinates for %s / %s", origin_id, dest_id)
@@ -260,7 +258,6 @@ async def _async_plan_trip_otp(
     to_place = f"{dest_stop['lat']},{dest_stop['lon']}"
 
     data = await provider_instance._get(
-        session,
         f"{base_url}/plan",
         {
             "fromPlace": from_place,

--- a/tests/test_trip_extended.py
+++ b/tests/test_trip_extended.py
@@ -216,7 +216,7 @@ async def test_otp_rest_no_stop_data(hass: HomeAssistant):
     provider.otp_base_url = "http://otp.local"
     provider._get = AsyncMock(return_value=None)
 
-    result = await _async_plan_trip_otp(hass, "stop:1", "stop:2", None, provider)
+    result = await _async_plan_trip_otp("stop:1", "stop:2", None, provider)
     assert result is None
 
 
@@ -232,7 +232,7 @@ async def test_otp_rest_no_itineraries(hass: HomeAssistant):
         {"plan": {"itineraries": []}},
     ])
 
-    result = await _async_plan_trip_otp(hass, "stop:1", "stop:2", None, provider)
+    result = await _async_plan_trip_otp("stop:1", "stop:2", None, provider)
     assert result is None
 
 
@@ -248,9 +248,17 @@ async def test_otp_rest_with_itineraries(hass: HomeAssistant):
         {"plan": {"itineraries": [_make_otp_itinerary()]}},
     ])
 
-    result = await _async_plan_trip_otp(hass, "stop:1", "stop:2", None, provider)
+    result = await _async_plan_trip_otp("stop:1", "stop:2", None, provider)
     assert result is not None
     assert len(result) == 1
+
+    # Regression test for the issue #59 bug: a stray `session` positional
+    # argument used to shift into `_get`'s `url` parameter (real signature is
+    # `_get(self, url, params=None)` — the session is injected once via the
+    # constructor, not per-call).
+    for call in provider._get.call_args_list:
+        assert 1 <= len(call.args) <= 2
+        assert isinstance(call.args[0], str)
 
 
 async def test_otp_rest_plan_data_none(hass: HomeAssistant):
@@ -262,7 +270,7 @@ async def test_otp_rest_plan_data_none(hass: HomeAssistant):
     provider.otp_base_url = "http://otp.local"
     provider._get = AsyncMock(side_effect=[origin_stop, dest_stop, None])
 
-    result = await _async_plan_trip_otp(hass, "stop:1", "stop:2", None, provider)
+    result = await _async_plan_trip_otp("stop:1", "stop:2", None, provider)
     assert result is None
 
 


### PR DESCRIPTION
## Summary

Fixes #59 — the VBN OTP trip planner always returns "No connections".

The issue's own root-cause guess (VBN's OTP2/Digitransit backend has no
`/index/stops/{id}` REST endpoint, needs a GraphQL `planConnection` migration
like PR #46) turned out not to be the actual cause. Git archaeology across
this repo and the `python-openpublictransport` PyPI package it depends on
shows a simpler regression:

- `_async_plan_trip_otp()` in `trip.py` calls
  `provider_instance._get(session, url, ...)`.
- That calling convention was correct when this code was first written
  (`_get(self, session, url, params=None)`), before providers were extracted
  into the standalone `python-openpublictransport` package.
- After that extraction, the session is injected once via the provider's
  constructor (`self.session`), and `_get()`'s signature became
  `_get(self, url, params=None)` — no `session` parameter. The caller in
  `trip.py` was never updated to match.
- The stray `session` argument therefore lands in the `url` parameter, and
  `self.session.get(<ClientSession>, ...)` fails while building a `yarl.URL`
  from a `ClientSession` object — exactly the `TypeError: Constructor
  parameter should be str` from the issue's log. Both stop-coordinate lookups
  silently return `None` (the exception is caught and logged inside `_get`),
  so the function always hits `if not origin_stop or not dest_stop` and
  returns `None`.
- A third, previously unreached `_get()` call (for the `/plan` endpoint) has
  the same bug in a worse form — 3 positional args against a 2-arg method —
  which would crash outright once the coordinate lookup was fixed.

Existing tests used a bare `AsyncMock()` for `provider._get` (no `spec=`),
which accepts any argument count, so this signature drift never surfaced in
CI.

## Changes

- Remove the stray `session` argument from all three `_get()` calls in
  `_async_plan_trip_otp()`.
- Drop the now-unused `hass` parameter from `_async_plan_trip_otp()` (matches
  its sibling `_async_plan_trip_otp2_graphql()`, which also doesn't need
  `hass`); update the one call site.
- Update the 4 affected tests in `tests/test_trip_extended.py` for the new
  signature, and add a regression assertion on `provider._get.call_args_list`
  so a future signature drift like this can't silently pass again.

## Test plan

- [x] `pytest tests/test_trip_extended.py -v` — 15/15 passed
- [x] `pytest tests/ -q` — full suite: 472 passed, 1 skipped
- [x] `black --check` / `isort --check-only` / `flake8` on
      `custom_components/openpublictransport/` (matches this repo's CI lint
      job) — clean