### PR TITLE
fix(trip): drop stray session arg breaking VBN OTP stop lookup (#59)

### DIFF
--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -117,7 +117,7 @@ async def async_plan_trip(
             return None
         session = async_get_clientsession(hass)
         provider_instance = get_provider(provider, session, api_key=api_key)
-        return await _async_plan_trip_otp(hass, origin_id, dest_id, departure_time, provider_instance)
+        return await _async_plan_trip_otp(origin_id, dest_id, departure_time, provider_instance)
 
     # EFA providers
     base_url = EFA_TRIP_ENDPOINTS.get(provider)
@@ -236,7 +236,6 @@ async def _async_plan_trip_otp2_graphql(
 
 
 async def _async_plan_trip_otp(
-    hass: HomeAssistant,
     origin_id: str,
     dest_id: str,
     departure_time: Optional[datetime],
@@ -244,13 +243,12 @@ async def _async_plan_trip_otp(
 ) -> Optional[List[Dict[str, Any]]]:
     """Plan a trip using the OTP 2.x REST /plan endpoint."""
     now = departure_time or dt_util.now()
-    session = async_get_clientsession(hass)
     base_url = provider_instance.otp_base_url
 
     # Resolve stop coordinates concurrently — OTP /plan needs lat,lon not stop IDs
     origin_stop, dest_stop = await asyncio.gather(
-        provider_instance._get(session, f"{base_url}/index/stops/{quote(origin_id, safe='')}"),
-        provider_instance._get(session, f"{base_url}/index/stops/{quote(dest_id, safe='')}"),
+        provider_instance._get(f"{base_url}/index/stops/{quote(origin_id, safe='')}"),
+        provider_instance._get(f"{base_url}/index/stops/{quote(dest_id, safe='')}"),
     )
     if not origin_stop or not dest_stop:
         _LOGGER.warning("VBN OTP trip: could not resolve stop coordinates for %s / %s", origin_id, dest_id)
@@ -260,7 +258,6 @@ async def _async_plan_trip_otp(
     to_place = f"{dest_stop['lat']},{dest_stop['lon']}"
 
     data = await provider_instance._get(
-        session,
         f"{base_url}/plan",
         {
             "fromPlace": from_place,

--- a/tests/test_trip_extended.py
+++ b/tests/test_trip_extended.py
@@ -216,7 +216,7 @@ async def test_otp_rest_no_stop_data(hass: HomeAssistant):
     provider.otp_base_url = "http://otp.local"
     provider._get = AsyncMock(return_value=None)
 
-    result = await _async_plan_trip_otp(hass, "stop:1", "stop:2", None, provider)
+    result = await _async_plan_trip_otp("stop:1", "stop:2", None, provider)
     assert result is None
 
 
@@ -232,7 +232,7 @@ async def test_otp_rest_no_itineraries(hass: HomeAssistant):
         {"plan": {"itineraries": []}},
     ])
 
-    result = await _async_plan_trip_otp(hass, "stop:1", "stop:2", None, provider)
+    result = await _async_plan_trip_otp("stop:1", "stop:2", None, provider)
     assert result is None
 
 
@@ -248,9 +248,17 @@ async def test_otp_rest_with_itineraries(hass: HomeAssistant):
         {"plan": {"itineraries": [_make_otp_itinerary()]}},
     ])
 
-    result = await _async_plan_trip_otp(hass, "stop:1", "stop:2", None, provider)
+    result = await _async_plan_trip_otp("stop:1", "stop:2", None, provider)
     assert result is not None
     assert len(result) == 1
+
+    # Regression test for the issue #59 bug: a stray `session` positional
+    # argument used to shift into `_get`'s `url` parameter (real signature is
+    # `_get(self, url, params=None)` — the session is injected once via the
+    # constructor, not per-call).
+    for call in provider._get.call_args_list:
+        assert 1 <= len(call.args) <= 2
+        assert isinstance(call.args[0], str)
 
 
 async def test_otp_rest_plan_data_none(hass: HomeAssistant):
@@ -262,7 +270,7 @@ async def test_otp_rest_plan_data_none(hass: HomeAssistant):
     provider.otp_base_url = "http://otp.local"
     provider._get = AsyncMock(side_effect=[origin_stop, dest_stop, None])
 
-    result = await _async_plan_trip_otp(hass, "stop:1", "stop:2", None, provider)
+    result = await _async_plan_trip_otp("stop:1", "stop:2", None, provider)
     assert result is None
 
 

--- a/tests/test_trip_extended.py
+++ b/tests/test_trip_extended.py
@@ -252,13 +252,21 @@ async def test_otp_rest_with_itineraries(hass: HomeAssistant):
     assert result is not None
     assert len(result) == 1
 
-    # Regression test for the issue #59 bug: a stray `session` positional
-    # argument used to shift into `_get`'s `url` parameter (real signature is
+    # Regression test for the issue #59 bug: a stray `session` argument used to
+    # shift into `_get`'s `url` parameter (the real signature is
     # `_get(self, url, params=None)` — the session is injected once via the
-    # constructor, not per-call).
+    # constructor, not per call). A bare AsyncMock accepts any signature, so
+    # the shape is asserted explicitly, positionally or by keyword.
     for call in provider._get.call_args_list:
-        assert 1 <= len(call.args) <= 2
-        assert isinstance(call.args[0], str)
+        assert "session" not in call.kwargs
+        assert len(call.args) <= 2
+
+        url = call.kwargs["url"] if "url" in call.kwargs else call.args[0]
+        assert isinstance(url, str)
+        assert url.startswith("http")
+
+        params = call.kwargs.get("params", call.args[1] if len(call.args) > 1 else None)
+        assert params is None or isinstance(params, dict)
 
 
 async def test_otp_rest_plan_data_none(hass: HomeAssistant):


### PR DESCRIPTION
Fixes #59.

Lands the fix from @rayphi's PR #60 on a branch in this repo so a pre-release
can be built from it for testing. Commit authorship is preserved.

## Root cause

`_async_plan_trip_otp()` calls `provider_instance._get(session, url)`. That was
correct before the providers were extracted into `python-openpublictransport` —
back then the signature was `_get(self, session, url, params=None)`. In the
library the session is injected once via the constructor (`self.session`) and
the signature is `_get(self, url, params=None)`.

So the stray `session` lands in the `url` parameter and `self.session.get(<ClientSession>)`
blows up building a `yarl.URL` — the `Constructor parameter should be str`
warning from the issue. `_get` catches it and returns `None`, both stop lookups
fail, `if not origin_stop or not dest_stop` fires, and the sensor is stuck on
`No connections` forever.

The third `_get` call (`/plan`) has the same bug in a worse form: 3 positional
args against a 2-arg method. It was never reached because the coordinate lookup
always failed first.

The issue's own root-cause guess (missing `/index/stops/{id}` REST endpoint,
needs a `planConnection` migration like #46) is not the cause — VBN's departure
monitor uses that same `/index/stops/{id}/...` API and works fine.

## Changes

- Drop the stray `session` argument from all three `_get()` calls.
- Drop the now-unused `hass` parameter from `_async_plan_trip_otp()`, matching
  its sibling `_async_plan_trip_otp2_graphql()`; update the call site.
- Update the 4 affected tests and add a regression assertion over
  `provider._get.call_args_list` — the existing bare `AsyncMock()` (no `spec=`)
  accepted any argument count, which is why CI never caught the drift.

## Verification

- `pytest tests/ -q` → 492 passed
- `black --check` / `isort --check-only` / `flake8` on `custom_components/openpublictransport/` → clean

Live check for the pre-release: the VBN trip entry should leave `No connections`
and show a real journey.

The diagnostics HTTP 500 noted at the bottom of #59 is #58 and is handled separately.

Co-authored-by: Raphael Tweitmann <r.tweitmann@neusta.de>
