### PR TITLE
feat(sensor): add a platform/track filter for departures (#57)

### DIFF
--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_OPT_API_KEY,
     CONF_OTP_BASE_URL,
     CONF_OTP_CUSTOM_API_KEY,
+    CONF_PLATFORM_FILTER,
     CONF_PROVIDER,
     CONF_REJSEPLANEN_API_KEY,
     CONF_RMV_API_KEY,
@@ -47,6 +48,7 @@ from .const import (
     DEFAULT_DELAY_THRESHOLD,
     DEFAULT_DEPARTURES,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WALKING_TIME,
     DOMAIN,
     PROVIDER_HVV,
     PROVIDER_KVV,
@@ -720,6 +722,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 ),
                 vol.Optional(CONF_LINE_FILTER, default=""): str,
                 vol.Optional(CONF_DESTINATION_FILTER, default=""): str,
+                vol.Optional(CONF_PLATFORM_FILTER, default=""): str,
                 vol.Optional(CONF_FAVORITE_LINES, default=""): str,
                 vol.Optional(CONF_WALKING_TIME, default=0): vol.All(int, vol.Range(min=0, max=30)),
             }
@@ -741,6 +744,15 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 CONF_TRANSPORTATION_TYPES: user_input[CONF_TRANSPORTATION_TYPES],
                 CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
                 CONF_USE_PROVIDER_LOGO: user_input.get(CONF_USE_PROVIDER_LOGO, False),
+                # These are offered by the settings form but used to be dropped
+                # on save, so a filter set during setup silently did nothing
+                # until it was entered again under Options.
+                CONF_DELAY_THRESHOLD: user_input.get(CONF_DELAY_THRESHOLD, DEFAULT_DELAY_THRESHOLD),
+                CONF_LINE_FILTER: user_input.get(CONF_LINE_FILTER, "").strip(),
+                CONF_DESTINATION_FILTER: user_input.get(CONF_DESTINATION_FILTER, "").strip(),
+                CONF_PLATFORM_FILTER: user_input.get(CONF_PLATFORM_FILTER, "").strip(),
+                CONF_FAVORITE_LINES: user_input.get(CONF_FAVORITE_LINES, "").strip(),
+                CONF_WALKING_TIME: user_input.get(CONF_WALKING_TIME, DEFAULT_WALKING_TIME),
             }
             # Add API key for Trafiklab or NTA (required)
             if self._provider == PROVIDER_TRAFIKLAB_SE:
@@ -1872,6 +1884,10 @@ class OpenPublicTransportOptionsFlowHandler(config_entries.OptionsFlow):
             CONF_DESTINATION_FILTER,
             self.config_entry.data.get(CONF_DESTINATION_FILTER, ""),
         )
