### PR TITLE
feat(hvv): expose the official Geofox GTI provider in the setup UI (#61)

### DIFF
--- a/custom_components/openpublictransport/__init__.py
+++ b/custom_components/openpublictransport/__init__.py
@@ -14,6 +14,8 @@ from homeassistant.helpers import entity_registry as er
 
 from .const import (
     CONF_DEPARTURES,
+    CONF_HVV_GTI_PASSWORD,
+    CONF_HVV_GTI_USER,
     CONF_NATIONAL_RAIL_API_KEY,
     CONF_NTA_API_KEY,
     CONF_NTA_API_KEY_SECONDARY,
@@ -30,6 +32,7 @@ from .const import (
     DEFAULT_DEPARTURES,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    PROVIDER_HVV_GTI,
     PROVIDER_NATIONAL_RAIL,
     PROVIDER_NTA_IE,
     PROVIDER_OPT,
@@ -117,6 +120,7 @@ async def _async_migrate_credential(hass: HomeAssistant, entry: ConfigEntry) -> 
         PROVIDER_VBN_OTP: (CONF_VBN_API_KEY, ""),
         PROVIDER_VBN_TRIAS: (CONF_VBN_API_KEY, ""),
         PROVIDER_NTA_IE: (CONF_NTA_API_KEY, CONF_NTA_API_KEY_SECONDARY),
+        PROVIDER_HVV_GTI: (CONF_HVV_GTI_USER, CONF_HVV_GTI_PASSWORD),
         PROVIDER_REJSEPLANEN: (CONF_REJSEPLANEN_API_KEY, ""),
         PROVIDER_NATIONAL_RAIL: (CONF_NATIONAL_RAIL_API_KEY, ""),
     }
@@ -352,6 +356,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     otp_custom_api_key = entry.data.get(CONF_OTP_CUSTOM_API_KEY)  # For custom OTP instance
     rejseplanen_api_key = entry.data.get(CONF_REJSEPLANEN_API_KEY)  # For Rejseplanen (DK)
     national_rail_api_key = entry.data.get(CONF_NATIONAL_RAIL_API_KEY)  # For National Rail (UK)
+    hvv_gti_user = entry.data.get(CONF_HVV_GTI_USER)  # For HVV Geofox GTI (password read by the coordinator)
     otp_custom_url = entry.data.get(CONF_OTP_BASE_URL)  # For custom OTP instance
 
     # Use appropriate API key (and URL) based on provider
@@ -374,6 +379,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         api_key = rejseplanen_api_key
     elif provider == PROVIDER_NATIONAL_RAIL:
         api_key = national_rail_api_key
+    elif provider == PROVIDER_HVV_GTI:
+        api_key = hvv_gti_user
 
     departures = entry.options.get(CONF_DEPARTURES, entry.data.get(CONF_DEPARTURES, DEFAULT_DEPARTURES))
     scan_interval = entry.options.get(CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))

--- a/custom_components/openpublictransport/config_flow.py
+++ b/custom_components/openpublictransport/config_flow.py
@@ -30,6 +30,8 @@ from .const import (
     CONF_ENTRY_LABEL,
     CONF_ENTRY_SUFFIX,
     CONF_FAVORITE_LINES,
+    CONF_HVV_GTI_PASSWORD,
+    CONF_HVV_GTI_USER,
     CONF_LINE_FILTER,
     CONF_NATIONAL_RAIL_API_KEY,
     CONF_NTA_API_KEY,
@@ -54,6 +56,7 @@ from .const import (
     DEFAULT_WALKING_TIME,
     DOMAIN,
     PROVIDER_HVV,
+    PROVIDER_HVV_GTI,
     PROVIDER_KVV,
     PROVIDER_NATIONAL_RAIL,
     PROVIDER_NTA_IE,
@@ -157,6 +160,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             {"value": "ding", "label": "DING — Ulm / Donau-Iller"},
             {"value": "entur_no", "label": "Entur — Norwegen"},
             {"value": "hvv", "label": "HVV — Hamburg"},
+            {"value": "hvv_gti", "label": "HVV — Hamburg (Geofox GTI, Zugangsdaten)"},
             {"value": "irishrail_ie", "label": "Irish Rail — Irland"},
             {"value": "kvv", "label": "KVV — Karlsruhe"},
             {"value": "mobiliteit_lu", "label": "mobilitéit.lu — Luxemburg"},
@@ -267,6 +271,11 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 if secondary_key:
                     result[CONF_NTA_API_KEY_SECONDARY] = secondary_key
                 return result
+            if provider == PROVIDER_HVV_GTI:
+                # GTI needs both halves; without the password nothing can be signed.
+                if not secondary_key:
+                    return {}
+                return {CONF_HVV_GTI_USER: api_key, CONF_HVV_GTI_PASSWORD: secondary_key}
         except Exception as exc:
             _LOGGER.debug("Could not read from application_credentials: %s", exc)
         return {}
@@ -298,6 +307,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             PROVIDER_RMV: [CONF_RMV_API_KEY],
             PROVIDER_NATIONAL_RAIL: [CONF_NATIONAL_RAIL_API_KEY],
             PROVIDER_REJSEPLANEN: [CONF_REJSEPLANEN_API_KEY],
+            PROVIDER_HVV_GTI: [CONF_HVV_GTI_USER, CONF_HVV_GTI_PASSWORD],
         }
         keys = key_map.get(provider, [])
         if not keys:
@@ -320,6 +330,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         PROVIDER_NTA_IE: "NTA (Irland)",
         PROVIDER_NATIONAL_RAIL: "National Rail (Großbritannien)",
         PROVIDER_REJSEPLANEN: "Rejseplanen (Dänemark)",
+        PROVIDER_HVV_GTI: "HVV Geofox GTI (Hamburg)",
     }
 
     async def _async_store_credential(self, provider: str) -> None:
@@ -328,7 +339,7 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             return
         secondary = ""
         key = self._api_key or ""
-        if provider == PROVIDER_NTA_IE:
+        if provider in (PROVIDER_NTA_IE, PROVIDER_HVV_GTI):
             secondary = self._api_key_secondary or ""
         if not key:
             return
@@ -480,6 +491,10 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
             elif self._provider == PROVIDER_REJSEPLANEN and creds.get(CONF_REJSEPLANEN_API_KEY):
                 self._api_key = creds[CONF_REJSEPLANEN_API_KEY]
                 return await self._async_next_step_after_api_key()
+            elif self._provider == PROVIDER_HVV_GTI and creds.get(CONF_HVV_GTI_USER):
+                self._api_key = creds[CONF_HVV_GTI_USER]
+                self._api_key_secondary = creds.get(CONF_HVV_GTI_PASSWORD)
+                return await self._async_next_step_after_api_key()
 
         if user_input is not None:
             if self._provider == PROVIDER_TRAFIKLAB_SE:
@@ -526,6 +541,17 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 else:
                     self._api_key = api_key
                     return await self._async_next_step_after_api_key()
+            elif self._provider == PROVIDER_HVV_GTI:
+                # GTI signs every request, so both halves are mandatory: the
+                # username identifies the app, the password is the HMAC key.
+                user = user_input.get(CONF_HVV_GTI_USER, "").strip()
+                password = user_input.get(CONF_HVV_GTI_PASSWORD, "").strip()
+                if not user or not password:
+                    errors["base"] = "hvv_gti_credentials_required"
+                else:
+                    self._api_key = user
+                    self._api_key_secondary = password
+                    return await self._async_next_step_after_api_key()
 
         # Show appropriate schema based on provider
         if self._provider == PROVIDER_TRAFIKLAB_SE:
@@ -557,6 +583,18 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
         elif self._provider == PROVIDER_REJSEPLANEN:
             schema = vol.Schema({vol.Required(CONF_REJSEPLANEN_API_KEY): str})
             description = "Rejseplanen API key required. Register for free at labs.rejseplanen.dk (50k calls/month, non-commercial)."
+        elif self._provider == PROVIDER_HVV_GTI:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_HVV_GTI_USER): str,
+                    vol.Required(CONF_HVV_GTI_PASSWORD): str,
+                }
+            )
+            description = (
+                "HVV Geofox GTI credentials required (username + password). "
+                "Request them for free by email at api@hochbahn.de, see hvv.de/de/fahrplaene/"
+                "abruf-fahrplaninfos/datenabruf. Free for non-commercial travel information only."
+            )
         else:  # NTA
             schema = vol.Schema(
                 {
@@ -821,6 +859,15 @@ class OpenPublicTransportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  
                 data[CONF_NTA_API_KEY] = self._api_key
                 if self._api_key_secondary:
                     data[CONF_NTA_API_KEY_SECONDARY] = self._api_key_secondary
+            elif self._provider == PROVIDER_HVV_GTI:
+                if not self._api_key or not self._api_key_secondary:
+                    return self.async_show_form(
+                        step_id="settings",
+                        data_schema=schema,
+                        errors={"base": "hvv_gti_credentials_required"},
+                    )
+                data[CONF_HVV_GTI_USER] = self._api_key
+                data[CONF_HVV_GTI_PASSWORD] = self._api_key_secondary
             elif self._provider == PROVIDER_RMV:
                 if not self._api_key:
                     return self.async_show_form(

--- a/custom_components/openpublictransport/const.py
+++ b/custom_components/openpublictransport/const.py
@@ -36,6 +36,9 @@ DEFAULT_WALKING_TIME = 0
 PROVIDER_VRR = "vrr"
 PROVIDER_KVV = "kvv"
 PROVIDER_HVV = "hvv"
+PROVIDER_HVV_GTI = "hvv_gti"  # HVV via the official Geofox GTI API (credentials required)
+CONF_HVV_GTI_USER = "hvv_gti_user"  # GTI application ID (geofox-auth-user)
+CONF_HVV_GTI_PASSWORD = "hvv_gti_password"  # GTI password, used as the HMAC-SHA1 key
 PROVIDER_BVG = "bvg"
 PROVIDER_MVV = "mvv"
 PROVIDER_VVS = "vvs"
@@ -81,6 +84,7 @@ PROVIDERS = [
     PROVIDER_VRR,
     PROVIDER_KVV,
     PROVIDER_HVV,
+    PROVIDER_HVV_GTI,
     PROVIDER_BVG,
     PROVIDER_MVV,
     PROVIDER_VVS,
@@ -137,6 +141,7 @@ PROVIDER_ICONS = {
     "vrr": "mdi:bus-clock",
     "kvv": "mdi:tram",
     "hvv": "mdi:ferry",
+    "hvv_gti": "mdi:ferry",
     "bvg": "mdi:subway-variant",
     "mvv": "mdi:tram",
     "vvs": "mdi:train",
@@ -173,6 +178,7 @@ PROVIDER_ENTITY_PICTURES = {
     "vrr": "https://www.vrr.de/favicon.ico",
     "kvv": "https://www.kvv.de/favicon.ico",
     "hvv": "https://www.hvv.de/favicon.ico",
+    "hvv_gti": "https://www.hvv.de/favicon.ico",
     "bvg": "https://www.bvg.de/favicon.ico",
     "mvv": "https://www.mvv-muenchen.de/favicon.ico",
     "vvs": "https://www.vvs.de/favicon.ico",

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -14,7 +14,7 @@
   "issue_tracker": "https://github.com/NerdySoftPaw/openpublictransport/issues",
   "quality_scale": "silver",
   "requirements": [
-    "python-openpublictransport==0.1.15",
+    "python-openpublictransport==0.1.16",
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],

--- a/custom_components/openpublictransport/sensor.py
+++ b/custom_components/openpublictransport/sensor.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_ENTRY_LABEL,
     CONF_ENTRY_SUFFIX,
     CONF_FAVORITE_LINES,
+    CONF_HVV_GTI_PASSWORD,
     CONF_LINE_FILTER,
     CONF_NTA_API_KEY_SECONDARY,
     CONF_PLATFORM_FILTER,
@@ -39,6 +40,7 @@ from .const import (
     DOMAIN,
     FILTERED_FETCH_LIMIT,
     PROVIDER_ENTITY_PICTURES,
+    PROVIDER_HVV_GTI,
     PROVIDER_NTA_IE,
     TRANSPORTATION_TYPES,
 )
@@ -128,7 +130,8 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
         self._api_calls_today = 0
         self._last_api_reset = datetime.now().date()
         self.api_key = api_key  # For Trafiklab API or NTA API (Primary)
-        self.api_key_secondary: Optional[str] = None  # For NTA API (Secondary, optional fallback)
+        # NTA's optional fallback key, and HVV GTI's password (its HMAC key)
+        self.api_key_secondary: Optional[str] = None
         self.custom_url = custom_url  # For otp_custom provider
 
         # Note: config_entry parameter was added in HA 2024.11+
@@ -138,12 +141,14 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
         self._empty_result_count = 0
         self.agency_name = config_entry.data.get("agency_name", "") if config_entry else ""
 
-        # Store secondary key for NTA
-        if provider == PROVIDER_NTA_IE and config_entry:
-            self.api_key_secondary = config_entry.data.get(CONF_NTA_API_KEY_SECONDARY)
-        self._nta_secondary_key = (
-            config_entry.data.get(CONF_NTA_API_KEY_SECONDARY) if config_entry and provider == PROVIDER_NTA_IE else None
-        )
+        # Providers whose second credential lives in entry.data rather than
+        # being threaded through the constructor.
+        secondary_key_conf = {
+            PROVIDER_NTA_IE: CONF_NTA_API_KEY_SECONDARY,
+            PROVIDER_HVV_GTI: CONF_HVV_GTI_PASSWORD,
+        }.get(provider)
+        if secondary_key_conf and config_entry:
+            self.api_key_secondary = config_entry.data.get(secondary_key_conf)
 
         self.last_update_success_time: Optional[datetime] = None
 
@@ -240,7 +245,7 @@ class PublicTransportDataUpdateCoordinator(DataUpdateCoordinator):
                 self.provider,
                 session,
                 api_key=self.api_key,
-                api_key_secondary=self._nta_secondary_key,
+                api_key_secondary=self.api_key_secondary,
                 custom_url=self.custom_url,
             )
             if not self.provider_instance:

--- a/custom_components/openpublictransport/strings.json
+++ b/custom_components/openpublictransport/strings.json
@@ -55,13 +55,17 @@
           "trafiklab_api_key": "Trafiklab API-Schlüssel",
           "nta_api_key": "NTA Primary API-Schlüssel",
           "nta_api_key_secondary": "NTA Secondary API-Schlüssel (optional)",
-          "rmv_api_key": "RMV API-Schlüssel"
+          "rmv_api_key": "RMV API-Schlüssel",
+          "hvv_gti_user": "GTI-Benutzername (Application ID)",
+          "hvv_gti_password": "GTI-Passwort"
         },
         "data_description": {
           "trafiklab_api_key": "Trafiklab API-Schlüssel (erhältlich auf trafiklab.se)",
           "nta_api_key": "NTA Primary API-Schlüssel (erforderlich, erhältlich auf developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA Secondary API-Schlüssel (optional, als Fallback)",
-          "rmv_api_key": "RMV API-Schlüssel (erhältlich auf opendata.rmv.de)"
+          "rmv_api_key": "RMV API-Schlüssel (erhältlich auf opendata.rmv.de)",
+          "hvv_gti_user": "Benutzername aus den Geofox-GTI-Zugangsdaten (geofox-auth-user)",
+          "hvv_gti_password": "Passwort aus den Geofox-GTI-Zugangsdaten. Wird zum Signieren jeder Anfrage verwendet und nicht übertragen"
         }
       },
       "settings": {
@@ -146,7 +150,8 @@
       "trafiklab_api_key_required": "Trafiklab API-Schlüssel ist erforderlich",
       "nta_api_key_required": "NTA API-Schlüssel ist erforderlich",
       "rmv_api_key_required": "RMV API-Schlüssel ist erforderlich",
-      "min_two_entities": "Bitte mindestens 2 Entity-IDs angeben"
+      "min_two_entities": "Bitte mindestens 2 Entity-IDs angeben",
+      "hvv_gti_credentials_required": "GTI-Benutzername und -Passwort sind beide erforderlich (kostenlos anfragen per E-Mail an api@hochbahn.de)"
     },
     "abort": {
       "reauth_successful": "API-Schlüssel erfolgreich aktualisiert.",

--- a/custom_components/openpublictransport/translations/de.json
+++ b/custom_components/openpublictransport/translations/de.json
@@ -53,14 +53,18 @@
           "nta_api_key": "NTA Primary API-Schlüssel",
           "nta_api_key_secondary": "NTA Secondary API-Schlüssel (optional)",
           "rmv_api_key": "RMV API-Schlüssel",
-          "vbn_api_key": "VBN API-Schlüssel"
+          "vbn_api_key": "VBN API-Schlüssel",
+          "hvv_gti_user": "GTI-Benutzername (Application ID)",
+          "hvv_gti_password": "GTI-Passwort"
         },
         "data_description": {
           "trafiklab_api_key": "Trafiklab API-Schlüssel (erhältlich auf trafiklab.se)",
           "nta_api_key": "NTA Primary API-Schlüssel (erforderlich, erhältlich auf developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA Secondary API-Schlüssel (optional, als Fallback)",
           "rmv_api_key": "RMV API-Schlüssel (erhältlich auf opendata.rmv.de)",
-          "vbn_api_key": "VBN API-Schlüssel — gilt für OTP und TRIAS. Kostenlos für private Nutzung, per E-Mail anfragen bei api@vbn.de"
+          "vbn_api_key": "VBN API-Schlüssel — gilt für OTP und TRIAS. Kostenlos für private Nutzung, per E-Mail anfragen bei api@vbn.de",
+          "hvv_gti_user": "Benutzername aus den Geofox-GTI-Zugangsdaten (geofox-auth-user)",
+          "hvv_gti_password": "Passwort aus den Geofox-GTI-Zugangsdaten. Wird zum Signieren jeder Anfrage verwendet und nicht übertragen"
         }
       },
       "settings": {
@@ -132,7 +136,8 @@
       "nta_api_key_required": "NTA API-Schlüssel ist erforderlich",
       "rmv_api_key_required": "RMV API-Schlüssel ist erforderlich",
       "vbn_api_key_required": "VBN API-Schlüssel ist erforderlich",
-      "min_two_entities": "Bitte mindestens 2 Entity-IDs angeben"
+      "min_two_entities": "Bitte mindestens 2 Entity-IDs angeben",
+      "hvv_gti_credentials_required": "GTI-Benutzername und -Passwort sind beide erforderlich (kostenlos anfragen per E-Mail an api@hochbahn.de)"
     }
   },
   "options": {

--- a/custom_components/openpublictransport/translations/en.json
+++ b/custom_components/openpublictransport/translations/en.json
@@ -53,14 +53,18 @@
           "nta_api_key": "NTA Primary API Key",
           "nta_api_key_secondary": "NTA Secondary API Key (optional)",
           "rmv_api_key": "RMV API Key",
-          "vbn_api_key": "VBN API Key"
+          "vbn_api_key": "VBN API Key",
+          "hvv_gti_user": "GTI username (application ID)",
+          "hvv_gti_password": "GTI password"
         },
         "data_description": {
           "trafiklab_api_key": "Trafiklab API key (available at trafiklab.se)",
           "nta_api_key": "NTA Primary API key (required, available at developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA Secondary API key (optional, used as fallback)",
           "rmv_api_key": "RMV API key (request at opendata.rmv.de)",
-          "vbn_api_key": "VBN API key — works for both OTP and TRIAS. Free for non-commercial use, request by e-mail at api@vbn.de"
+          "vbn_api_key": "VBN API key — works for both OTP and TRIAS. Free for non-commercial use, request by e-mail at api@vbn.de",
+          "hvv_gti_user": "Username from your Geofox GTI credentials (geofox-auth-user)",
+          "hvv_gti_password": "Password from your Geofox GTI credentials. Used to sign each request; it is never transmitted"
         }
       },
       "settings": {
@@ -137,7 +141,8 @@
       "nta_api_key_required": "NTA API key is required",
       "rmv_api_key_required": "RMV API key is required",
       "vbn_api_key_required": "VBN API key is required",
-      "min_two_entities": "Please provide at least 2 entity IDs"
+      "min_two_entities": "Please provide at least 2 entity IDs",
+      "hvv_gti_credentials_required": "Both the GTI username and password are required (request them free by email at api@hochbahn.de)"
     }
   },
   "options": {

--- a/custom_components/openpublictransport/translations/fr.json
+++ b/custom_components/openpublictransport/translations/fr.json
@@ -55,13 +55,17 @@
           "trafiklab_api_key": "Clé API Trafiklab",
           "nta_api_key": "Clé API primaire NTA",
           "nta_api_key_secondary": "Clé API secondaire NTA (facultatif)",
-          "rmv_api_key": "Clé API RMV"
+          "rmv_api_key": "Clé API RMV",
+          "hvv_gti_user": "Nom d'utilisateur GTI (ID application)",
+          "hvv_gti_password": "Mot de passe GTI"
         },
         "data_description": {
           "trafiklab_api_key": "Clé API Trafiklab (disponible sur trafiklab.se)",
           "nta_api_key": "Clé API primaire NTA (requise, disponible sur developer.nationaltransport.ie)",
           "nta_api_key_secondary": "Clé API secondaire NTA (facultatif, utilisée en secours)",
-          "rmv_api_key": "Clé API RMV (à demander sur opendata.rmv.de)"
+          "rmv_api_key": "Clé API RMV (à demander sur opendata.rmv.de)",
+          "hvv_gti_user": "Nom d'utilisateur de vos identifiants Geofox GTI (geofox-auth-user)",
+          "hvv_gti_password": "Mot de passe de vos identifiants Geofox GTI. Sert à signer chaque requête et n'est jamais transmis"
         }
       },
       "settings": {
@@ -132,7 +136,8 @@
       "trafiklab_api_key_required": "La clé API Trafiklab est requise",
       "nta_api_key_required": "La clé API NTA est requise",
       "rmv_api_key_required": "La clé API RMV est requise",
-      "min_two_entities": "Veuillez fournir au moins 2 identifiants d'entités"
+      "min_two_entities": "Veuillez fournir au moins 2 identifiants d'entités",
+      "hvv_gti_credentials_required": "Le nom d'utilisateur et le mot de passe GTI sont tous deux requis (gratuits par e-mail à api@hochbahn.de)"
     }
   },
   "options": {

--- a/custom_components/openpublictransport/translations/it.json
+++ b/custom_components/openpublictransport/translations/it.json
@@ -55,13 +55,17 @@
           "trafiklab_api_key": "API Key Trafiklab",
           "nta_api_key": "API Key primaria NTA",
           "nta_api_key_secondary": "API Key secondaria NTA (facoltativa)",
-          "rmv_api_key": "API Key RMV"
+          "rmv_api_key": "API Key RMV",
+          "hvv_gti_user": "Nome utente GTI (ID applicazione)",
+          "hvv_gti_password": "Password GTI"
         },
         "data_description": {
           "trafiklab_api_key": "API Key Trafiklab (disponibile su trafiklab.se)",
           "nta_api_key": "API Key primaria NTA (obbligatoria, disponibile su developer.nationaltransport.ie)",
           "nta_api_key_secondary": "API Key secondaria NTA (facoltativa, usata come riserva)",
-          "rmv_api_key": "API Key RMV (da richiedere su opendata.rmv.de)"
+          "rmv_api_key": "API Key RMV (da richiedere su opendata.rmv.de)",
+          "hvv_gti_user": "Nome utente delle credenziali Geofox GTI (geofox-auth-user)",
+          "hvv_gti_password": "Password delle credenziali Geofox GTI. Serve a firmare ogni richiesta e non viene mai trasmessa"
         }
       },
       "settings": {
@@ -132,7 +136,8 @@
       "trafiklab_api_key_required": "L'API Key Trafiklab è obbligatoria",
       "nta_api_key_required": "L'API Key NTA è obbligatoria",
       "rmv_api_key_required": "L'API Key RMV è obbligatoria",
-      "min_two_entities": "Fornisci almeno 2 ID entità"
+      "min_two_entities": "Fornisci almeno 2 ID entità",
+      "hvv_gti_credentials_required": "Sono richiesti sia il nome utente sia la password GTI (gratuiti via e-mail a api@hochbahn.de)"
     }
   },
   "options": {

--- a/custom_components/openpublictransport/translations/nl.json
+++ b/custom_components/openpublictransport/translations/nl.json
@@ -55,13 +55,17 @@
           "trafiklab_api_key": "Trafiklab API Key",
           "nta_api_key": "NTA primaire API Key",
           "nta_api_key_secondary": "NTA secundaire API Key (optioneel)",
-          "rmv_api_key": "RMV API Key"
+          "rmv_api_key": "RMV API Key",
+          "hvv_gti_user": "GTI-gebruikersnaam (application ID)",
+          "hvv_gti_password": "GTI-wachtwoord"
         },
         "data_description": {
           "trafiklab_api_key": "Trafiklab API Key (beschikbaar op trafiklab.se)",
           "nta_api_key": "NTA primaire API Key (vereist, beschikbaar op developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA secundaire API Key (optioneel, gebruikt als terugval)",
-          "rmv_api_key": "RMV API Key (aan te vragen op opendata.rmv.de)"
+          "rmv_api_key": "RMV API Key (aan te vragen op opendata.rmv.de)",
+          "hvv_gti_user": "Gebruikersnaam uit je Geofox GTI-gegevens (geofox-auth-user)",
+          "hvv_gti_password": "Wachtwoord uit je Geofox GTI-gegevens. Wordt gebruikt om elk verzoek te ondertekenen en nooit verzonden"
         }
       },
       "settings": {
@@ -132,7 +136,8 @@
       "trafiklab_api_key_required": "Trafiklab API Key is vereist",
       "nta_api_key_required": "NTA API Key is vereist",
       "rmv_api_key_required": "RMV API Key is vereist",
-      "min_two_entities": "Geef ten minste 2 entiteits-ID's op"
+      "min_two_entities": "Geef ten minste 2 entiteits-ID's op",
+      "hvv_gti_credentials_required": "GTI-gebruikersnaam én wachtwoord zijn vereist (gratis aan te vragen per e-mail via api@hochbahn.de)"
     }
   },
   "options": {

--- a/custom_components/openpublictransport/translations/pl.json
+++ b/custom_components/openpublictransport/translations/pl.json
@@ -55,13 +55,17 @@
           "trafiklab_api_key": "Klucz API Trafiklab",
           "nta_api_key": "Podstawowy klucz API NTA",
           "nta_api_key_secondary": "Dodatkowy klucz API NTA (opcjonalnie)",
-          "rmv_api_key": "Klucz API RMV"
+          "rmv_api_key": "Klucz API RMV",
+          "hvv_gti_user": "Nazwa użytkownika GTI (application ID)",
+          "hvv_gti_password": "Hasło GTI"
         },
         "data_description": {
           "trafiklab_api_key": "Klucz API Trafiklab (dostępny na trafiklab.se)",
           "nta_api_key": "Podstawowy klucz API NTA (wymagany, dostępny na developer.nationaltransport.ie)",
           "nta_api_key_secondary": "Dodatkowy klucz API NTA (opcjonalnie, używany jako zapasowy)",
-          "rmv_api_key": "Klucz API RMV (do uzyskania na opendata.rmv.de)"
+          "rmv_api_key": "Klucz API RMV (do uzyskania na opendata.rmv.de)",
+          "hvv_gti_user": "Nazwa użytkownika z danych dostępowych Geofox GTI (geofox-auth-user)",
+          "hvv_gti_password": "Hasło z danych dostępowych Geofox GTI. Służy do podpisywania każdego żądania i nigdy nie jest przesyłane"
         }
       },
       "settings": {
@@ -132,7 +136,8 @@
       "trafiklab_api_key_required": "Klucz API Trafiklab jest wymagany",
       "nta_api_key_required": "Klucz API NTA jest wymagany",
       "rmv_api_key_required": "Klucz API RMV jest wymagany",
-      "min_two_entities": "Podaj co najmniej 2 identyfikatory encji"
+      "min_two_entities": "Podaj co najmniej 2 identyfikatory encji",
+      "hvv_gti_credentials_required": "Wymagane są zarówno nazwa użytkownika, jak i hasło GTI (bezpłatnie e-mailem na api@hochbahn.de)"
     }
   },
   "options": {

--- a/custom_components/openpublictransport/translations/sv.json
+++ b/custom_components/openpublictransport/translations/sv.json
@@ -55,13 +55,17 @@
           "trafiklab_api_key": "Trafiklab API-nyckel",
           "nta_api_key": "NTA primär API-nyckel",
           "nta_api_key_secondary": "NTA sekundär API-nyckel (valfritt)",
-          "rmv_api_key": "RMV API-nyckel"
+          "rmv_api_key": "RMV API-nyckel",
+          "hvv_gti_user": "GTI-användarnamn (applikations-ID)",
+          "hvv_gti_password": "GTI-lösenord"
         },
         "data_description": {
           "trafiklab_api_key": "Trafiklab API-nyckel (tillgänglig på trafiklab.se)",
           "nta_api_key": "NTA primär API-nyckel (obligatorisk, tillgänglig på developer.nationaltransport.ie)",
           "nta_api_key_secondary": "NTA sekundär API-nyckel (valfritt, används som reserv)",
-          "rmv_api_key": "RMV API-nyckel (begär på opendata.rmv.de)"
+          "rmv_api_key": "RMV API-nyckel (begär på opendata.rmv.de)",
+          "hvv_gti_user": "Användarnamn från dina Geofox GTI-uppgifter (geofox-auth-user)",
+          "hvv_gti_password": "Lösenord från dina Geofox GTI-uppgifter. Används för att signera varje begäran och skickas aldrig"
         }
       },
       "settings": {
@@ -132,7 +136,8 @@
       "trafiklab_api_key_required": "Trafiklab API-nyckel krävs",
       "nta_api_key_required": "NTA API-nyckel krävs",
       "rmv_api_key_required": "RMV API-nyckel krävs",
-      "min_two_entities": "Ange minst 2 entitets-ID:n"
+      "min_two_entities": "Ange minst 2 entitets-ID:n",
+      "hvv_gti_credentials_required": "Både GTI-användarnamn och lösenord krävs (begär dem gratis via e-post till api@hochbahn.de)"
     }
   },
   "options": {

--- a/docs/providers/hvv-gti.md
+++ b/docs/providers/hvv-gti.md
@@ -1,0 +1,92 @@
+# HVV Geofox GTI (Hamburg, official API)
+
+The **Geofox Thin Interface (GTI)** is HOCHBAHN's official API, operated on behalf of the
+Hamburger Verkehrsverbund. It is an alternative to the keyless [HVV](hvv.md) provider, which
+uses the public EFA endpoint.
+
+Both providers stay available. Pick this one if you want real-time data; pick the plain
+[HVV](hvv.md) provider if you do not want to apply for credentials.
+
+!!! note
+    "hvv" is the *Hamburger Verkehrsverbund*, the regional transit association. HOCHBAHN is a
+    company within it and runs the API on the association's behalf.
+
+## Why use it
+
+| | HVV (EFA) | HVV Geofox GTI |
+|---|---|---|
+| Credentials | none | username + password, free |
+| Real-time delays | inferred from planned vs. estimated | explicit `delay` in seconds |
+| Cancellations | ✗ | ✓ |
+| Platform changes | ✗ | ✓ (`realtimePlatform`) |
+| Reinforcement trips (*Verstärkerfahrten*) | ✗ | ✓ |
+
+## Getting credentials
+
+The API is **free**. Send an email to **api@hochbahn.de** describing your project and naming a
+contact person. You receive a username (the *application ID*) and a password.
+
+See [hvv.de — Datenabruf](https://www.hvv.de/de/fahrplaene/abruf-fahrplaninfos/datenabruf) and
+the [GTI handbook](https://gti.geofox.de/html/GTIHandbuch_p.html).
+
+!!! warning "Terms of use"
+    HOCHBAHN grants access for building a **free-of-charge** travel information service. You
+    may not charge for it directly or indirectly, and you may not pass the data on to third
+    parties without written approval. Access can be withdrawn with four weeks' notice. Running
+    this integration in your own Home Assistant is exactly the intended use; republishing the
+    data is not.
+
+## API Details
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | `https://gti.geofox.de/gti/public/` |
+| **API version** | 63 |
+| **Credentials** | Required (username + password) |
+| **Authentication** | HMAC-SHA1 over the request body, Base64, in `geofox-auth-signature` |
+| **Timezone** | Europe/Berlin |
+| **Methods used** | `checkName` (stop search), `departureList` (departures) |
+
+Your password is used as the HMAC key to sign each request — it is never sent to the server.
+Both values are stored in Home Assistant's **Application Credentials** store, like every other
+provider key.
+
+## Configuration
+
+1. Select **HVV — Hamburg (Geofox GTI, Zugangsdaten)** as provider
+2. Enter your GTI username and password
+3. Search for your stop (e.g. "Hamburg Hauptbahnhof")
+4. Select the stop and configure departure count and filters
+
+Once entered, the credentials are reused automatically for any further GTI entries.
+
+## Transport Types
+
+Mapped from the line's `type.shortInfo`, falling back to the coarse `type.simpleType` and,
+where that is ambiguous, to the line name.
+
+| GTI | Type |
+|-----|------|
+| `UBAHN` / `U` | subway |
+| `SBAHN` / `S`, `AKN` / `A`, `RBAHN`, `FERNBAHN`, `ZUG` | train |
+| `BUS`, `STADTBUS`, `METROBUS`, `SCHNELLBUS`, `NACHTBUS`, `XPRESSBUS`, `EILBUS` | bus |
+| `FAEHRE` / `SHIP` | ferry |
+| `AST` (Anruf-Sammel-Taxi) | taxi |
+
+## Departure attributes
+
+GTI returns offsets rather than timestamps: a reference time for the whole board, plus per
+departure a `timeOffset` in **minutes** and a `delay` in **seconds**.
+
+- `planned_time` = reference + `timeOffset`
+- `departure_time` = `planned_time` + `delay`
+- `delay` is reported in minutes, as for every other provider
+- `platform` prefers `realtimePlatform` over the scheduled `platform`; when the two differ,
+  `platform_changed` is set and the disruption event entity fires
+- cancellations and reinforcement trips appear in `notices`
+
+## Limitations
+
+- **Trip planning is not supported yet.** The GTI `getRoute` method is not wired up; use the
+  keyless [HVV](hvv.md) provider for trip entries.
+- The public interface is limited to HVV lines.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -35,6 +35,17 @@ These use the HAFAS "Scotty", HAFAS `mgate.exe`, or Entur transmodel interfaces.
 | **Irish Rail** | Ireland | HAFAS mgate | Yes | Yes | Cancellations | Autocomplete |
 | **TPG** | Geneva, Switzerland | HAFAS mgate | Yes | Yes | Cancellations | Autocomplete |
 
+### Providers added in 0.1.16
+
+| Provider | Region | API Type | Real-time | Platform | Notices | Stop Search |
+|----------|--------|----------|-----------|----------|---------|-------------|
+| **[HVV Geofox GTI](hvv-gti.md)** | Hamburg, Germany | GTI (HMAC-signed JSON) | Yes (explicit delay) | Yes, incl. changes | Cancellations, attributes | Autocomplete |
+
+HOCHBAHN's official API on behalf of the HVV. Free credentials, requested by email at
+api@hochbahn.de. It exposes delays, cancellations and platform changes that the keyless
+[HVV](hvv.md) EFA provider does not — both providers remain available.
+Trip planning is not supported on GTI yet; use the EFA `hvv` provider for trip entries.
+
 ## Timezone Handling
 
 Each provider uses its local timezone for departure times:
@@ -44,6 +55,7 @@ Each provider uses its local timezone for departure times:
 | VRR | Europe/Berlin |
 | KVV | Europe/Berlin |
 | HVV | Europe/Berlin |
+| HVV Geofox GTI | Europe/Berlin |
 | MVV | Europe/Berlin |
 | VVS | Europe/Berlin |
 | VGN | Europe/Berlin |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - VRR (Rhein-Ruhr): providers/vrr.md
       - KVV (Karlsruhe): providers/kvv.md
       - HVV (Hamburg): providers/hvv.md
+      - HVV Geofox GTI (Hamburg): providers/hvv-gti.md
       - BVG (Berlin): providers/bvg.md
       - MVV (München): providers/mvv.md
       - VVS (Stuttgart): providers/vvs.md

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,5 +5,5 @@ pytest-cov>=4.1.0
 pytest-homeassistant-custom-component>=0.13.0
 homeassistant>=2024.1.0
 aiofiles>=23.0.0
-python-openpublictransport>=0.1.15
+python-openpublictransport>=0.1.16
 PyTurboJPEG>=1.7.0

--- a/tests/test_config_flow_hvv_gti.py
+++ b/tests/test_config_flow_hvv_gti.py
@@ -1,0 +1,186 @@
+"""Tests for the HVV Geofox GTI provider wiring (issue #61).
+
+GTI is the first provider that needs *two* mandatory credentials: the username
+identifies the application and the password is the HMAC key every request is
+signed with. Neither half is optional, unlike NTA's secondary key.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.openpublictransport.const import (
+    CONF_DELAY_THRESHOLD,
+    CONF_DEPARTURES,
+    CONF_DESTINATION_FILTER,
+    CONF_FAVORITE_LINES,
+    CONF_HVV_GTI_PASSWORD,
+    CONF_HVV_GTI_USER,
+    CONF_LINE_FILTER,
+    CONF_PLATFORM_FILTER,
+    CONF_PROVIDER,
+    CONF_SCAN_INTERVAL,
+    CONF_STATION_ID,
+    CONF_TRANSPORTATION_TYPES,
+    CONF_USE_PROVIDER_LOGO,
+    CONF_WALKING_TIME,
+    DOMAIN,
+    PROVIDER_HVV,
+    PROVIDER_HVV_GTI,
+    PROVIDERS,
+)
+from custom_components.openpublictransport.sensor import PublicTransportDataUpdateCoordinator
+
+STOPS = [{"id": "Master:80953", "name": "Hauptbahnhof", "place": "Hamburg"}]
+
+SETTINGS = {
+    CONF_DEPARTURES: 10,
+    CONF_SCAN_INTERVAL: 60,
+    CONF_TRANSPORTATION_TYPES: ["bus", "train", "tram", "subway"],
+    CONF_USE_PROVIDER_LOGO: False,
+    CONF_DELAY_THRESHOLD: 5,
+    CONF_LINE_FILTER: "",
+    CONF_DESTINATION_FILTER: "",
+    CONF_PLATFORM_FILTER: "",
+    CONF_FAVORITE_LINES: "",
+    CONF_WALKING_TIME: 0,
+}
+
+
+async def _start(hass: HomeAssistant):
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+        data={"entry_type": "departures", CONF_PROVIDER: PROVIDER_HVV_GTI},
+    )
+
+
+def test_provider_is_offered_alongside_the_efa_one():
+    """The keyless EFA provider must stay — its ID is load-bearing for existing entries."""
+    assert PROVIDER_HVV_GTI in PROVIDERS
+    assert PROVIDER_HVV in PROVIDERS
+
+
+async def test_flow_asks_for_both_credentials(hass: HomeAssistant):
+    result = await _start(hass)
+
+    assert result["step_id"] == "api_key"
+    keys = {str(key) for key in result["data_schema"].schema}
+    assert keys == {CONF_HVV_GTI_USER, CONF_HVV_GTI_PASSWORD}
+
+
+async def test_password_is_mandatory(hass: HomeAssistant):
+    """Unlike NTA's secondary key, the GTI password is not optional."""
+    result = await _start(hass)
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HVV_GTI_USER: "myapp", CONF_HVV_GTI_PASSWORD: "  "}
+    )
+
+    assert result2["step_id"] == "api_key"
+    assert result2["errors"] == {"base": "hvv_gti_credentials_required"}
+
+
+async def test_username_is_mandatory(hass: HomeAssistant):
+    result = await _start(hass)
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HVV_GTI_USER: "", CONF_HVV_GTI_PASSWORD: "s3cr3t"}
+    )
+
+    assert result2["errors"] == {"base": "hvv_gti_credentials_required"}
+
+
+async def test_full_flow_stores_both_credentials(hass: HomeAssistant):
+    result = await _start(hass)
+
+    with patch("custom_components.openpublictransport.config_flow.get_provider") as mock_gp:
+        provider = AsyncMock()
+        provider.search_stops = AsyncMock(return_value=STOPS)
+        mock_gp.return_value = provider
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HVV_GTI_USER: "myapp", CONF_HVV_GTI_PASSWORD: "s3cr3t"},
+        )
+        if result["step_id"] == "stop_search":
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], user_input={"stop_search": "Hauptbahnhof"}
+            )
+
+    if result["step_id"] == "stop_select":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"stop": "Master:80953"}
+        )
+
+    assert result["step_id"] == "settings"
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=SETTINGS)
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_PROVIDER] == PROVIDER_HVV_GTI
+    assert result["data"][CONF_HVV_GTI_USER] == "myapp"
+    assert result["data"][CONF_HVV_GTI_PASSWORD] == "s3cr3t"
+    assert result["data"][CONF_STATION_ID] == "Master:80953"
+
+
+async def test_coordinator_passes_the_password_to_the_provider(hass: HomeAssistant):
+    """The password is the HMAC key — without it nothing can be signed."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROVIDER: PROVIDER_HVV_GTI,
+            CONF_STATION_ID: "Master:80953",
+            "place_dm": "Hamburg",
+            "name_dm": "Hauptbahnhof",
+            CONF_HVV_GTI_USER: "myapp",
+            CONF_HVV_GTI_PASSWORD: "s3cr3t",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = PublicTransportDataUpdateCoordinator(
+        hass,
+        PROVIDER_HVV_GTI,
+        "Hamburg",
+        "Hauptbahnhof",
+        "Master:80953",
+        10,
+        60,
+        config_entry=entry,
+        api_key="myapp",
+    )
+
+    assert coordinator.api_key_secondary == "s3cr3t"
+
+    with patch("custom_components.openpublictransport.sensor.get_provider") as mock_gp:
+        coordinator._ensure_provider()
+
+    assert mock_gp.call_args.kwargs["api_key"] == "myapp"
+    assert mock_gp.call_args.kwargs["api_key_secondary"] == "s3cr3t"
+
+
+async def test_efa_hvv_coordinator_has_no_secondary_key(hass: HomeAssistant):
+    """The keyless provider is unaffected."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_PROVIDER: PROVIDER_HVV, CONF_STATION_ID: "de:02000:1", "place_dm": "", "name_dm": "Hbf"},
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = PublicTransportDataUpdateCoordinator(
+        hass, PROVIDER_HVV, "", "Hbf", "de:02000:1", 10, 60, config_entry=entry
+    )
+
+    assert coordinator.api_key_secondary is None
+
+
+async def test_provider_resolves_from_the_library(hass: HomeAssistant):
+    """The registry entry exists and reports that it needs a key."""
+    from openpublictransport import get_provider
+
+    provider = get_provider(PROVIDER_HVV_GTI, None, api_key="u", api_key_secondary="p")
+
+    assert provider is not None
+    assert provider.provider_id == PROVIDER_HVV_GTI
+    assert provider.requires_api_key is True


