### PR TITLE
feat(config_flow): allow one station twice with different filters (#55)

### DIFF
--- a/custom_components/openpublictransport/binary_sensor.py
+++ b/custom_components/openpublictransport/binary_sensor.py
@@ -27,7 +27,12 @@ from .const import (
     PROVIDER_VRR,
     TRANSPORTATION_TYPES,
 )
-from .sensor import _RESTORE_SKIP_ATTRS, PublicTransportDataUpdateCoordinator
+from .sensor import (
+    _RESTORE_SKIP_ATTRS,
+    PublicTransportDataUpdateCoordinator,
+    station_device_name,
+    station_entity_key,
+)
 
 PARALLEL_UPDATES = 0
 
@@ -74,18 +79,14 @@ class PublicTransportDelayBinarySensor(CoordinatorEntity, RestoreEntity, BinaryS
         self._attributes: dict[str, Any] = {}
 
         # Setup entity
-        provider = coordinator.provider
-        station_id = coordinator.station_id
         place_dm = coordinator.place_dm
-        name_dm = coordinator.name_dm
 
-        station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
-        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
-        self._attr_unique_id = f"{provider}_{station_key}_delays"
+        entity_key = station_entity_key(coordinator, config_entry)
+        self._attr_unique_id = f"{entity_key}_delays"
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{provider}_{station_key}")},
-            name=device_name,
+            identifiers={(DOMAIN, entity_key)},
+            name=station_device_name(coordinator, config_entry),
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/calendar.py
+++ b/custom_components/openpublictransport/calendar.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import CONF_TRANSPORTATION_TYPES, DOMAIN, TRANSPORTATION_TYPES
-from .sensor import PublicTransportDataUpdateCoordinator
+from .sensor import PublicTransportDataUpdateCoordinator, station_device_name, station_entity_key
 
 PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
@@ -54,18 +54,13 @@ class DepartureCalendar(CoordinatorEntity, CalendarEntity):
         self._config_entry = config_entry
         self._events: list[CalendarEvent] = []
 
-        provider = coordinator.provider
-        station_id = coordinator.station_id
         place_dm = coordinator.place_dm
-        name_dm = coordinator.name_dm
-        station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
-
-        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
-        self._attr_unique_id = f"{provider}_{station_key}_calendar"
+        entity_key = station_entity_key(coordinator, config_entry)
+        self._attr_unique_id = f"{entity_key}_calendar"
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{provider}_{station_key}")},
-            name=device_name,
+            identifiers={(DOMAIN, entity_key)},
+            name=station_device_name(coordinator, config_entry),
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/camera.py
+++ b/custom_components/openpublictransport/camera.py
@@ -19,7 +19,7 @@ from homeassistant.util import dt as dt_util
 from PIL import Image, ImageDraw, ImageFont
 
 from .const import CONF_TRANSPORTATION_TYPES, DOMAIN, TRANSPORTATION_TYPES
-from .sensor import PublicTransportDataUpdateCoordinator
+from .sensor import PublicTransportDataUpdateCoordinator, station_device_name, station_entity_key
 
 PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
@@ -190,19 +190,16 @@ class DepartureBoardCamera(CoordinatorEntity, Camera):
         self._config_entry = config_entry
         self._image: bytes | None = None
 
-        provider = coordinator.provider
-        station_id = coordinator.station_id
         place_dm = coordinator.place_dm
         name_dm = coordinator.name_dm
-        station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
+        entity_key = station_entity_key(coordinator, config_entry)
 
         self._station_name = f"{place_dm} - {name_dm}" if place_dm else name_dm
-        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
-        self._attr_unique_id = f"{provider}_{station_key}_board"
+        self._attr_unique_id = f"{entity_key}_board"
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{provider}_{station_key}")},
-            name=device_name,
+            identifiers={(DOMAIN, entity_key)},
+            name=station_device_name(coordinator, config_entry),
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Open Public Transport integration with autocomplete support."""
 
 import asyncio
+import hashlib
 import logging
 from datetime import datetime
 from difflib import SequenceMatcher
@@ -26,6 +27,8 @@ from .const import (
     CONF_DELAY_THRESHOLD,
     CONF_DEPARTURES,
     CONF_DESTINATION_FILTER,
+    CONF_ENTRY_LABEL,
+    CONF_ENTRY_SUFFIX,
     CONF_FAVORITE_LINES,
     CONF_LINE_FILTER,
     CONF_NATIONAL_RAIL_API_KEY,
@@ -66,6 +69,49 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Filters that make one entry for a station distinct from another (issue #55),
+# paired with how each reads in the entry title and device name.
+_DISCRIMINATING_FILTERS = (
+    (CONF_LINE_FILTER, "{}"),
+    (CONF_DESTINATION_FILTER, "→ {}"),
+    (CONF_PLATFORM_FILTER, "Pl. {}"),
+)
+
+
+def _filter_values(user_input: Dict[str, Any], key: str) -> List[str]:
+    """Split one comma-separated filter field into its trimmed values."""
+    return [value.strip() for value in str(user_input.get(key) or "").split(",") if value.strip()]
+
+
+def _filter_discriminator(user_input: Dict[str, Any]) -> str:
+    """Return a stable short id for this entry's filter set, "" when unfiltered.
+
+    Order- and case-insensitive, so "S1, S2" and "s2,s1" are recognised as the
+    same configuration and the second one is rejected as already_configured.
+
+    Frozen into ``entry.data`` at creation: entity unique IDs are built on it,
+    so it must not move when the filters are later edited under Options.
+    """
+    canonical = {
+        key: sorted({value.casefold() for value in _filter_values(user_input, key)})
+        for key, _ in _DISCRIMINATING_FILTERS
+    }
+    if not any(canonical.values()):
+        return ""
+
+    fingerprint = "|".join(f"{key}={','.join(values)}" for key, values in sorted(canonical.items()))
+    return hashlib.sha1(fingerprint.encode("utf-8")).hexdigest()[:8]
+
+
+def _filter_label(user_input: Dict[str, Any]) -> str:
+    """Return a short human-readable form of the filters, "" when unfiltered."""
+    bits = []
+    for key, template in _DISCRIMINATING_FILTERS:
+        values = _filter_values(user_input, key)
+        if values:
+            bits.append(template.format(", ".join(values)))
+    return " ".join(bits)
 
 
 class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
@@ -825,9 +871,23 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             name = self._selected_stop.get("name", "")
             title = f"{(self._provider or '').upper()} {place} - {name}".strip()
 
+            # A filtered entry says what it is filtered to, both in its title and
+            # in the device name, so two entries for one station are tellable
+            # apart at a glance (issue #55).
+            label = _filter_label(user_input)
+            if label:
+                title = f"{title} ({label})"
+
             self._found_stops = []
 
             if self._reconfiguring and self._reconfigure_entry:
+                # Reconfigure only moves the entry to a different stop. Carry the
+                # existing discriminator over untouched — regenerating it here
+                # would rename every entity of the entry.
+                for key in (CONF_ENTRY_SUFFIX, CONF_ENTRY_LABEL):
+                    existing = self._reconfigure_entry.data.get(key)
+                    if existing:
+                        data[key] = existing
                 return self.async_update_reload_and_abort(
                     self._reconfigure_entry,
                     title=title,
@@ -835,8 +895,20 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                     reason="reconfigure_successful",
                 )
 
-            # Create unique ID (self._selected_stop validated above)
+            # Create unique ID (self._selected_stop validated above).
+            #
+            # An unfiltered entry keeps the historical f"{provider}_{stop_id}",
+            # so nothing that already exists is renamed. A filtered entry gets a
+            # stable suffix derived from its filters, which is what allows the
+            # same station to be added twice for two directions — and still
+            # aborts as already_configured when the filters are identical.
             unique_id = f"{self._provider}_{self._selected_stop['id']}"
+            suffix = _filter_discriminator(user_input)
+            if suffix:
+                unique_id = f"{unique_id}_{suffix}"
+                data[CONF_ENTRY_SUFFIX] = suffix
+                data[CONF_ENTRY_LABEL] = label
+
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()
 

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Open Public Transport integration with autocomplete support."""
 
 import asyncio
-import hashlib
 import logging
 from datetime import datetime
 from difflib import SequenceMatcher
@@ -67,51 +66,9 @@ from .const import (
     PROVIDER_VRR,
     TRANSPORTATION_TYPES,
 )
+from .filters import filter_discriminator, filter_label
 
 _LOGGER = logging.getLogger(__name__)
-
-# Filters that make one entry for a station distinct from another (issue #55),
-# paired with how each reads in the entry title and device name.
-_DISCRIMINATING_FILTERS = (
-    (CONF_LINE_FILTER, "{}"),
-    (CONF_DESTINATION_FILTER, "→ {}"),
-    (CONF_PLATFORM_FILTER, "Pl. {}"),
-)
-
-
-def _filter_values(user_input: Dict[str, Any], key: str) -> List[str]:
-    """Split one comma-separated filter field into its trimmed values."""
-    return [value.strip() for value in str(user_input.get(key) or "").split(",") if value.strip()]
-
-
-def _filter_discriminator(user_input: Dict[str, Any]) -> str:
-    """Return a stable short id for this entry's filter set, "" when unfiltered.
-
-    Order- and case-insensitive, so "S1, S2" and "s2,s1" are recognised as the
-    same configuration and the second one is rejected as already_configured.
-
-    Frozen into ``entry.data`` at creation: entity unique IDs are built on it,
-    so it must not move when the filters are later edited under Options.
-    """
-    canonical = {
-        key: sorted({value.casefold() for value in _filter_values(user_input, key)})
-        for key, _ in _DISCRIMINATING_FILTERS
-    }
-    if not any(canonical.values()):
-        return ""
-
-    fingerprint = "|".join(f"{key}={','.join(values)}" for key, values in sorted(canonical.items()))
-    return hashlib.sha1(fingerprint.encode("utf-8")).hexdigest()[:8]
-
-
-def _filter_label(user_input: Dict[str, Any]) -> str:
-    """Return a short human-readable form of the filters, "" when unfiltered."""
-    bits = []
-    for key, template in _DISCRIMINATING_FILTERS:
-        values = _filter_values(user_input, key)
-        if values:
-            bits.append(template.format(", ".join(values)))
-    return " ".join(bits)
 
 
 class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
@@ -874,7 +831,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             # A filtered entry says what it is filtered to, both in its title and
             # in the device name, so two entries for one station are tellable
             # apart at a glance (issue #55).
-            label = _filter_label(user_input)
+            label = filter_label(user_input)
             if label:
                 title = f"{title} ({label})"
 
@@ -903,7 +860,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             # same station to be added twice for two directions — and still
             # aborts as already_configured when the filters are identical.
             unique_id = f"{self._provider}_{self._selected_stop['id']}"
-            suffix = _filter_discriminator(user_input)
+            suffix = filter_discriminator(user_input)
             if suffix:
                 unique_id = f"{unique_id}_{suffix}"
                 data[CONF_ENTRY_SUFFIX] = suffix

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -22,6 +22,11 @@ CONF_DELAY_THRESHOLD = "delay_threshold"  # Minutes threshold for delay binary s
 CONF_LINE_FILTER = "line_filter"  # Comma-separated line numbers to show
 CONF_DESTINATION_FILTER = "destination_filter"  # Comma-separated destinations (substring match) to show
 CONF_PLATFORM_FILTER = "platform_filter"  # Comma-separated platforms/tracks to show
+# Discriminator that lets the same station be configured more than once with
+# different filters (issue #55). Absent on entries created before that, which
+# is what keeps their unique IDs byte-identical.
+CONF_ENTRY_SUFFIX = "entry_suffix"
+CONF_ENTRY_LABEL = "entry_label"  # Human-readable form of that discriminator, e.g. "S1 → Plochingen"
 CONF_WALKING_TIME = "walking_time"  # Minutes to walk to the stop
 CONF_FAVORITE_LINES = "favorite_lines"  # Comma-separated favorite lines (shown first)
 DEFAULT_DELAY_THRESHOLD = 5

--- a/custom_components/openpublictransport/event.py
+++ b/custom_components/openpublictransport/event.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
-from .sensor import PublicTransportDataUpdateCoordinator
+from .sensor import PublicTransportDataUpdateCoordinator, station_device_name, station_entity_key
 
 PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
@@ -54,18 +54,13 @@ class DisruptionEventEntity(CoordinatorEntity, EventEntity):
         self._config_entry = config_entry
         self._previous_notices: set[str] = set()
 
-        provider = coordinator.provider
-        station_id = coordinator.station_id
         place_dm = coordinator.place_dm
-        name_dm = coordinator.name_dm
-        station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
-
-        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
-        self._attr_unique_id = f"{provider}_{station_key}_disruptions"
+        entity_key = station_entity_key(coordinator, config_entry)
+        self._attr_unique_id = f"{entity_key}_disruptions"
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{provider}_{station_key}")},
-            name=device_name,
+            identifiers={(DOMAIN, entity_key)},
+            name=station_device_name(coordinator, config_entry),
             suggested_area=place_dm,
         )
 

--- a/custom_components/openpublictransport/filters.py
+++ b/custom_components/openpublictransport/filters.py
@@ -1,0 +1,67 @@
+"""Departure filters that distinguish one entry for a station from another.
+
+Shared by the config flow (which freezes a discriminator into the entry at
+creation time, issue #55) and the sensor platform (which renders the current
+filters into the device name).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, List, Mapping
+
+from .const import CONF_DESTINATION_FILTER, CONF_LINE_FILTER, CONF_PLATFORM_FILTER
+
+# The filters that make two entries for one station genuinely different,
+# paired with how each reads in the entry title and device name.
+#
+# Deliberately excludes favourite lines and walking time: those change how
+# departures are presented, not which departures the entry is about, so two
+# entries differing only there are still duplicates.
+DISCRIMINATING_FILTERS = (
+    (CONF_LINE_FILTER, "{}"),
+    (CONF_DESTINATION_FILTER, "→ {}"),
+    (CONF_PLATFORM_FILTER, "Pl. {}"),
+)
+
+
+def filter_values(source: Mapping[str, Any], key: str) -> List[str]:
+    """Split one comma-separated filter field into its trimmed values."""
+    return [value.strip() for value in str(source.get(key) or "").split(",") if value.strip()]
+
+
+def filter_discriminator(source: Mapping[str, Any]) -> str:
+    """Return a stable short id for this filter set, "" when unfiltered.
+
+    Order- and case-insensitive, so "S1, S2" and "s2,s1" are recognised as the
+    same configuration and the second one is rejected as already_configured.
+
+    Frozen into ``entry.data`` at creation: entity unique IDs are built on it,
+    so it must not move when the filters are later edited under Options.
+    """
+    canonical = {
+        key: sorted({value.casefold() for value in filter_values(source, key)}) for key, _ in DISCRIMINATING_FILTERS
+    }
+    if not any(canonical.values()):
+        return ""
+
+    fingerprint = "|".join(f"{key}={','.join(values)}" for key, values in sorted(canonical.items()))
+    return hashlib.sha1(fingerprint.encode("utf-8")).hexdigest()[:8]
+
+
+def filter_label(source: Mapping[str, Any]) -> str:
+    """Return a short human-readable form of the filters, "" when unfiltered."""
+    bits = []
+    for key, template in DISCRIMINATING_FILTERS:
+        values = filter_values(source, key)
+        if values:
+            bits.append(template.format(", ".join(values)))
+    return " ".join(bits)
+
+
+def current_filters(entry: Any) -> dict:
+    """Return an entry's filters as they are configured *right now*.
+
+    Options win over data, matching how every consumer reads them.
+    """
+    return {key: entry.options.get(key, entry.data.get(key, "")) for key, _ in DISCRIMINATING_FILTERS}

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -42,6 +42,7 @@ from .const import (
     PROVIDER_NTA_IE,
     TRANSPORTATION_TYPES,
 )
+from .filters import current_filters, filter_label
 
 _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
@@ -88,17 +89,24 @@ def station_entity_key(coordinator: Any, config_entry: Optional[ConfigEntry] = N
 def station_device_name(coordinator: Any, config_entry: Optional[ConfigEntry] = None) -> str:
     """Return the device name, disambiguated when a station is configured twice.
 
-    Without a filter label this is the historical ``"Agency - Stop"``; entries
-    created with a discriminator (issue #55) get the filter appended so the two
-    devices are told apart in the UI.
+    Without a discriminator this is the historical ``"Agency - Stop"``, so no
+    pre-existing device is renamed. Entries created as a deliberate duplicate
+    (issue #55) get their filter appended so the two are told apart in the UI.
+
+    That label follows the *current* filters, unlike the unique-ID suffix,
+    which is frozen at creation. The two deliberately diverge once the filters
+    are edited under Options: renaming a device is harmless — entity IDs were
+    assigned once, at creation — whereas moving the suffix would rename every
+    entity of the entry.
     """
     name_dm = coordinator.name_dm
     agency_name = coordinator.agency_name
     base = f"{agency_name} - {name_dm}" if agency_name else name_dm
 
-    label = ""
-    if config_entry is not None:
-        label = str(config_entry.data.get(CONF_ENTRY_LABEL) or "").strip()
+    if config_entry is None or not str(config_entry.data.get(CONF_ENTRY_SUFFIX) or "").strip():
+        return base
+
+    label = filter_label(current_filters(config_entry)) or str(config_entry.data.get(CONF_ENTRY_LABEL) or "").strip()
 
     return f"{base} ({label})" if label else base
 

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -23,6 +23,8 @@ from .const import (
     API_RATE_LIMIT_PER_DAY,
     CONF_DEPARTURES,
     CONF_DESTINATION_FILTER,
+    CONF_ENTRY_LABEL,
+    CONF_ENTRY_SUFFIX,
     CONF_FAVORITE_LINES,
     CONF_LINE_FILTER,
     CONF_NTA_API_KEY_SECONDARY,
@@ -59,6 +61,46 @@ _RESTORE_SKIP_ATTRS = frozenset(
     }
 )
 INTEGRATION_VERSION = json.loads((Path(__file__).parent / "manifest.json").read_text()).get("version", "unknown")
+
+
+def station_entity_key(coordinator: Any, config_entry: Optional[ConfigEntry] = None) -> str:
+    """Return the key every entity unique_id and the device identifier build on.
+
+    Historically ``f"{provider}_{station_id}"``. That collides when the same
+    station is configured twice with different filters, so entries created
+    since issue #55 carry a stable discriminator in
+    ``entry.data[CONF_ENTRY_SUFFIX]`` and append it here.
+
+    Entries without that key — every entry that existed before — get the exact
+    legacy string back, so no existing entity or device is renamed.
+    """
+    station_id = coordinator.station_id
+    station_key = station_id or f"{coordinator.place_dm}_{coordinator.name_dm}".lower().replace(" ", "_")
+    base = f"{coordinator.provider}_{station_key}"
+
+    suffix = ""
+    if config_entry is not None:
+        suffix = str(config_entry.data.get(CONF_ENTRY_SUFFIX) or "").strip()
+
+    return f"{base}_{suffix}" if suffix else base
+
+
+def station_device_name(coordinator: Any, config_entry: Optional[ConfigEntry] = None) -> str:
+    """Return the device name, disambiguated when a station is configured twice.
+
+    Without a filter label this is the historical ``"Agency - Stop"``; entries
+    created with a discriminator (issue #55) get the filter appended so the two
+    devices are told apart in the UI.
+    """
+    name_dm = coordinator.name_dm
+    agency_name = coordinator.agency_name
+    base = f"{agency_name} - {name_dm}" if agency_name else name_dm
+
+    label = ""
+    if config_entry is not None:
+        label = str(config_entry.data.get(CONF_ENTRY_LABEL) or "").strip()
+
+    return f"{base} ({label})" if label else base
 
 
 class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
@@ -388,19 +430,16 @@ class MultiProviderSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         # Setup entity
         self._provider = coordinator.provider
         provider = self._provider
-        station_id = coordinator.station_id
         place_dm = coordinator.place_dm
-        name_dm = coordinator.name_dm
 
-        station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
-        self._attr_unique_id = f"{provider}_{station_key}"
-        agency_name = coordinator.agency_name
-        display_name = f"{agency_name} - {name_dm}" if agency_name else name_dm
+        entity_key = station_entity_key(coordinator, config_entry)
+        self._attr_unique_id = entity_key
+        display_name = station_device_name(coordinator, config_entry)
         self._attr_name = None  # device name IS the entity name
 
         # Device info
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{provider}_{station_key}")},
+            identifiers={(DOMAIN, entity_key)},
             name=display_name,
             manufacturer=f"{provider.upper()} Public Transport",
             model="Departure Monitor",

--- a/custom_components/openpublictransport/statistics.py
+++ b/custom_components/openpublictransport/statistics.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
-from .sensor import PublicTransportDataUpdateCoordinator
+from .sensor import PublicTransportDataUpdateCoordinator, station_device_name, station_entity_key
 
 PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
@@ -60,19 +60,15 @@ class PunctualitySensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._config_entry = config_entry
 
-        provider = coordinator.provider
-        station_id = coordinator.station_id
         place_dm = coordinator.place_dm
-        name_dm = coordinator.name_dm
-        station_key = station_id or f"{place_dm}_{name_dm}".lower().replace(" ", "_")
+        entity_key = station_entity_key(coordinator, config_entry)
 
-        device_name = f"{coordinator.agency_name} - {name_dm}" if coordinator.agency_name else name_dm
-        self._attr_unique_id = f"{provider}_{station_key}_statistics"
+        self._attr_unique_id = f"{entity_key}_statistics"
         self._attr_native_unit_of_measurement = "%"
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{provider}_{station_key}")},
-            name=device_name,
+            identifiers={(DOMAIN, entity_key)},
+            name=station_device_name(coordinator, config_entry),
             suggested_area=place_dm,
         )
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,34 @@ To monitor multiple stops:
 
 Each stop will create its own sensor and binary sensor entities.
 
+### Adding the Same Stop Twice
+
+You can add one stop more than once — for example one entry for the outbound direction and
+one for the inbound direction of the same S-Bahn station — as long as the two entries differ
+in at least one of the **line**, **destination** or **platform** filters.
+
+The filter is appended to the entry title and the device name, so the two are easy to tell
+apart:
+
+```
+VVS Stuttgart - Vaihingen (→ Plochingen)
+VVS Stuttgart - Vaihingen (→ Herrenberg)
+```
+
+Two entries with *identical* filters, or two unfiltered entries, are still rejected as
+**already configured** — there would be nothing to distinguish them.
+
+!!! note
+    The filters you set **during setup** determine the entry's entity IDs, and they stay
+    fixed afterwards. Changing a filter later under **Configure** takes effect immediately
+    but deliberately does not rename any entity, so your dashboards and automations keep
+    working. If you want the new filter reflected in the entity IDs, remove the entry and
+    add it again.
+
+!!! tip
+    Entries created before this feature keep their existing entity IDs exactly as they were.
+    Nothing is renamed by upgrading.
+
 ## Modifying Settings
 
 After initial setup, you can modify settings:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,13 +102,14 @@ Two entries with *identical* filters, or two unfiltered entries, are still rejec
 !!! note
     The filters you set **during setup** determine the entry's entity IDs, and they stay
     fixed afterwards. Changing a filter later under **Configure** takes effect immediately
-    but deliberately does not rename any entity, so your dashboards and automations keep
-    working. If you want the new filter reflected in the entity IDs, remove the entry and
-    add it again.
+    and updates the device name, but deliberately does *not* rename any entity, so your
+    dashboards and automations keep working. If you want the new filter reflected in the
+    entity IDs too, remove the entry and add it again.
 
 !!! tip
-    Entries created before this feature keep their existing entity IDs exactly as they were.
-    Nothing is renamed by upgrading.
+    Entries created before this feature keep their existing entity IDs **and** their existing
+    device names exactly as they were, even if they have filters configured. Nothing is
+    renamed by upgrading.
 
 ## Modifying Settings
 

--- a/tests/test_config_flow_duplicate_station.py
+++ b/tests/test_config_flow_duplicate_station.py
@@ -12,7 +12,7 @@ import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.openpublictransport.config_flow import _filter_discriminator, _filter_label
+from custom_components.openpublictransport.filters import filter_discriminator, filter_label
 from custom_components.openpublictransport.const import (
     CONF_DELAY_THRESHOLD,
     CONF_DEPARTURES,
@@ -194,10 +194,74 @@ async def test_entity_key_falls_back_to_place_and_name(hass: HomeAssistant):
 
 async def test_entity_key_appends_the_discriminator(hass: HomeAssistant):
     """A filtered entry gets its own key, so the two do not collide."""
-    entry = _entry(hass, **{CONF_ENTRY_SUFFIX: "abc12345", CONF_ENTRY_LABEL: "→ Duisburg"})
+    entry = _entry(
+        hass,
+        **{CONF_DESTINATION_FILTER: "Duisburg", CONF_ENTRY_SUFFIX: "abc12345", CONF_ENTRY_LABEL: "→ Duisburg"},
+    )
 
     assert station_entity_key(_coordinator(), entry) == f"{PROVIDER_VRR}_{STOP_ID}_abc12345"
     assert station_device_name(_coordinator(), entry) == "Rheinbahn - Hauptbahnhof (→ Duisburg)"
+
+
+# ── the device name tracks the filters, the unique ID does not ────────────────
+
+
+async def test_editing_filters_renames_the_device_but_not_the_entities(hass: HomeAssistant):
+    """Changing a filter under Options must update the label, not the IDs.
+
+    The device would otherwise keep advertising the filter it was created
+    with — "(→ Duisburg)" on an entry that now filters for Köln. Renaming a
+    device is harmless because entity IDs are assigned once at creation;
+    moving the unique-ID suffix would rename every entity of the entry.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROVIDER: PROVIDER_VRR,
+            CONF_STATION_ID: STOP_ID,
+            CONF_DESTINATION_FILTER: "Duisburg",
+            CONF_ENTRY_SUFFIX: "abc12345",
+            CONF_ENTRY_LABEL: "→ Duisburg",
+        },
+        options={CONF_DESTINATION_FILTER: "Köln"},
+    )
+    entry.add_to_hass(hass)
+
+    assert station_device_name(_coordinator(), entry) == "Rheinbahn - Hauptbahnhof (→ Köln)"
+    assert station_entity_key(_coordinator(), entry) == f"{PROVIDER_VRR}_{STOP_ID}_abc12345"
+
+
+async def test_clearing_every_filter_falls_back_to_the_creation_label(hass: HomeAssistant):
+    """An entry with a suffix stays labelled even if the filters are emptied.
+
+    Dropping the label would make two same-station devices indistinguishable.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROVIDER: PROVIDER_VRR,
+            CONF_STATION_ID: STOP_ID,
+            CONF_DESTINATION_FILTER: "Duisburg",
+            CONF_ENTRY_SUFFIX: "abc12345",
+            CONF_ENTRY_LABEL: "→ Duisburg",
+        },
+        options={CONF_DESTINATION_FILTER: ""},
+    )
+    entry.add_to_hass(hass)
+
+    assert station_device_name(_coordinator(), entry) == "Rheinbahn - Hauptbahnhof (→ Duisburg)"
+
+
+async def test_filters_on_a_pre_existing_entry_do_not_rename_its_device(hass: HomeAssistant):
+    """No discriminator means no label — upgrading must not rename anything.
+
+    Plenty of existing entries have filters set under Options; they were
+    created before #55 and carry no suffix, so their device name must stay
+    exactly what it was.
+    """
+    entry = _entry(hass, **{CONF_DESTINATION_FILTER: "Duisburg"})
+
+    assert station_device_name(_coordinator(), entry) == "Rheinbahn - Hauptbahnhof"
 
 
 async def test_every_platform_derives_its_key_from_the_shared_helper(hass: HomeAssistant):
@@ -232,13 +296,13 @@ async def test_every_platform_derives_its_key_from_the_shared_helper(hass: HomeA
     ],
 )
 def test_no_discriminator_without_filters(user_input):
-    assert _filter_discriminator(user_input) == ""
-    assert _filter_label(user_input) == ""
+    assert filter_discriminator(user_input) == ""
+    assert filter_label(user_input) == ""
 
 
 def test_discriminator_is_stable_and_short():
-    first = _filter_discriminator({CONF_DESTINATION_FILTER: "Duisburg"})
-    second = _filter_discriminator({CONF_DESTINATION_FILTER: "Duisburg"})
+    first = filter_discriminator({CONF_DESTINATION_FILTER: "Duisburg"})
+    second = filter_discriminator({CONF_DESTINATION_FILTER: "Duisburg"})
 
     assert first == second
     assert len(first) == 8
@@ -246,18 +310,18 @@ def test_discriminator_is_stable_and_short():
 
 
 def test_discriminator_ignores_order_and_case():
-    assert _filter_discriminator({CONF_LINE_FILTER: "S1,S2"}) == _filter_discriminator(
+    assert filter_discriminator({CONF_LINE_FILTER: "S1,S2"}) == filter_discriminator(
         {CONF_LINE_FILTER: " s2 , S1 "}
     )
 
 
 def test_discriminator_differs_per_filter_field():
     """The same text in two different fields is two different configurations."""
-    assert _filter_discriminator({CONF_LINE_FILTER: "3"}) != _filter_discriminator({CONF_PLATFORM_FILTER: "3"})
+    assert filter_discriminator({CONF_LINE_FILTER: "3"}) != filter_discriminator({CONF_PLATFORM_FILTER: "3"})
 
 
 def test_label_covers_all_three_filters():
-    label = _filter_label(
+    label = filter_label(
         {CONF_LINE_FILTER: "S1", CONF_DESTINATION_FILTER: "Duisburg", CONF_PLATFORM_FILTER: "3"}
     )
     assert label == "S1 → Duisburg Pl. 3"

--- a/tests/test_config_flow_duplicate_station.py
+++ b/tests/test_config_flow_duplicate_station.py
@@ -1,0 +1,263 @@
+"""Tests for adding the same station twice with different filters (issue #55).
+
+The wizard used to abort with `already_configured` on the second entry, because
+the unique ID was just `f"{provider}_{stop_id}"`. A filtered entry now gets a
+stable discriminator derived from its filters — and entries created before this
+must keep their exact previous unique ID, since the entity registry is keyed on it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.openpublictransport.config_flow import _filter_discriminator, _filter_label
+from custom_components.openpublictransport.const import (
+    CONF_DELAY_THRESHOLD,
+    CONF_DEPARTURES,
+    CONF_DESTINATION_FILTER,
+    CONF_ENTRY_LABEL,
+    CONF_ENTRY_SUFFIX,
+    CONF_FAVORITE_LINES,
+    CONF_LINE_FILTER,
+    CONF_PLATFORM_FILTER,
+    CONF_PROVIDER,
+    CONF_SCAN_INTERVAL,
+    CONF_STATION_ID,
+    CONF_TRANSPORTATION_TYPES,
+    CONF_USE_PROVIDER_LOGO,
+    CONF_WALKING_TIME,
+    DOMAIN,
+    PROVIDER_VRR,
+)
+from custom_components.openpublictransport.sensor import station_device_name, station_entity_key
+
+STOP_ID = "de:05111:100"
+STOPS = [{"id": STOP_ID, "name": "Düsseldorf Hbf", "place": "Düsseldorf"}]
+
+
+def _settings(**overrides) -> dict:
+    base = {
+        CONF_DEPARTURES: 10,
+        CONF_SCAN_INTERVAL: 60,
+        CONF_TRANSPORTATION_TYPES: ["bus", "train", "tram"],
+        CONF_USE_PROVIDER_LOGO: False,
+        CONF_DELAY_THRESHOLD: 5,
+        CONF_LINE_FILTER: "",
+        CONF_DESTINATION_FILTER: "",
+        CONF_PLATFORM_FILTER: "",
+        CONF_FAVORITE_LINES: "",
+        CONF_WALKING_TIME: 0,
+    }
+    base.update(overrides)
+    return base
+
+
+async def _run_flow(hass: HomeAssistant, settings: dict):
+    """Drive the departures flow from provider selection to the settings step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+        data={"entry_type": "departures", CONF_PROVIDER: PROVIDER_VRR},
+    )
+
+    with patch("custom_components.openpublictransport.config_flow.get_provider") as mock_gp:
+        provider = AsyncMock()
+        provider.search_stops = AsyncMock(return_value=STOPS)
+        mock_gp.return_value = provider
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"stop_search": "Düsseldorf"}
+        )
+
+    if result["step_id"] == "stop_select":
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"stop": STOP_ID})
+
+    assert result["step_id"] == "settings"
+    return await hass.config_entries.flow.async_configure(result["flow_id"], user_input=settings)
+
+
+# ── the reported scenario ─────────────────────────────────────────────────────
+
+
+async def test_same_station_twice_with_different_destination_filters(hass: HomeAssistant):
+    """Outbound and inbound badges for one S-Bahn station — the issue's use case."""
+    outbound = await _run_flow(hass, _settings(**{CONF_DESTINATION_FILTER: "Duisburg"}))
+    assert outbound["type"] == "create_entry"
+
+    inbound = await _run_flow(hass, _settings(**{CONF_DESTINATION_FILTER: "Köln"}))
+    assert inbound["type"] == "create_entry"
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 2
+    assert entries[0].unique_id != entries[1].unique_id
+    # Both are still recognisably the same station
+    for entry in entries:
+        assert entry.unique_id.startswith(f"{PROVIDER_VRR}_{STOP_ID}")
+
+
+async def test_titles_and_device_names_distinguish_the_two_entries(hass: HomeAssistant):
+    """A filtered entry says what it is filtered to."""
+    result = await _run_flow(hass, _settings(**{CONF_LINE_FILTER: "S1", CONF_DESTINATION_FILTER: "Duisburg"}))
+
+    assert result["title"] == "VRR Düsseldorf - Düsseldorf Hbf (S1 → Duisburg)"
+    assert result["data"][CONF_ENTRY_LABEL] == "S1 → Duisburg"
+
+
+async def test_same_station_twice_with_identical_filters_still_aborts(hass: HomeAssistant):
+    """Two truly identical entries are still a duplicate."""
+    first = await _run_flow(hass, _settings(**{CONF_DESTINATION_FILTER: "Duisburg"}))
+    assert first["type"] == "create_entry"
+
+    second = await _run_flow(hass, _settings(**{CONF_DESTINATION_FILTER: "Duisburg"}))
+    assert second["type"] == "abort"
+    assert second["reason"] == "already_configured"
+
+
+async def test_filter_order_and_case_do_not_create_a_new_entry(hass: HomeAssistant):
+    """"S1, S2" and "s2 , s1" are the same configuration."""
+    first = await _run_flow(hass, _settings(**{CONF_LINE_FILTER: "S1, S2"}))
+    assert first["type"] == "create_entry"
+
+    second = await _run_flow(hass, _settings(**{CONF_LINE_FILTER: "s2 , s1"}))
+    assert second["type"] == "abort"
+    assert second["reason"] == "already_configured"
+
+
+async def test_unfiltered_duplicate_still_aborts(hass: HomeAssistant):
+    """Without filters there is nothing to tell the entries apart."""
+    first = await _run_flow(hass, _settings())
+    assert first["type"] == "create_entry"
+
+    second = await _run_flow(hass, _settings())
+    assert second["type"] == "abort"
+    assert second["reason"] == "already_configured"
+
+
+# ── backwards compatibility ───────────────────────────────────────────────────
+
+
+async def test_unfiltered_entry_keeps_the_legacy_unique_id(hass: HomeAssistant):
+    """No filters → no discriminator, so the ID format is untouched."""
+    result = await _run_flow(hass, _settings())
+
+    assert result["type"] == "create_entry"
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.unique_id == f"{PROVIDER_VRR}_{STOP_ID}"
+    assert CONF_ENTRY_SUFFIX not in result["data"]
+    assert CONF_ENTRY_LABEL not in result["data"]
+
+
+def _coordinator() -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.provider = PROVIDER_VRR
+    coordinator.station_id = STOP_ID
+    coordinator.place_dm = "Düsseldorf"
+    coordinator.name_dm = "Hauptbahnhof"
+    coordinator.agency_name = "Rheinbahn"
+    return coordinator
+
+
+def _entry(hass: HomeAssistant, **extra) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_PROVIDER: PROVIDER_VRR, CONF_STATION_ID: STOP_ID, **extra},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_entity_key_unchanged_for_pre_existing_entries(hass: HomeAssistant):
+    """An entry without a discriminator gets the byte-identical legacy key.
+
+    CLAUDE.md pins f"{provider}_{station_id}" as stable — existing users'
+    entity registries depend on it.
+    """
+    entry = _entry(hass)
+
+    assert station_entity_key(_coordinator(), entry) == f"{PROVIDER_VRR}_{STOP_ID}"
+    assert station_device_name(_coordinator(), entry) == "Rheinbahn - Hauptbahnhof"
+
+
+async def test_entity_key_without_a_config_entry(hass: HomeAssistant):
+    """Callers that pass no entry still get the legacy key."""
+    assert station_entity_key(_coordinator()) == f"{PROVIDER_VRR}_{STOP_ID}"
+
+
+async def test_entity_key_falls_back_to_place_and_name(hass: HomeAssistant):
+    """Providers with no stop ID key on place+name, as before."""
+    coordinator = _coordinator()
+    coordinator.station_id = None
+
+    assert station_entity_key(coordinator, _entry(hass)) == f"{PROVIDER_VRR}_düsseldorf_hauptbahnhof"
+
+
+async def test_entity_key_appends_the_discriminator(hass: HomeAssistant):
+    """A filtered entry gets its own key, so the two do not collide."""
+    entry = _entry(hass, **{CONF_ENTRY_SUFFIX: "abc12345", CONF_ENTRY_LABEL: "→ Duisburg"})
+
+    assert station_entity_key(_coordinator(), entry) == f"{PROVIDER_VRR}_{STOP_ID}_abc12345"
+    assert station_device_name(_coordinator(), entry) == "Rheinbahn - Hauptbahnhof (→ Duisburg)"
+
+
+async def test_every_platform_derives_its_key_from_the_shared_helper(hass: HomeAssistant):
+    """sensor, binary_sensor, calendar, camera, event and statistics stay in sync."""
+    from custom_components.openpublictransport.binary_sensor import PublicTransportDelayBinarySensor
+    from custom_components.openpublictransport.calendar import DepartureCalendar
+    from custom_components.openpublictransport.event import DisruptionEventEntity
+    from custom_components.openpublictransport.statistics import PunctualitySensor
+
+    entry = _entry(hass, **{CONF_ENTRY_SUFFIX: "abc12345", CONF_ENTRY_LABEL: "→ Duisburg"})
+    coordinator = _coordinator()
+    coordinator.hass = hass
+    expected = f"{PROVIDER_VRR}_{STOP_ID}_abc12345"
+
+    assert PublicTransportDelayBinarySensor(coordinator, entry, ["bus"]).unique_id == f"{expected}_delays"
+    assert DepartureCalendar(coordinator, entry).unique_id == f"{expected}_calendar"
+    assert DisruptionEventEntity(coordinator, entry).unique_id == f"{expected}_disruptions"
+    assert PunctualitySensor(coordinator, entry).unique_id == f"{expected}_statistics"
+
+
+# ── the discriminator itself ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    [
+        {},
+        {CONF_LINE_FILTER: "", CONF_DESTINATION_FILTER: "", CONF_PLATFORM_FILTER: ""},
+        {CONF_LINE_FILTER: "  ", CONF_DESTINATION_FILTER: ",", CONF_PLATFORM_FILTER: " , "},
+        # Filters that do not discriminate between directions are ignored
+        {CONF_FAVORITE_LINES: "S1", CONF_WALKING_TIME: 5, CONF_DEPARTURES: 20},
+    ],
+)
+def test_no_discriminator_without_filters(user_input):
+    assert _filter_discriminator(user_input) == ""
+    assert _filter_label(user_input) == ""
+
+
+def test_discriminator_is_stable_and_short():
+    first = _filter_discriminator({CONF_DESTINATION_FILTER: "Duisburg"})
+    second = _filter_discriminator({CONF_DESTINATION_FILTER: "Duisburg"})
+
+    assert first == second
+    assert len(first) == 8
+    assert first.isalnum()
+
+
+def test_discriminator_ignores_order_and_case():
+    assert _filter_discriminator({CONF_LINE_FILTER: "S1,S2"}) == _filter_discriminator(
+        {CONF_LINE_FILTER: " s2 , S1 "}
+    )
+
+
+def test_discriminator_differs_per_filter_field():
+    """The same text in two different fields is two different configurations."""
+    assert _filter_discriminator({CONF_LINE_FILTER: "3"}) != _filter_discriminator({CONF_PLATFORM_FILTER: "3"})
+
+
+def test_label_covers_all_three_filters():
+    label = _filter_label(
+        {CONF_LINE_FILTER: "S1", CONF_DESTINATION_FILTER: "Duisburg", CONF_PLATFORM_FILTER: "3"}
+    )
+    assert label == "S1 → Duisburg Pl. 3"


