### PR TITLE
fix(deps): require python-openpublictransport 0.1.15 for EFA platform (#56)

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,7 +14,7 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.14",
+    "python-openpublictransport==0.1.15",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -64,7 +64,10 @@ Each departure in the `departures` list contains:
 | `departure_time` | String | Actual/estimated departure time (HH:MM) |
 | `planned_time` | String | Scheduled departure time (HH:MM) |
 | `delay` | Integer | Delay in minutes (0 if on time) |
-| `platform` | String | Platform/track number |
+| `platform` | String | Platform/track — the provider's technical identifier (`"3"`, `"A"`) |
+| `platform_name` | String | Human-readable platform label (`"Gleis 3"`), only when it differs from `platform` |
+| `planned_platform` | String | Scheduled platform, only present when it changed |
+| `platform_changed` | Boolean | `true` when the departure was moved to another platform |
 | `transportation_type` | String | Type: bus, train, tram, subway, ferry, taxi |
 | `is_realtime` | Boolean | Whether real-time data is available |
 | `minutes_until_departure` | Integer | Minutes until departure |

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,5 +5,5 @@ pytest-cov>=4.1.0
 pytest-homeassistant-custom-component>=0.13.0
 homeassistant>=2024.1.0
 aiofiles>=23.0.0
-python-openpublictransport>=0.1.5
+python-openpublictransport>=0.1.15
 PyTurboJPEG>=1.7.0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -319,6 +319,84 @@ async def test_sensor_destination_filtering(hass: HomeAssistant):
     assert departures[0]["destination"] == "Duisburg Hbf"
 
 
+async def test_sensor_exposes_efa_platform(hass: HomeAssistant):
+    """EFA departures reach HA with their platform filled in (issue #56).
+
+    The track lives at location.properties.platform in EFA's RapidJSON. Needs
+    python-openpublictransport >= 0.1.15.
+    """
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.openpublictransport.const import CONF_PROVIDER, CONF_STATION_ID, PROVIDER_VVS
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="VVS Stuttgart - Vaihingen",
+        data={
+            CONF_PROVIDER: PROVIDER_VVS,
+            "place_dm": "Stuttgart",
+            "name_dm": "Vaihingen",
+            CONF_STATION_ID: "de:08111:6002",
+        },
+        unique_id="vvs_platform",
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = MagicMock()
+    coordinator.data = {
+        "stopEvents": [
+            {
+                "location": {
+                    "id": "de:08111:6002:1:3",
+                    "name": "Vaihingen",
+                    "disassembledName": "Gleis 3",
+                    "type": "platform",
+                    "pointType": "TRACK",
+                    "properties": {
+                        "stopId": "5006002",
+                        "platform": "3",
+                        "platformName": "Gleis 3",
+                        "plannedPlatformName": "Gleis 3",
+                    },
+                },
+                "departureTimePlanned": "2026-07-18T18:25:00Z",
+                "departureTimeEstimated": "2026-07-18T18:26:00Z",
+                "isRealtimeControlled": True,
+                "transportation": {
+                    "number": "S1",
+                    "destination": {"name": "Plochingen"},
+                    "description": "Herrenberg - Stuttgart - Plochingen",
+                    "product": {"class": 1, "name": "S-Bahn"},
+                },
+            }
+        ]
+    }
+    coordinator.last_update_success = True
+    coordinator.provider = PROVIDER_VVS
+    coordinator.place_dm = "Stuttgart"
+    coordinator.name_dm = "Vaihingen"
+    coordinator.station_id = "de:08111:6002"
+    coordinator.departures_limit = 10
+
+    from openpublictransport import get_provider
+
+    coordinator.provider_instance = get_provider(PROVIDER_VVS, hass)
+
+    sensor = MultiProviderSensor(coordinator, entry, ["train"])
+
+    with patch("custom_components.openpublictransport.sensor.dt_util.now") as mock_now:
+        mock_now.return_value = dt_util.parse_datetime("2026-07-18T18:08:00Z")
+        sensor._process_departure_data(coordinator.data)
+
+    departures = sensor._attributes.get("departures", [])
+    assert len(departures) == 1
+    # Technical value, not the "Gleis 3" label
+    assert departures[0]["platform"] == "3"
+    assert departures[0]["platform_name"] == "Gleis 3"
+    # "3" vs "Gleis 3" is the same platform, not a change
+    assert "platform_changed" not in departures[0]
+
+
 # ── restore state across restart ──────────────────────────────────────────────
 # Regression: after a restart the push-style sensor showed `unknown` until the
 # next poll. It should now populate on add — from fresh coordinator data if


### PR DESCRIPTION
Fixes #56 — integration half. The actual fix is in the library:
**NerdySoftPaw/python-openpublictransport#15** (releases 0.1.15).

## Root cause (recap)

`EFABaseProvider.get_platform_fn()` read `platform.name` / `platformName`. EFA's RapidJSON
has neither — the track is at `location.properties.platform`. Every EFA provider without its
own override reported `platform: ''` while the API had the value all along: **VVS, VRR, MVV,
VGN, VRN, VVO, DING, AVV, RVV, BSVG, NWL, VAG**. HVV and KVV had private workarounds.

## Changes here

- `manifest.json` — pin `python-openpublictransport==0.1.15`.
- `requirements_test.txt` — `>=0.1.15`, so CI actually exercises the fix.
- `docs/sensors.md` — document `platform` as the technical identifier and add the three
  attributes that now become meaningful: `platform_name`, `planned_platform`,
  `platform_changed`.
- `tests/test_sensor.py` — end-to-end test that the payload from the issue reaches the
  `departures` attribute as `platform: "3"` / `platform_name: "Gleis 3"`, with no spurious
  `platform_changed`.

## ⚠️ Behaviour change for KVV

KVV's override pinned the *readable* `location.disassembledName`, so its `platform` was
`"Gleis 3"`. It is now `"3"`, consistent with every other EFA provider. The readable string
is still there as `platform_name`. Anything comparing `platform == "Gleis 3"` in a template
or card needs updating.

## ⚠️ CI is red until 0.1.15 is on PyPI

`requirements_test.txt` asks for `>=0.1.15`, which does not exist yet — the library PR needs
to merge and be released first. That is the point: this PR genuinely cannot work on 0.1.14.
CI goes green on its own once the release lands.

Locally, against the library branch: **493 passed**, `black` / `flake8` clean.

## What to test in the pre-release

A VVS S-Bahn departure should show `platform: "3"` (previously `''`). On KVV, expect `"3"`
where you used to see `"Gleis 3"`. Bus stops should now show their technical platform (e.g.
`"A"`) where the readable label was empty.

## Follow-up (not in this PR)

`custom_components/openpublictransport/parsers.py` is a stale copy of the library's parser —
nothing imports it except two test modules, and it still contains the pre-fix
planned-platform logic. Worth deleting so nobody "fixes" the wrong file.