### PR DESCRIPTION
Closes #61 — integration half. Provider implementation is in
**NerdySoftPaw/python-openpublictransport#16** (releases 0.1.16).

> Stacked on #66 → #65 → #64. Base is `feat/55-duplicate-station-entries`; GitHub retargets
> as the stack merges.

## What

@ThePlaceholderName was right — HOCHBAHN does run an official API on behalf of the HVV, the
[Geofox Thin Interface](https://gti.geofox.de/), and we were not using it. The existing `hvv`
provider talks to the public EFA endpoint, which has no explicit delay field, no cancellation
flag and no platform-change signal. GTI has all three.

New provider **`hvv_gti`**, added **alongside** `hvv` rather than replacing it: provider IDs
are load-bearing for existing config entries, and not everyone will want to apply for
credentials. Credentials are free, by email to api@hochbahn.de.

|  | HVV (EFA) | HVV Geofox GTI |
|---|---|---|
| Credentials | none | username + password, free |
| Real-time delays | inferred from planned vs. estimated | explicit `delay` in seconds |
| Cancellations | ✗ | ✓ |
| Platform changes | ✗ | ✓ (`realtimePlatform`) |
| Reinforcement trips | ✗ | ✓ |

## The interesting bit: two mandatory credentials

GTI is the first provider that needs **two** credentials where neither is optional — the
username identifies the application, the password is the HMAC-SHA1 key every request body is
signed with. NTA's two-key setup has an *optional* secondary, so its plumbing did not quite fit.

- New two-field branch in `async_step_api_key` with its own `hvv_gti_credentials_required`
  error, rather than reusing the single-key path.
- Both values go into the **Application Credentials** store (password as the client secret),
  and are reused automatically for further GTI entries.
- The coordinator now resolves its secondary credential from a small per-provider map instead
  of an NTA-only special case. That also let me drop `_nta_secondary_key`, an alias that had
  already stopped being NTA-specific.

## Files

`const.py`, `config_flow.py` (selector, credentials step, reuse, storage, entry data),
`sensor.py` (secondary-credential resolution), `__init__.py` (credential migration map + key
resolution), `manifest.json` + `requirements_test.txt` (0.1.16), `strings.json` + all 7
translations (2 field labels, 2 descriptions, 1 error key each — verified programmatically),
`docs/providers/hvv-gti.md` + `mkdocs.yml` nav + `docs/providers/index.md`.

The docs page covers the free application by email, the HMAC scheme, the transport-type
mapping, the `timeOffset`/`delay` arithmetic, and the terms of use — HOCHBAHN grants access for
a **free** travel-information service and forbids passing the data to third parties without
written approval. Running this in your own Home Assistant is the intended use; republishing is
not.

## Tests

New `tests/test_config_flow_hvv_gti.py` — 8 tests: both providers offered, the credentials step
asks for exactly two fields, each half independently mandatory, the full flow through to entry
creation, the coordinator actually forwarding the password to the provider, the EFA provider
being unaffected, and library registry resolution.

`pytest tests/ -q` → **535 passed**. `black` / `isort` / `flake8` clean.

## ⚠️ Not verified against the live API, and CI is red until 0.1.16 ships

I have no GTI credentials, so the provider is covered by fixture tests only. When you have
credentials, the two things worth checking against a real response are the **delay arithmetic**
(does a delayed departure show the right minutes?) and the **transport-type mapping** (are
U-Bahn, S-Bahn, AKN and ferries all classified correctly?).

`requirements_test.txt` asks for `>=0.1.16`, which does not exist yet — CI goes green once the
library release lands.

## Not in scope

Trip planning via GTI `getRoute`. Trip entries stay on the EFA `hvv` provider; straightforward
follow-up once the departure path is confirmed against the live API.
