### PR TITLE
fix(diagnostics): make diagnostics work for trip and multi-stop entries (#58)

### DIFF
--- a/custom_components/openpublictransport/diagnostics.py
+++ b/custom_components/openpublictransport/diagnostics.py
@@ -2,17 +2,56 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .const import (
+    CONF_NATIONAL_RAIL_API_KEY,
+    CONF_NTA_API_KEY,
+    CONF_NTA_API_KEY_SECONDARY,
+    CONF_OPT_API_KEY,
+    CONF_OTP_CUSTOM_API_KEY,
+    CONF_REJSEPLANEN_API_KEY,
+    CONF_RMV_API_KEY,
+    CONF_TRAFIKLAB_API_KEY,
+    CONF_VBN_API_KEY,
+)
+
 TO_REDACT = {
     "station_id",
     "place_dm",
     "name_dm",
+    # Trip planner entries
+    "trip_origin",
+    "trip_origin_city",
+    "trip_origin_id",
+    "trip_destination",
+    "trip_destination_city",
+    "trip_destination_id",
+    # Credentials — these normally live in the Application Credentials store,
+    # but older entries and the reconfigure path can still carry them in data.
+    CONF_TRAFIKLAB_API_KEY,
+    CONF_NTA_API_KEY,
+    CONF_NTA_API_KEY_SECONDARY,
+    CONF_RMV_API_KEY,
+    CONF_VBN_API_KEY,
+    CONF_OPT_API_KEY,
+    CONF_OTP_CUSTOM_API_KEY,
+    CONF_NATIONAL_RAIL_API_KEY,
+    CONF_REJSEPLANEN_API_KEY,
 }
+
+
+def _entry_type(entry: ConfigEntry) -> str:
+    """Return which of the three entry flavours this config entry is."""
+    if entry.data.get("is_trip"):
+        return "trip"
+    if entry.data.get("is_multi_stop"):
+        return "multi_stop"
+    return "departure_monitor"
 
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
@@ -20,47 +59,131 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 
     coordinator = getattr(entry, "runtime_data", None)
 
-    diagnostics_data = {
+    diagnostics_data: dict[str, Any] = {
         "entry": {
             "title": entry.title,
+            "entry_type": _entry_type(entry),
             "data": async_redact_data(entry.data, TO_REDACT),
             "options": async_redact_data(entry.options, TO_REDACT),
         },
     }
 
     if coordinator:
-        diagnostics_data["coordinator"] = {
-            "provider": coordinator.provider,
-            "last_update_success": coordinator.last_update_success,
-            "last_update_success_time": (
-                coordinator.last_update_success_time.isoformat() if coordinator.last_update_success_time else None
-            ),
-            "update_interval": str(coordinator.update_interval),
-            "api_calls_today": coordinator._api_calls_today,
-            "last_api_reset": coordinator._last_api_reset.isoformat(),
-            "departures_limit": coordinator.departures_limit,
-        }
+        diagnostics_data["coordinator"] = _coordinator_diagnostics(coordinator)
 
-        # Add sample of last data (anonymized)
-        if coordinator.data:
-            stop_events = coordinator.data.get("stopEvents", [])
-            diagnostics_data["last_api_response"] = {
-                "stop_events_count": len(stop_events),
-                "sample_event": _anonymize_stop_event(stop_events[0]) if stop_events else None,
-            }
+        last_response = _last_response_diagnostics(coordinator)
+        if last_response is not None:
+            diagnostics_data["last_api_response"] = last_response
 
     return diagnostics_data
 
 
-def _anonymize_stop_event(event: dict[str, Any]) -> dict[str, Any]:
+def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
+    """Describe a coordinator without assuming which flavour it is.
+
+    The departure monitor (`PublicTransportDataUpdateCoordinator`) and the trip
+    planner (`TripDataUpdateCoordinator`) do not share a shape — the trip
+    coordinator has no API-call budget and no departure limit — so every
+    flavour-specific attribute is read defensively (issue #58).
+    """
+    data: dict[str, Any] = {
+        "coordinator_type": type(coordinator).__name__,
+        "provider": getattr(coordinator, "provider", None),
+        "last_update_success": getattr(coordinator, "last_update_success", None),
+        "last_update_success_time": _isoformat(getattr(coordinator, "last_update_success_time", None)),
+        "update_interval": str(getattr(coordinator, "update_interval", None)),
+    }
+
+    for key, attr in (
+        ("api_calls_today", "_api_calls_today"),
+        ("departures_limit", "departures_limit"),
+    ):
+        value = getattr(coordinator, attr, None)
+        if value is not None:
+            data[key] = value
+
+    last_api_reset = getattr(coordinator, "_last_api_reset", None)
+    if last_api_reset is not None:
+        data["last_api_reset"] = _isoformat(last_api_reset)
+
+    return data
+
+
+def _last_response_diagnostics(coordinator: Any) -> Optional[dict[str, Any]]:
+    """Summarise the coordinator's last payload, whatever shape it has."""
+    data = getattr(coordinator, "data", None)
+
+    # Departure monitor: {"stopEvents": [...]}
+    if isinstance(data, dict):
+        stop_events = data.get("stopEvents", [])
+        if not isinstance(stop_events, list):
+            stop_events = []
+        return {
+            "stop_events_count": len(stop_events),
+            "sample_event": _anonymize_stop_event(stop_events[0]) if stop_events else None,
+        }
+
+    # Trip planner: a list of journey dicts
+    if isinstance(data, list):
+        return {
+            "journey_count": len(data),
+            "sample_journey": _anonymize_journey(data[0]) if data else None,
+        }
+
+    return None
+
+
+def _isoformat(value: Any) -> Optional[str]:
+    """Return ``value.isoformat()`` when value is datetime-like, else None."""
+    isoformat = getattr(value, "isoformat", None)
+    return isoformat() if callable(isoformat) else None
+
+
+def _anonymize_stop_event(event: Any) -> Optional[dict[str, Any]]:
     """Anonymize a stop event for diagnostics."""
+    if not isinstance(event, dict):
+        return None
+
+    transportation = event.get("transportation")
+    if not isinstance(transportation, dict):
+        transportation = {}
+    product = transportation.get("product")
+    if not isinstance(product, dict):
+        product = {}
+
     return {
         "has_departure_time_planned": "departureTimePlanned" in event,
         "has_departure_time_estimated": "departureTimeEstimated" in event,
         "transportation": {
-            "product_class": event.get("transportation", {}).get("product", {}).get("class"),
-            "product_name": event.get("transportation", {}).get("product", {}).get("name"),
+            "product_class": product.get("class"),
+            "product_name": product.get("name"),
         },
         "realtime_status": event.get("realtimeStatus", []),
         "is_realtime_controlled": event.get("isRealtimeControlled"),
+    }
+
+
+def _anonymize_journey(journey: Any) -> Optional[dict[str, Any]]:
+    """Anonymize a trip-planner journey for diagnostics.
+
+    Keeps the structure that matters when debugging a trip — leg count,
+    products, transfer assessment — and drops the stop names.
+    """
+    if not isinstance(journey, dict):
+        return None
+
+    legs = journey.get("legs")
+    if not isinstance(legs, list):
+        legs = []
+
+    return {
+        "leg_count": len(legs),
+        "leg_products": [leg.get("product") for leg in legs if isinstance(leg, dict)],
+        "has_departure": bool(journey.get("departure")),
+        "has_arrival": bool(journey.get("arrival")),
+        "duration_minutes": journey.get("duration_minutes"),
+        "transfers": journey.get("transfers"),
+        "connection_feasible": journey.get("connection_feasible"),
+        "transfer_risk": journey.get("transfer_risk"),
+        "min_transfer_time": journey.get("min_transfer_time"),
     }

--- a/custom_components/openpublictransport/diagnostics.py
+++ b/custom_components/openpublictransport/diagnostics.py
@@ -86,12 +86,16 @@ def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
     coordinator has no API-call budget and no departure limit — so every
     flavour-specific attribute is read defensively (issue #58).
     """
+    # Stringified because a timedelta is not JSON-serialisable — but a missing
+    # interval stays null rather than becoming the string "None".
+    update_interval = getattr(coordinator, "update_interval", None)
+
     data: dict[str, Any] = {
         "coordinator_type": type(coordinator).__name__,
         "provider": getattr(coordinator, "provider", None),
         "last_update_success": getattr(coordinator, "last_update_success", None),
         "last_update_success_time": _isoformat(getattr(coordinator, "last_update_success_time", None)),
-        "update_interval": str(getattr(coordinator, "update_interval", None)),
+        "update_interval": str(update_interval) if update_interval is not None else None,
     }
 
     for key, attr in (

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -5,7 +5,7 @@ Created via the plan_trip config flow.
 """
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from homeassistant.components.sensor import SensorEntity
@@ -16,6 +16,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_OPT_API_KEY,
@@ -73,10 +74,13 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
         self.dest_id = dest_id
         self.api_key = api_key
         self.custom_url = custom_url
+        # Mirrors PublicTransportDataUpdateCoordinator so diagnostics can report
+        # it for trip entries too (issue #58).
+        self.last_update_success_time: Optional[datetime] = None
 
     async def _async_update_data(self) -> Optional[List[Dict[str, Any]]]:
         """Fetch trip data."""
-        return await async_plan_trip(
+        data = await async_plan_trip(
             self.hass,
             self.provider,
             self.origin,
@@ -88,6 +92,11 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
             api_key=self.api_key,
             custom_url=self.custom_url,
         )
+        if data:
+            # Only stamp an actual result — async_plan_trip returns None when
+            # the provider yields no journeys, same as the departure monitor.
+            self.last_update_success_time = dt_util.now()
+        return data
 
 
 async def async_setup_trip_entry(

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -92,9 +92,11 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
             api_key=self.api_key,
             custom_url=self.custom_url,
         )
-        if data:
-            # Only stamp an actual result — async_plan_trip returns None when
-            # the provider yields no journeys, same as the departure monitor.
+        if data is not None:
+            # `None` is a failed or unsupported lookup; an empty list is a
+            # successful query that simply found no connection (EFA's
+            # _parse_journeys returns [] for an empty board). Both leave
+            # last_update_success True, so only the former must skip the stamp.
             self.last_update_success_time = dt_util.now()
         return data
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,9 +1,14 @@
 """Tests for OpenPublicTransport diagnostics."""
 
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.openpublictransport.const import DOMAIN
 from custom_components.openpublictransport.diagnostics import async_get_config_entry_diagnostics
+from custom_components.openpublictransport.trip_sensor import TripDataUpdateCoordinator
 
 
 async def test_diagnostics(hass: HomeAssistant, mock_config_entry, mock_coordinator):
@@ -18,6 +23,7 @@ async def test_diagnostics(hass: HomeAssistant, mock_config_entry, mock_coordina
     assert "entry" in diagnostics
     assert "coordinator" in diagnostics
     assert diagnostics["entry"]["title"] == "Test Station"
+    assert diagnostics["entry"]["entry_type"] == "departure_monitor"
     assert diagnostics["entry"]["data"]["provider"] == "vrr"
     # place_dm and name_dm should be redacted
     assert diagnostics["entry"]["data"]["place_dm"] == "**REDACTED**"
@@ -28,6 +34,10 @@ async def test_diagnostics(hass: HomeAssistant, mock_config_entry, mock_coordina
     assert "last_update_success" in diagnostics["coordinator"]
     assert "last_update_success_time" in diagnostics["coordinator"]
     assert diagnostics["coordinator"]["last_update_success_time"] is None
+
+    # Departure-monitor payload is summarised, not dumped
+    assert diagnostics["last_api_response"]["stop_events_count"] == len(mock_coordinator.data["stopEvents"])
+    assert diagnostics["last_api_response"]["sample_event"]["has_departure_time_planned"] is True
 
 
 async def test_diagnostics_no_coordinator(hass: HomeAssistant, mock_config_entry):
@@ -40,3 +50,170 @@ async def test_diagnostics_no_coordinator(hass: HomeAssistant, mock_config_entry
     # When no coordinator, the diagnostics should still have entry data but no coordinator
     assert "entry" in diagnostics
     assert "coordinator" not in diagnostics
+
+
+def _trip_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a trip-planner config entry added to hass."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="KVV Karlsruhe → Ettlingen",
+        data={
+            "is_trip": True,
+            "trip_provider": "kvv",
+            "trip_origin": "Hauptbahnhof",
+            "trip_origin_city": "Karlsruhe",
+            "trip_origin_id": "de:08212:1",
+            "trip_destination": "Stadtbahnhof",
+            "trip_destination_city": "Ettlingen",
+            "trip_destination_id": "de:08215:2",
+            "scan_interval": 120,
+        },
+        unique_id="kvv_trip_test",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _journey() -> dict:
+    """Return a journey in the shape async_plan_trip produces."""
+    return {
+        "departure": "10:05",
+        "arrival": "10:32",
+        "duration_minutes": 27,
+        "transfers": 1,
+        "connection_feasible": True,
+        "transfer_risk": "low",
+        "min_transfer_time": 6,
+        "legs": [
+            {"origin": "Hauptbahnhof", "destination": "Marktplatz", "line": "S1", "product": "tram"},
+            {"origin": "Marktplatz", "destination": "Stadtbahnhof", "line": "S2", "product": "train"},
+        ],
+    }
+
+
+async def test_diagnostics_trip_entry(hass: HomeAssistant):
+    """Trip entries produce diagnostics instead of raising AttributeError (issue #58).
+
+    TripDataUpdateCoordinator has no _api_calls_today / _last_api_reset /
+    departures_limit, and its data is a list of journeys rather than a
+    {"stopEvents": [...]} dict.
+    """
+    entry = _trip_entry(hass)
+
+    coordinator = TripDataUpdateCoordinator(
+        hass,
+        "kvv",
+        "Hauptbahnhof",
+        "Karlsruhe",
+        "Stadtbahnhof",
+        "Ettlingen",
+        scan_interval=120,
+        origin_id="de:08212:1",
+        dest_id="de:08215:2",
+    )
+    coordinator.data = [_journey()]
+    coordinator.last_update_success_time = datetime(2026, 7, 20, 15, 55, tzinfo=timezone.utc)
+    entry.runtime_data = coordinator
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["entry"]["entry_type"] == "trip"
+    # Origin/destination are stop names — they must not leak
+    assert diagnostics["entry"]["data"]["trip_origin"] == "**REDACTED**"
+    assert diagnostics["entry"]["data"]["trip_destination"] == "**REDACTED**"
+    assert diagnostics["entry"]["data"]["trip_origin_id"] == "**REDACTED**"
+
+    coord = diagnostics["coordinator"]
+    assert coord["coordinator_type"] == "TripDataUpdateCoordinator"
+    assert coord["provider"] == "kvv"
+    assert coord["last_update_success_time"] == "2026-07-20T15:55:00+00:00"
+    # Departure-monitor-only fields are simply absent, not fatal
+    assert "api_calls_today" not in coord
+    assert "departures_limit" not in coord
+    assert "last_api_reset" not in coord
+
+    response = diagnostics["last_api_response"]
+    assert response["journey_count"] == 1
+    assert response["sample_journey"]["leg_count"] == 2
+    assert response["sample_journey"]["leg_products"] == ["tram", "train"]
+    assert response["sample_journey"]["transfer_risk"] == "low"
+    # Stop names must not survive anonymisation
+    assert "Hauptbahnhof" not in str(response)
+
+
+async def test_diagnostics_trip_entry_without_data(hass: HomeAssistant):
+    """A trip coordinator that never produced a journey still yields diagnostics."""
+    entry = _trip_entry(hass)
+
+    coordinator = TripDataUpdateCoordinator(
+        hass,
+        "vbn_otp",
+        "Bremen Hbf",
+        "Bremen",
+        "Oldenburg Hbf",
+        "Oldenburg",
+    )
+    coordinator.data = None
+    entry.runtime_data = coordinator
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["coordinator"]["last_update_success_time"] is None
+    assert "last_api_response" not in diagnostics
+
+
+async def test_diagnostics_multi_stop_entry(hass: HomeAssistant):
+    """Multi-stop entries have no coordinator at all."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Multi-Stop",
+        data={
+            "is_multi_stop": True,
+            "source_entities": ["sensor.a", "sensor.b"],
+            "multi_stop_name": "Zuhause",
+        },
+        unique_id="multi_stop_test",
+    )
+    entry.add_to_hass(hass)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["entry"]["entry_type"] == "multi_stop"
+    assert "coordinator" not in diagnostics
+
+
+async def test_diagnostics_redacts_api_keys(hass: HomeAssistant):
+    """API keys left in entry.data by older entries must be redacted."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="VBN",
+        data={
+            "provider": "vbn_otp",
+            "station_id": "1:000009013845",
+            "vbn_api_key": "super-secret",
+        },
+        unique_id="vbn_otp_test",
+    )
+    entry.add_to_hass(hass)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["entry"]["data"]["vbn_api_key"] == "**REDACTED**"
+    assert "super-secret" not in str(diagnostics)
+
+
+async def test_coordinator_diagnostics_tolerates_partial_coordinator(hass: HomeAssistant, mock_config_entry):
+    """A coordinator missing every optional attribute must not raise."""
+    coordinator = MagicMock(spec=["provider", "last_update_success", "update_interval", "data"])
+    coordinator.provider = "vrr"
+    coordinator.last_update_success = False
+    coordinator.update_interval = timedelta(seconds=60)
+    coordinator.data = None
+    mock_config_entry.runtime_data = coordinator
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+
+    assert diagnostics["coordinator"]["last_update_success"] is False
+    assert diagnostics["coordinator"]["last_update_success_time"] is None
+    assert diagnostics["coordinator"]["update_interval"] == "0:01:00"
+    assert "last_api_response" not in diagnostics

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -217,3 +217,16 @@ async def test_coordinator_diagnostics_tolerates_partial_coordinator(hass: HomeA
     assert diagnostics["coordinator"]["last_update_success_time"] is None
     assert diagnostics["coordinator"]["update_interval"] == "0:01:00"
     assert "last_api_response" not in diagnostics
+
+
+async def test_missing_update_interval_is_null_not_the_string_none(hass: HomeAssistant, mock_config_entry):
+    """A missing interval stays JSON null, like every other absent field."""
+    coordinator = MagicMock(spec=["provider", "last_update_success", "data"])
+    coordinator.provider = "vrr"
+    coordinator.last_update_success = True
+    coordinator.data = None
+    mock_config_entry.runtime_data = coordinator
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+
+    assert diagnostics["coordinator"]["update_interval"] is None

--- a/tests/test_trip_sensor.py
+++ b/tests/test_trip_sensor.py
@@ -78,6 +78,40 @@ async def test_coordinator_async_update_data(hass: HomeAssistant):
         result = await coordinator._async_update_data()
 
     assert result == mock_journeys
+    assert coordinator.last_update_success_time is not None
+
+
+async def test_empty_journey_list_still_counts_as_a_successful_update(hass: HomeAssistant):
+    """[] is "no connection right now", not a failure (issue #58 review).
+
+    EFA's _parse_journeys returns [] for an empty board. The coordinator
+    reports last_update_success=True for it, so diagnostics must not show a
+    null last_update_success_time alongside that.
+    """
+    coordinator = _make_trip_coordinator(hass)
+
+    with patch(
+        "custom_components.openpublictransport.trip_sensor.async_plan_trip",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        result = await coordinator._async_update_data()
+
+    assert result == []
+    assert coordinator.last_update_success_time is not None
+
+
+async def test_failed_lookup_does_not_stamp_a_success_time(hass: HomeAssistant):
+    """None means the lookup failed or the provider is unsupported."""
+    coordinator = _make_trip_coordinator(hass)
+
+    with patch(
+        "custom_components.openpublictransport.trip_sensor.async_plan_trip",
+        new_callable=AsyncMock, return_value=None,
+    ):
+        result = await coordinator._async_update_data()
+
+    assert result is None
+    assert coordinator.last_update_success_time is None
 
 
 # ── async_setup_trip_entry ────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #58.

## Root cause

`diagnostics.py` was written against the departure-monitor coordinator and read four of
its attributes unconditionally:

```python
coordinator.last_update_success_time.isoformat()
coordinator._api_calls_today
coordinator._last_api_reset.isoformat()
coordinator.departures_limit
```

`TripDataUpdateCoordinator` has **none** of them — hence the `AttributeError` from the
issue. And `coordinator.data` for a trip is a *list of journeys*, not a
`{"stopEvents": [...]}` dict, so `coordinator.data.get("stopEvents", [])` would have been
the next crash immediately behind the first. Multi-stop entries have no coordinator at all.

The existing test never caught this because `mock_coordinator` is a bare `MagicMock`, which
happily answers any attribute.

## Changes

- `diagnostics.py`
  - every flavour-specific attribute is read via `getattr(..., None)` and only emitted when
    present, so the trip coordinator simply reports fewer fields instead of exploding;
  - new `coordinator_type` and `entry.entry_type` fields, so a dump says what it describes;
  - the payload is summarised **by shape** — `stop_events_count` + anonymised sample event
    for a dict, `journey_count` + anonymised sample journey for a list;
  - `_anonymize_journey()` keeps leg count, products and the transfer assessment and drops
    the stop names;
  - `TO_REDACT` gains the trip origin/destination names and IDs, plus the nine `*_api_key`
    config keys older entries can still carry in `entry.data`.
- `trip_sensor.py` — `TripDataUpdateCoordinator` gets its own `last_update_success_time`,
  stamped only on an actual result, mirroring `PublicTransportDataUpdateCoordinator`.

## Tests

`tests/test_diagnostics.py` grows from 2 to 7 tests: a real (not mocked)
`TripDataUpdateCoordinator`, a trip coordinator that never produced a journey, a multi-stop
entry, API-key redaction, and a `MagicMock(spec=[...])` coordinator missing every optional
attribute.

- `pytest tests/ -q` → 497 passed
- `black --check` / `isort --check-only` / `flake8` → clean

## What to test in the pre-release

Settings → Devices & services → OpenPublicTransport → three-dot menu on a **Trip Planner**
entry → *Download diagnostics*. You should get a redacted JSON file instead of a failed
download. Departure Monitor entries should behave exactly as before.

This also clears the diagnostics HTTP 500 noted at the bottom of #59.