### PR DESCRIPTION
Closes #55.

> **Stacked on #65** (platform filter, #57), which is itself stacked on #64. Base is
> `feat/57-platform-filter`, so the diff here is only the duplicate-entry work. GitHub
> retargets as the stack merges.

## The problem

The reporter wants two badges for one S-Bahn station — one outbound, one inbound. The wizard
refuses: the config-entry unique ID is `f"{provider}_{stop_id}"`, so the second attempt aborts
with `already_configured`. Every entity unique ID and the device identifier are built on the
same string, so simply dropping the abort would just move the collision one level down.

## Approach

An entry that has a **line**, **destination** or **platform** filter gets a stable 8-char
discriminator derived from those filters. It is appended to the config-entry unique ID, and —
via `entry.data["entry_suffix"]` — to every entity unique ID and the device identifier.

An entry **without** filters gets no discriminator at all. That is the important half:
`CLAUDE.md` pins `f"{provider}_{station_key}"` as a stable format because existing users'
entity registries depend on it, and this keeps it byte-identical. Nothing is renamed by the
upgrade.

Duplicate detection still works:

| Second entry | Result |
|---|---|
| different filters | created, own unique ID |
| identical filters | `already_configured` |
| `"S1, S2"` vs `"s2 , s1"` | `already_configured` — order/case-insensitive |
| both unfiltered | `already_configured` |