+        current_platform_filter = self.config_entry.options.get(
+            CONF_PLATFORM_FILTER,
+            self.config_entry.data.get(CONF_PLATFORM_FILTER, ""),
+        )
         current_walking_time = self.config_entry.options.get(
             CONF_WALKING_TIME,
             self.config_entry.data.get(CONF_WALKING_TIME, 0),
@@ -1892,6 +1908,7 @@ class OpenPublicTransportOptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 vol.Optional(CONF_LINE_FILTER, default=current_line_filter): str,
                 vol.Optional(CONF_DESTINATION_FILTER, default=current_destination_filter): str,
+                vol.Optional(CONF_PLATFORM_FILTER, default=current_platform_filter): str,
                 vol.Optional(
                     CONF_FAVORITE_LINES,
                     default=self.config_entry.options.get(

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -4,7 +4,7 @@ DEFAULT_NAME = "Elbruchstrasse"
 DEFAULT_DEPARTURES = 10
 DEFAULT_SCAN_INTERVAL = 60
 
-# When a line/destination filter is active, fetch a larger raw board from the API
+# When a line/destination/platform filter is active, fetch a larger raw board from the API
 # so client-side filtering isn't starved before truncating to the display count (issue #43).
 FILTERED_FETCH_LIMIT = 100
 
@@ -21,6 +21,7 @@ CONF_USE_PROVIDER_LOGO = "use_provider_logo"  # Show provider logo instead of tr
 CONF_DELAY_THRESHOLD = "delay_threshold"  # Minutes threshold for delay binary sensor
 CONF_LINE_FILTER = "line_filter"  # Comma-separated line numbers to show
 CONF_DESTINATION_FILTER = "destination_filter"  # Comma-separated destinations (substring match) to show
+CONF_PLATFORM_FILTER = "platform_filter"  # Comma-separated platforms/tracks to show
 CONF_WALKING_TIME = "walking_time"  # Minutes to walk to the stop
 CONF_FAVORITE_LINES = "favorite_lines"  # Comma-separated favorite lines (shown first)
 DEFAULT_DELAY_THRESHOLD = 5

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 from openpublictransport import AuthenticationError, get_provider
+from openpublictransport.parsers import normalize_platform
 
 from .const import (
     API_RATE_LIMIT_PER_DAY,
@@ -25,6 +26,7 @@ from .const import (
     CONF_FAVORITE_LINES,
     CONF_LINE_FILTER,
     CONF_NTA_API_KEY_SECONDARY,
+    CONF_PLATFORM_FILTER,
     CONF_SCAN_INTERVAL,
     CONF_TRANSPORTATION_TYPES,
     CONF_USE_PROVIDER_LOGO,
@@ -255,7 +257,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error fetching data: {err}")
 
     def _compute_fetch_limit(self) -> int:
-        """Over-fetch a larger board when a line/destination filter is active.
+        """Over-fetch a larger board when a line/destination/platform filter is active.
 
         Filters are applied client-side after the fetch, so requesting only
         ``departures_limit`` starves filtered results at busy stops (issue #43).
@@ -264,9 +266,11 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
         """
         entry = self._config_entry
         if entry is not None:
-            line = entry.options.get(CONF_LINE_FILTER, entry.data.get(CONF_LINE_FILTER, ""))
-            dest = entry.options.get(CONF_DESTINATION_FILTER, entry.data.get(CONF_DESTINATION_FILTER, ""))
-            if (line or "").strip() or (dest or "").strip():
+            active = (
+                entry.options.get(key, entry.data.get(key, "")) or ""
+                for key in (CONF_LINE_FILTER, CONF_DESTINATION_FILTER, CONF_PLATFORM_FILTER)
+            )
+            if any(value.strip() for value in active):
                 return max(self.departures_limit, FILTERED_FETCH_LIMIT)
         return self.departures_limit
 
@@ -352,6 +356,17 @@ class MultiProviderSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         )
         self._destination_filter: list[str] = (
             [d.strip().lower() for d in dest_filter_str.split(",") if d.strip()] if dest_filter_str else []
+        )
+
+        # Get platform filter from options/data (exact match on the normalized
+        # track, so "3" and "Gleis 3" are interchangeable — issue #57)
+        platform_filter_str = config_entry.options.get(
+            CONF_PLATFORM_FILTER, config_entry.data.get(CONF_PLATFORM_FILTER, "")
+        )
+        self._platform_filter: set[str] = (
+            {normalize_platform(p) for p in platform_filter_str.split(",") if normalize_platform(p)}
+            if platform_filter_str
+            else set()
         )
 
         # Get favorite lines from options/data
@@ -579,6 +594,8 @@ class MultiProviderSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
                 if self._destination_filter and not any(
                     term in (dep.destination or "").lower() for term in self._destination_filter
                 ):
+                    continue
+                if self._platform_filter and normalize_platform(dep.platform) not in self._platform_filter:
                     continue
                 departures.append(dep)
 

--- a/custom_components/openpublictransport/strings.json
+++ b/custom_components/openpublictransport/strings.json
@@ -75,6 +75,7 @@
           "delay_threshold": "Verspätungs-Schwellwert (Minuten)",
           "line_filter": "Linien-Filter",
           "destination_filter": "Ziel-Filter",
+          "platform_filter": "Gleis-/Steig-Filter",
           "walking_time": "Fußweg (Minuten)",
           "favorite_lines": "Favoriten-Linien"
         },
@@ -86,6 +87,7 @@
           "delay_threshold": "Ab wie vielen Minuten Verspätung soll der Delay-Sensor auslösen? (1-30)",
           "line_filter": "Nur bestimmte Linien anzeigen, kommagetrennt (z.B. U79, RE5, Bus 42). Leer = alle Linien",
           "destination_filter": "Nur Abfahrten mit passendem Ziel anzeigen, kommagetrennt, Teiltreffer (z.B. Duisburg, Flughafen). Leer = alle Ziele",
+          "platform_filter": "Nur Abfahrten von bestimmten Gleisen/Steigen anzeigen, kommagetrennt (z.B. 3, 4 oder Gleis 3). Leer = alle Gleise",
           "walking_time": "Fußweg zur Haltestelle in Minuten (0 = deaktiviert). Abfahrten die nicht mehr erreichbar sind werden ausgeblendet",
           "favorite_lines": "Kommagetrennte Linien, die zuerst angezeigt werden (z.B. U79, RE5). Leer = keine Favoriten"
         }
@@ -164,6 +166,7 @@
           "delay_threshold": "Verspätungs-Schwellwert (Minuten)",
           "line_filter": "Linien-Filter",
           "destination_filter": "Ziel-Filter",
+          "platform_filter": "Gleis-/Steig-Filter",
           "walking_time": "Fußweg (Minuten)",
           "favorite_lines": "Favoriten-Linien"
         },
@@ -172,6 +175,7 @@
           "delay_threshold": "Ab wie vielen Minuten Verspätung soll der Delay-Sensor auslösen? (1-30)",
           "line_filter": "Nur bestimmte Linien anzeigen, kommagetrennt (z.B. U79, RE5, Bus 42). Leer = alle Linien",
           "destination_filter": "Nur Abfahrten mit passendem Ziel anzeigen, kommagetrennt, Teiltreffer (z.B. Duisburg, Flughafen). Leer = alle Ziele",
+          "platform_filter": "Nur Abfahrten von bestimmten Gleisen/Steigen anzeigen, kommagetrennt (z.B. 3, 4 oder Gleis 3). Leer = alle Gleise",
           "walking_time": "Fußweg zur Haltestelle in Minuten (0 = deaktiviert). Abfahrten die nicht mehr erreichbar sind werden ausgeblendet",
           "favorite_lines": "Kommagetrennte Linien, die zuerst angezeigt werden (z.B. U79, RE5). Leer = keine Favoriten"
         }

--- a/custom_components/openpublictransport/translations/de.json
+++ b/custom_components/openpublictransport/translations/de.json
@@ -74,6 +74,7 @@
           "delay_threshold": "Verspätungs-Schwellwert (Minuten)",
           "line_filter": "Linien-Filter",
           "destination_filter": "Ziel-Filter",
+          "platform_filter": "Gleis-/Steig-Filter",
           "walking_time": "Fußweg (Minuten)",
           "favorite_lines": "Favoriten-Linien"
         },
@@ -85,6 +86,7 @@
           "delay_threshold": "Ab wie vielen Minuten Verspätung soll der Delay-Sensor auslösen? (1-30)",
           "line_filter": "Nur bestimmte Linien anzeigen, kommagetrennt (z.B. U79, RE5, Bus 42). Leer = alle Linien",
           "destination_filter": "Nur Abfahrten mit passendem Ziel anzeigen, kommagetrennt, Teiltreffer (z.B. Duisburg, Flughafen). Leer = alle Ziele",
+          "platform_filter": "Nur Abfahrten von bestimmten Gleisen/Steigen anzeigen, kommagetrennt (z.B. 3, 4 oder Gleis 3). Leer = alle Gleise",
           "walking_time": "Fußweg zur Haltestelle in Minuten (0 = deaktiviert). Abfahrten die nicht mehr erreichbar sind werden ausgeblendet",
           "favorite_lines": "Kommagetrennte Linien, die zuerst angezeigt werden (z.B. U79, RE5). Leer = keine Favoriten"
         }
@@ -145,6 +147,7 @@
           "delay_threshold": "Verspätungs-Schwellwert (Minuten)",
           "line_filter": "Linien-Filter",
           "destination_filter": "Ziel-Filter",
+          "platform_filter": "Gleis-/Steig-Filter",
           "walking_time": "Fußweg (Minuten)",
           "favorite_lines": "Favoriten-Linien"
         },
@@ -153,6 +156,7 @@
           "delay_threshold": "Ab wie vielen Minuten Verspätung soll der Delay-Sensor auslösen? (1-30)",
           "line_filter": "Nur bestimmte Linien anzeigen, kommagetrennt (z.B. U79, RE5, Bus 42). Leer = alle Linien",
           "destination_filter": "Nur Abfahrten mit passendem Ziel anzeigen, kommagetrennt, Teiltreffer (z.B. Duisburg, Flughafen). Leer = alle Ziele",
+          "platform_filter": "Nur Abfahrten von bestimmten Gleisen/Steigen anzeigen, kommagetrennt (z.B. 3, 4 oder Gleis 3). Leer = alle Gleise",
           "walking_time": "Fußweg zur Haltestelle in Minuten (0 = deaktiviert). Abfahrten die nicht mehr erreichbar sind werden ausgeblendet",
           "favorite_lines": "Kommagetrennte Linien, die zuerst angezeigt werden (z.B. U79, RE5). Leer = keine Favoriten"
         }

--- a/custom_components/openpublictransport/translations/en.json
+++ b/custom_components/openpublictransport/translations/en.json
@@ -74,6 +74,7 @@
           "delay_threshold": "Delay threshold (minutes)",
           "line_filter": "Line filter",
           "destination_filter": "Destination filter",
+          "platform_filter": "Platform filter",
           "walking_time": "Walking time (minutes)",
           "favorite_lines": "Favorite lines"
         },
@@ -85,6 +86,7 @@
           "delay_threshold": "Minimum delay in minutes to trigger the delay sensor (1-30)",
           "line_filter": "Only show specific lines, comma-separated (e.g. U79, RE5, Bus 42). Empty = all lines",
           "destination_filter": "Show only departures whose destination matches, comma-separated, partial match (e.g. Duisburg, Airport). Empty = all destinations",
+          "platform_filter": "Show only departures from specific platforms/tracks, comma-separated (e.g. 3, 4 or Gleis 3). Empty = all platforms",
           "walking_time": "Walking time to stop in minutes (0 = disabled). Departures that can no longer be reached are hidden",
           "favorite_lines": "Comma-separated lines to show first (e.g. U79, RE5). Empty = no favorites"
         }
@@ -150,6 +152,7 @@
           "delay_threshold": "Delay threshold (minutes)",
           "line_filter": "Line filter",
           "destination_filter": "Destination filter",
+          "platform_filter": "Platform filter",
           "walking_time": "Walking time (minutes)",
           "favorite_lines": "Favorite lines"
         },
@@ -158,6 +161,7 @@
           "delay_threshold": "Minimum delay in minutes to trigger the delay sensor (1-30)",
           "line_filter": "Only show specific lines, comma-separated (e.g. U79, RE5, Bus 42). Empty = all lines",
           "destination_filter": "Show only departures whose destination matches, comma-separated, partial match (e.g. Duisburg, Airport). Empty = all destinations",
+          "platform_filter": "Show only departures from specific platforms/tracks, comma-separated (e.g. 3, 4 or Gleis 3). Empty = all platforms",
           "walking_time": "Walking time to stop in minutes (0 = disabled). Departures that can no longer be reached are hidden",
           "favorite_lines": "Comma-separated lines to show first (e.g. U79, RE5). Empty = no favorites"
         }

--- a/custom_components/openpublictransport/translations/fr.json
+++ b/custom_components/openpublictransport/translations/fr.json
@@ -75,6 +75,7 @@
           "delay_threshold": "Seuil de retard (minutes)",
           "line_filter": "Filtre de lignes",
           "destination_filter": "Filtre de destination",
+          "platform_filter": "Filtre de quai",
           "walking_time": "Temps de marche (minutes)",
           "favorite_lines": "Lignes favorites"
         },
@@ -86,6 +87,7 @@
           "delay_threshold": "Retard minimum en minutes pour déclencher le capteur de retard (1-30)",
           "line_filter": "Afficher uniquement certaines lignes, séparées par des virgules (ex. U79, RE5, Bus 42). Vide = toutes les lignes",
           "destination_filter": "Afficher uniquement les départs dont la destination correspond, séparés par des virgules, correspondance partielle (ex. Duisburg, Aéroport). Vide = toutes les destinations",
+          "platform_filter": "Afficher uniquement les départs de quais/voies spécifiques, séparés par des virgules (ex. 3, 4). Vide = tous les quais",
           "walking_time": "Temps de marche jusqu'à l'arrêt en minutes (0 = désactivé). Les départs qui ne peuvent plus être atteints sont masqués",
           "favorite_lines": "Lignes à afficher en premier, séparées par des virgules (ex. U79, RE5). Vide = pas de favoris"
         }
@@ -145,6 +147,7 @@
           "delay_threshold": "Seuil de retard (minutes)",
           "line_filter": "Filtre de lignes",
           "destination_filter": "Filtre de destination",
+          "platform_filter": "Filtre de quai",
           "walking_time": "Temps de marche (minutes)",
           "favorite_lines": "Lignes favorites"
         },
@@ -153,6 +156,7 @@
           "delay_threshold": "Retard minimum en minutes pour déclencher le capteur de retard (1-30)",
           "line_filter": "Afficher uniquement certaines lignes, séparées par des virgules (ex. U79, RE5, Bus 42). Vide = toutes les lignes",
           "destination_filter": "Afficher uniquement les départs dont la destination correspond, séparés par des virgules, correspondance partielle (ex. Duisburg, Aéroport). Vide = toutes les destinations",
+          "platform_filter": "Afficher uniquement les départs de quais/voies spécifiques, séparés par des virgules (ex. 3, 4). Vide = tous les quais",
           "walking_time": "Temps de marche jusqu'à l'arrêt en minutes (0 = désactivé). Les départs qui ne peuvent plus être atteints sont masqués",
           "favorite_lines": "Lignes à afficher en premier, séparées par des virgules (ex. U79, RE5). Vide = pas de favoris"
         }

--- a/custom_components/openpublictransport/translations/it.json
+++ b/custom_components/openpublictransport/translations/it.json
@@ -75,6 +75,7 @@
           "delay_threshold": "Soglia di ritardo (minuti)",
           "line_filter": "Filtro linee",
           "destination_filter": "Filtro destinazione",
+          "platform_filter": "Filtro binario",
           "walking_time": "Tempo a piedi (minuti)",
           "favorite_lines": "Linee preferite"
         },
@@ -86,6 +87,7 @@
           "delay_threshold": "Ritardo minimo in minuti per attivare il sensore di ritardo (1-30)",
           "line_filter": "Mostra solo linee specifiche, separate da virgole (es. U79, RE5, Bus 42). Vuoto = tutte le linee",
           "destination_filter": "Mostra solo le partenze con destinazione corrispondente, separate da virgola, corrispondenza parziale (es. Duisburg, Aeroporto). Vuoto = tutte le destinazioni",
+          "platform_filter": "Mostra solo le partenze da binari/marciapiedi specifici, separati da virgola (es. 3, 4). Vuoto = tutti i binari",
           "walking_time": "Tempo a piedi fino alla fermata in minuti (0 = disattivato). Le partenze non più raggiungibili vengono nascoste",
           "favorite_lines": "Linee da mostrare per prime, separate da virgole (es. U79, RE5). Vuoto = nessun preferito"
         }
@@ -145,6 +147,7 @@
           "delay_threshold": "Soglia di ritardo (minuti)",
           "line_filter": "Filtro linee",
           "destination_filter": "Filtro destinazione",
+          "platform_filter": "Filtro binario",
           "walking_time": "Tempo a piedi (minuti)",
           "favorite_lines": "Linee preferite"
         },
@@ -153,6 +156,7 @@
           "delay_threshold": "Ritardo minimo in minuti per attivare il sensore di ritardo (1-30)",
           "line_filter": "Mostra solo linee specifiche, separate da virgole (es. U79, RE5, Bus 42). Vuoto = tutte le linee",
           "destination_filter": "Mostra solo le partenze con destinazione corrispondente, separate da virgola, corrispondenza parziale (es. Duisburg, Aeroporto). Vuoto = tutte le destinazioni",
+          "platform_filter": "Mostra solo le partenze da binari/marciapiedi specifici, separati da virgola (es. 3, 4). Vuoto = tutti i binari",
           "walking_time": "Tempo a piedi fino alla fermata in minuti (0 = disattivato). Le partenze non più raggiungibili vengono nascoste",
           "favorite_lines": "Linee da mostrare per prime, separate da virgole (es. U79, RE5). Vuoto = nessun preferito"
         }

--- a/custom_components/openpublictransport/translations/nl.json
+++ b/custom_components/openpublictransport/translations/nl.json
@@ -75,6 +75,7 @@
           "delay_threshold": "Vertragingsdrempel (minuten)",
           "line_filter": "Lijnfilter",
           "destination_filter": "Bestemmingsfilter",
+          "platform_filter": "Perronfilter",
           "walking_time": "Looptijd (minuten)",
           "favorite_lines": "Favoriete lijnen"
         },
@@ -86,6 +87,7 @@
           "delay_threshold": "Minimale vertraging in minuten om de vertragingssensor te activeren (1-30)",
           "line_filter": "Toon alleen specifieke lijnen, gescheiden door komma's (bijv. U79, RE5, Bus 42). Leeg = alle lijnen",
           "destination_filter": "Toon alleen vertrekken met overeenkomende bestemming, kommagescheiden, gedeeltelijke overeenkomst (bijv. Duisburg, Luchthaven). Leeg = alle bestemmingen",
+          "platform_filter": "Toon alleen vertrekken van specifieke perrons/sporen, kommagescheiden (bijv. 3, 4). Leeg = alle perrons",
           "walking_time": "Looptijd naar de halte in minuten (0 = uitgeschakeld). Vertrekken die niet meer gehaald kunnen worden, worden verborgen",
           "favorite_lines": "Lijnen die als eerste worden getoond, gescheiden door komma's (bijv. U79, RE5). Leeg = geen favorieten"
         }
@@ -145,6 +147,7 @@
           "delay_threshold": "Vertragingsdrempel (minuten)",
           "line_filter": "Lijnfilter",
           "destination_filter": "Bestemmingsfilter",
+          "platform_filter": "Perronfilter",
           "walking_time": "Looptijd (minuten)",
           "favorite_lines": "Favoriete lijnen"
         },
@@ -153,6 +156,7 @@
           "delay_threshold": "Minimale vertraging in minuten om de vertragingssensor te activeren (1-30)",
           "line_filter": "Toon alleen specifieke lijnen, gescheiden door komma's (bijv. U79, RE5, Bus 42). Leeg = alle lijnen",
           "destination_filter": "Toon alleen vertrekken met overeenkomende bestemming, kommagescheiden, gedeeltelijke overeenkomst (bijv. Duisburg, Luchthaven). Leeg = alle bestemmingen",
+          "platform_filter": "Toon alleen vertrekken van specifieke perrons/sporen, kommagescheiden (bijv. 3, 4). Leeg = alle perrons",
           "walking_time": "Looptijd naar de halte in minuten (0 = uitgeschakeld). Vertrekken die niet meer gehaald kunnen worden, worden verborgen",
           "favorite_lines": "Lijnen die als eerste worden getoond, gescheiden door komma's (bijv. U79, RE5). Leeg = geen favorieten"
         }

--- a/custom_components/openpublictransport/translations/pl.json
+++ b/custom_components/openpublictransport/translations/pl.json
@@ -75,6 +75,7 @@
           "delay_threshold": "Próg opóźnienia (minuty)",
           "line_filter": "Filtr linii",
           "destination_filter": "Filtr kierunku",
+          "platform_filter": "Filtr peronu",
           "walking_time": "Czas dojścia (minuty)",
           "favorite_lines": "Ulubione linie"
         },
@@ -86,6 +87,7 @@
           "delay_threshold": "Minimalne opóźnienie w minutach, aby uruchomić czujnik opóźnień (1-30)",
           "line_filter": "Pokaż tylko określone linie, oddzielone przecinkami (np. U79, RE5, Bus 42). Puste = wszystkie linie",
           "destination_filter": "Pokaż tylko odjazdy z pasującym kierunkiem, oddzielone przecinkami, częściowe dopasowanie (np. Duisburg, Lotnisko). Puste = wszystkie kierunki",
+          "platform_filter": "Pokaż tylko odjazdy z określonych peronów/torów, oddzielone przecinkami (np. 3, 4). Puste = wszystkie perony",
           "walking_time": "Czas dojścia do przystanku w minutach (0 = wyłączone). Odjazdy, na które nie można już zdążyć, są ukrywane",
           "favorite_lines": "Linie wyświetlane na początku, oddzielone przecinkami (np. U79, RE5). Puste = brak ulubionych"
         }
@@ -145,6 +147,7 @@
           "delay_threshold": "Próg opóźnienia (minuty)",
           "line_filter": "Filtr linii",
           "destination_filter": "Filtr kierunku",
+          "platform_filter": "Filtr peronu",
           "walking_time": "Czas dojścia (minuty)",
           "favorite_lines": "Ulubione linie"
         },
@@ -153,6 +156,7 @@
           "delay_threshold": "Minimalne opóźnienie w minutach, aby uruchomić czujnik opóźnień (1-30)",
           "line_filter": "Pokaż tylko określone linie, oddzielone przecinkami (np. U79, RE5, Bus 42). Puste = wszystkie linie",
           "destination_filter": "Pokaż tylko odjazdy z pasującym kierunkiem, oddzielone przecinkami, częściowe dopasowanie (np. Duisburg, Lotnisko). Puste = wszystkie kierunki",
+          "platform_filter": "Pokaż tylko odjazdy z określonych peronów/torów, oddzielone przecinkami (np. 3, 4). Puste = wszystkie perony",
           "walking_time": "Czas dojścia do przystanku w minutach (0 = wyłączone). Odjazdy, na które nie można już zdążyć, są ukrywane",
           "favorite_lines": "Linie wyświetlane na początku, oddzielone przecinkami (np. U79, RE5). Puste = brak ulubionych"
         }

--- a/custom_components/openpublictransport/translations/sv.json
+++ b/custom_components/openpublictransport/translations/sv.json
@@ -75,6 +75,7 @@
           "delay_threshold": "Försenigströskel (minuter)",
           "line_filter": "Linjefilter",
           "destination_filter": "Destinationsfilter",
+          "platform_filter": "Plattformsfilter",
           "walking_time": "Gångtid (minuter)",
           "favorite_lines": "Favoritlinjer"
         },
@@ -86,6 +87,7 @@
           "delay_threshold": "Minsta försening i minuter för att utlösa förseningssensorn (1-30)",
           "line_filter": "Visa bara specifika linjer, kommaseparerade (t.ex. U79, RE5, Bus 42). Tomt = alla linjer",
           "destination_filter": "Visa endast avgångar med matchande destination, kommaseparerade, delvis matchning (t.ex. Duisburg, Flygplats). Tomt = alla destinationer",
+          "platform_filter": "Visa endast avgångar från specifika plattformar/spår, kommaseparerade (t.ex. 3, 4). Tomt = alla plattformar",
           "walking_time": "Gångtid till hållplatsen i minuter (0 = inaktiverat). Avgångar som inte längre kan nås döljs",
           "favorite_lines": "Linjer som visas först, kommaseparerade (t.ex. U79, RE5). Tomt = inga favoriter"
         }
@@ -145,6 +147,7 @@
           "delay_threshold": "Försenigströskel (minuter)",
           "line_filter": "Linjefilter",
           "destination_filter": "Destinationsfilter",
+          "platform_filter": "Plattformsfilter",
           "walking_time": "Gångtid (minuter)",
           "favorite_lines": "Favoritlinjer"
         },
@@ -153,6 +156,7 @@
           "delay_threshold": "Minsta försening i minuter för att utlösa förseningssensorn (1-30)",
           "line_filter": "Visa bara specifika linjer, kommaseparerade (t.ex. U79, RE5, Bus 42). Tomt = alla linjer",
           "destination_filter": "Visa endast avgångar med matchande destination, kommaseparerade, delvis matchning (t.ex. Duisburg, Flygplats). Tomt = alla destinationer",
+          "platform_filter": "Visa endast avgångar från specifika plattformar/spår, kommaseparerade (t.ex. 3, 4). Tomt = alla plattformar",
           "walking_time": "Gångtid till hållplatsen i minuter (0 = inaktiverat). Avgångar som inte längre kan nås döljs",
           "favorite_lines": "Linjer som visas först, kommaseparerade (t.ex. U79, RE5). Tomt = inga favoriter"
         }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,3 +138,34 @@ How often the integration fetches new data from the API.
 ### Use Provider Logo
 
 When enabled, the entity picture shows the provider's logo instead of the dynamic transport type icon.
+
+### Departure Filters
+
+Three optional filters narrow the departure list. All are comma-separated, all are applied
+after the data is fetched, and leaving one empty disables it. When any filter is active the
+integration fetches a larger raw board so filtered results aren't starved at busy stops.
+
+| Filter | Matching | Example |
+|--------|----------|---------|
+| **Line filter** | Exact line name, case-insensitive | `U79, RE5` |
+| **Destination filter** | Substring of the destination, case-insensitive | `Duisburg, Airport` |
+| **Platform filter** | Exact platform/track | `3, 4` |
+
+#### Platform filter
+
+Filtering by platform is often more stable than filtering by destination: the same direction
+can appear under many different destination strings (shortened names, special services,
+temporary changes), while the track number usually stays put.
+
+The value is matched against the provider's technical platform identifier — the same value
+you see in the `platform` attribute of the departures list. Common labels are stripped before
+comparing, so `3`, `Gleis 3` and `gleis 3` all match the same track.
+
+!!! note
+    At larger stations the same platform number can exist more than once — track 3 for rail
+    and stop position 3 for buses, for example. The filter cannot tell those apart on its own;
+    combine it with the **Transportation types** selector when the number is ambiguous.
+
+!!! tip
+    Not every provider returns platform data. Check the `platform` attribute of your
+    departures sensor first — if it is empty, this filter will match nothing.

--- a/tests/test_fetch_limit.py
+++ b/tests/test_fetch_limit.py
@@ -1,8 +1,8 @@
 """Tests for the departures over-fetch behaviour (issue #43).
 
-When a line/destination filter is active, the coordinator must request a larger
-raw board from the API so client-side filtering isn't starved before the list is
-truncated to the user's display count.
+When a line/destination/platform filter is active, the coordinator must request a
+larger raw board from the API so client-side filtering isn't starved before the
+list is truncated to the user's display count.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -12,6 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.openpublictransport.const import (
     CONF_DESTINATION_FILTER,
     CONF_LINE_FILTER,
+    CONF_PLATFORM_FILTER,
     DOMAIN,
     FILTERED_FETCH_LIMIT,
     PROVIDER_VRR,
@@ -46,7 +47,7 @@ async def test_no_config_entry_uses_display_limit(hass):
 
 
 async def test_no_filter_uses_display_limit(hass):
-    entry = _entry(hass, **{CONF_LINE_FILTER: "", CONF_DESTINATION_FILTER: ""})
+    entry = _entry(hass, **{CONF_LINE_FILTER: "", CONF_DESTINATION_FILTER: "", CONF_PLATFORM_FILTER: ""})
     coordinator = _coordinator(hass, entry=entry, departures_limit=20)
     assert coordinator._compute_fetch_limit() == 20
 
@@ -59,6 +60,20 @@ async def test_line_filter_triggers_overfetch(hass):
 
 async def test_destination_filter_triggers_overfetch(hass):
     entry = _entry(hass, **{CONF_DESTINATION_FILTER: "Airport"})
+    coordinator = _coordinator(hass, entry=entry, departures_limit=20)
+    assert coordinator._compute_fetch_limit() == FILTERED_FETCH_LIMIT
+
+
+async def test_platform_filter_triggers_overfetch(hass):
+    entry = _entry(hass, **{CONF_PLATFORM_FILTER: "3"})
+    coordinator = _coordinator(hass, entry=entry, departures_limit=20)
+    assert coordinator._compute_fetch_limit() == FILTERED_FETCH_LIMIT
+
+
+async def test_platform_filter_from_entry_data_triggers_overfetch(hass):
+    """A filter stored in entry.data (set during setup) counts too."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_PLATFORM_FILTER: "3"}, options={})
+    entry.add_to_hass(hass)
     coordinator = _coordinator(hass, entry=entry, departures_limit=20)
     assert coordinator._compute_fetch_limit() == FILTERED_FETCH_LIMIT
 

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -7,8 +7,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.openpublictransport.const import (
     CONF_DELAY_THRESHOLD,
     CONF_DEPARTURES,
+    CONF_DESTINATION_FILTER,
     CONF_FAVORITE_LINES,
     CONF_LINE_FILTER,
+    CONF_PLATFORM_FILTER,
     CONF_PROVIDER,
     CONF_SCAN_INTERVAL,
     CONF_TRANSPORTATION_TYPES,
@@ -65,6 +67,47 @@ async def test_options_flow_creates_entry(hass: HomeAssistant):
     assert result2["type"] == "create_entry"
     assert result2["data"][CONF_DEPARTURES] == 15
     assert result2["data"][CONF_SCAN_INTERVAL] == 120
+
+
+async def test_options_flow_saves_platform_filter(hass: HomeAssistant):
+    """The platform filter round-trips through the options flow (issue #57)."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_DEPARTURES: 10,
+            CONF_SCAN_INTERVAL: 60,
+            CONF_TRANSPORTATION_TYPES: ["train"],
+            CONF_USE_PROVIDER_LOGO: False,
+            CONF_DELAY_THRESHOLD: 5,
+            CONF_LINE_FILTER: "",
+            CONF_DESTINATION_FILTER: "",
+            CONF_PLATFORM_FILTER: "3, 4",
+            CONF_FAVORITE_LINES: "",
+            CONF_WALKING_TIME: 0,
+        },
+    )
+
+    assert result2["type"] == "create_entry"
+    assert result2["data"][CONF_PLATFORM_FILTER] == "3, 4"
+
+
+async def test_options_flow_prefills_platform_filter(hass: HomeAssistant):
+    """An existing platform filter is offered back as the default."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_PROVIDER: PROVIDER_VRR},
+        options={CONF_PLATFORM_FILTER: "3"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    defaults = {str(key): key.default() for key in result["data_schema"].schema if hasattr(key, "default")}
+    assert defaults[CONF_PLATFORM_FILTER] == "3"
 
 
 async def test_options_flow_uses_existing_options(hass: HomeAssistant):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -397,6 +397,167 @@ async def test_sensor_exposes_efa_platform(hass: HomeAssistant):
     assert "platform_changed" not in departures[0]
 
 
+def _multi_platform_board() -> dict:
+    """Three departures from tracks 3, 4 and a bus stop position A."""
+    return {
+        "stopEvents": [
+            {
+                "location": {"properties": {"platform": "3", "platformName": "Gleis 3"}},
+                "departureTimePlanned": "2026-07-18T18:25:00Z",
+                "departureTimeEstimated": "2026-07-18T18:25:00Z",
+                "transportation": {
+                    "number": "S1",
+                    "destination": {"name": "Plochingen"},
+                    "product": {"class": 1, "name": "S-Bahn"},
+                },
+            },
+            {
+                "location": {"properties": {"platform": "4", "platformName": "Gleis 4"}},
+                "departureTimePlanned": "2026-07-18T18:27:00Z",
+                "departureTimeEstimated": "2026-07-18T18:27:00Z",
+                "transportation": {
+                    "number": "S1",
+                    "destination": {"name": "Herrenberg"},
+                    "product": {"class": 1, "name": "S-Bahn"},
+                },
+            },
+            {
+                "location": {"properties": {"platform": "A"}},
+                "departureTimePlanned": "2026-07-18T18:29:00Z",
+                "departureTimeEstimated": "2026-07-18T18:29:00Z",
+                "transportation": {
+                    "number": "92",
+                    "destination": {"name": "Rohr"},
+                    "product": {"class": 5, "name": "Stadtbus"},
+                },
+            },
+        ]
+    }
+
+
+def _platform_filter_sensor(hass, entry_kwargs) -> MultiProviderSensor:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.openpublictransport.const import CONF_PROVIDER, CONF_STATION_ID, PROVIDER_VVS
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="VVS Stuttgart - Vaihingen",
+        data={
+            CONF_PROVIDER: PROVIDER_VVS,
+            "place_dm": "Stuttgart",
+            "name_dm": "Vaihingen",
+            CONF_STATION_ID: "de:08111:6002",
+        },
+        **entry_kwargs,
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = MagicMock()
+    coordinator.data = _multi_platform_board()
+    coordinator.last_update_success = True
+    coordinator.provider = PROVIDER_VVS
+    coordinator.place_dm = "Stuttgart"
+    coordinator.name_dm = "Vaihingen"
+    coordinator.station_id = "de:08111:6002"
+    coordinator.departures_limit = 10
+
+    from openpublictransport import get_provider
+
+    coordinator.provider_instance = get_provider(PROVIDER_VVS, hass)
+
+    sensor = MultiProviderSensor(coordinator, entry, ["train", "bus"])
+    with patch("custom_components.openpublictransport.sensor.dt_util.now") as mock_now:
+        mock_now.return_value = dt_util.parse_datetime("2026-07-18T18:08:00Z")
+        sensor._process_departure_data(coordinator.data)
+    return sensor
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected_platforms"),
+    [
+        ("3", ["3"]),
+        ("Gleis 3", ["3"]),  # readable label accepted
+        ("gleis 3", ["3"]),  # case-insensitive
+        (" 3 ", ["3"]),  # whitespace tolerated
+        ("3,4", ["3", "4"]),
+        ("3, A", ["3", "A"]),
+        ("a", ["A"]),  # bus stop position, case-insensitive
+        ("", ["3", "4", "A"]),  # empty = no filtering
+        ("9", []),  # no match = no departures
+    ],
+)
+async def test_sensor_platform_filtering(hass: HomeAssistant, configured, expected_platforms):
+    """Departures are filtered by platform/track (issue #57)."""
+    from custom_components.openpublictransport.const import CONF_PLATFORM_FILTER
+
+    sensor = _platform_filter_sensor(hass, {"options": {CONF_PLATFORM_FILTER: configured}})
+
+    departures = sensor._attributes.get("departures", [])
+    assert [d["platform"] for d in departures] == expected_platforms
+
+
+async def test_platform_filter_from_entry_data(hass: HomeAssistant):
+    """A platform filter set during setup (entry.data) is honoured."""
+    from custom_components.openpublictransport.const import (
+        CONF_PLATFORM_FILTER,
+        CONF_PROVIDER,
+        CONF_STATION_ID,
+        PROVIDER_VVS,
+    )
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="VVS Stuttgart - Vaihingen",
+        data={
+            CONF_PROVIDER: PROVIDER_VVS,
+            "place_dm": "Stuttgart",
+            "name_dm": "Vaihingen",
+            CONF_STATION_ID: "de:08111:6002",
+            CONF_PLATFORM_FILTER: "4",
+        },
+        unique_id="vvs_platform_data",
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = MagicMock()
+    coordinator.data = _multi_platform_board()
+    coordinator.last_update_success = True
+    coordinator.provider = PROVIDER_VVS
+    coordinator.place_dm = "Stuttgart"
+    coordinator.name_dm = "Vaihingen"
+    coordinator.station_id = "de:08111:6002"
+    coordinator.departures_limit = 10
+
+    from openpublictransport import get_provider
+
+    coordinator.provider_instance = get_provider(PROVIDER_VVS, hass)
+
+    sensor = MultiProviderSensor(coordinator, entry, ["train", "bus"])
+    with patch("custom_components.openpublictransport.sensor.dt_util.now") as mock_now:
+        mock_now.return_value = dt_util.parse_datetime("2026-07-18T18:08:00Z")
+        sensor._process_departure_data(coordinator.data)
+
+    departures = sensor._attributes.get("departures", [])
+    assert [d["platform"] for d in departures] == ["4"]
+
+
+async def test_platform_filter_combines_with_destination_filter(hass: HomeAssistant):
+    """Platform and destination filters are ANDed, not ORed."""
+    from custom_components.openpublictransport.const import CONF_DESTINATION_FILTER, CONF_PLATFORM_FILTER
+
+    sensor = _platform_filter_sensor(
+        hass,
+        {"options": {CONF_PLATFORM_FILTER: "3,4", CONF_DESTINATION_FILTER: "herrenberg"}},
+    )
+
+    departures = sensor._attributes.get("departures", [])
+    assert len(departures) == 1
+    assert departures[0]["platform"] == "4"
+    assert departures[0]["destination"] == "Herrenberg"
+
+
 # ── restore state across restart ──────────────────────────────────────────────
 # Regression: after a restart the push-style sensor showed `unknown` until the
 # next poll. It should now populate on add — from fresh coordinator data if


### PR DESCRIPTION
Closes #57.

> **Stacked on #64** (the 0.1.15 pin for #56). Base is `fix/56-platform-attribute`, so the
> diff here shows only the filter work. GitHub retargets it to `main` when #64 merges.
> The dependency is real: without 0.1.15 most EFA providers report no platform at all, so
> there would be nothing to filter on.

## What this adds

A **platform filter** next to the existing line and destination filters, in both the setup
wizard and the options flow. Comma-separated, empty = disabled.

As the issue argues, the track is usually a far more stable direction selector than the
destination name, which drifts with abbreviations, special services and temporary changes.

## Matching

Values are compared on the *normalized* platform, using `normalize_platform()` from
python-openpublictransport (added in 0.1.15) rather than a second implementation here.
So `3`, `Gleis 3` and `gleis 3` all select track 3, and `a` matches bus stop position `A`.

An active platform filter also triggers the over-fetch added for #43, so filtered results
are not starved at busy stops.

## On the ambiguity the issue raises

The issue notes that the same platform number can exist for rail and bus at large stations
and suggests combining `location.type` / `pointType` / `properties.platform`. I did **not**
build a composite matcher — it would only work for EFA providers and would put provider-shaped
fields into a user-facing setting. The documented answer is to combine the platform filter
with the existing **Transportation types** selector, which already separates rail from bus
and works for every provider. Happy to revisit if it turns out not to be enough in practice.

## Drive-by fix in the same form

`async_step_settings` offered the delay threshold, line filter, destination filter, favourite
lines and walking time — and then dropped all five when building the entry data. A filter set
during setup silently did nothing until you entered it again under Options. All of them are
now persisted. (Without this, the new platform filter would have had the same problem.)

## Files

- `const.py`, `config_flow.py` (both schemas + persistence), `sensor.py` (parse, filter loop,
  `_compute_fetch_limit`)
- `strings.json` + all 7 translations — 4 insertion points each, verified programmatically:
  32 added lines, 0 removed, no reformatting
- `docs/configuration.md` — new "Departure Filters" section covering all three filters, the
  normalization rule, the ambiguity caveat, and the "check the `platform` attribute first"
  tip for providers that return no platform data

## Tests

- 9 parametrised filter cases (bare number, readable label, case, whitespace, multiple values,
  bus position, empty, no match)
- filter set via `entry.data` (setup) as well as `entry.options`
- platform × destination filters AND together
- over-fetch triggered by a platform filter, from both `options` and `data`
- options flow round-trip + pre-fill

`pytest tests/ -q` → **508 passed**. `black` / `isort` / `flake8` clean.

## What to test in the pre-release

On a multi-platform stop, set **Platform filter** to one track and confirm only those
departures remain. Try both `3` and `Gleis 3`. Then set a filter during initial setup and
confirm it now survives (previously it did not).