Filters are also rendered into the entry title and the device name, so the two entries are
tellable apart at a glance:

```
VRR Düsseldorf - Düsseldorf Hbf (S1 → Duisburg)
VRR Düsseldorf - Düsseldorf Hbf (→ Köln)
```

## Deliberate design points

- **The discriminator is frozen at creation.** Editing filters under Options does *not*
  recompute it — that would rename every entity of the entry and break dashboards. Same for
  reconfigure (moving the entry to another stop), where the existing suffix is explicitly
  carried over. Documented in `docs/configuration.md`.
- **`favorite_lines` / `walking_time` are not discriminators.** They change presentation, not
  which departures the entry is about, so two entries differing only there are still duplicates.
- **A hash, not a readable slug.** Unique IDs are never user-visible; readability lives in the
  title and device name, which are separate. A hash also can't collide or blow up in length.

## Refactor

Entity keys and device names now come from two shared helpers in `sensor.py`
(`station_entity_key`, `station_device_name`) instead of six copies of the same f-string
across `sensor`, `binary_sensor`, `calendar`, `camera`, `event` and `statistics`.

## Tests

New `tests/test_config_flow_duplicate_station.py` — 19 tests:

- the reported scenario end to end through the real flow, plus title/label assertions
- all four duplicate-detection cases in the table above
- **back-compat**: an entry with no discriminator produces the exact legacy key, with no
  config entry at all, and with the place+name fallback for providers with no stop ID
- all four secondary platforms derive their key from the shared helper
- the discriminator itself: empty for unfiltered input, stable, 8 alphanumeric chars,
  order/case-insensitive, and different for the same text in different filter fields

`pytest tests/ -q` → **527 passed**. `black` / `isort` / `flake8` clean.

## What to test in the pre-release

The important check is a **negative** one: after installing, confirm your existing entries'
entity IDs are unchanged in the entity registry and no dashboard broke. Then add an
already-configured station a second time with a different destination filter and confirm both
entries coexist with distinct devices.
