### PR TITLE
Add issue templates for bugs, features, and documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,178 @@
+name: 🐛 Bug Report
+description: Something is broken or behaves unexpectedly
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report!
+
+        Before you continue, please check:
+        - [Existing issues](https://github.com/NerdySoftPaw/openpublictransport/issues?q=is%3Aissue) — someone may have reported this already
+        - [Documentation](https://docs.openpublictransport.net/)
+        - [Migration Guide](https://docs.openpublictransport.net/latest/migration/) if you came from `vrr` / VRRAPI-HACS / hacs-publictransport
+
+        Have a **question** rather than a bug? Please use
+        [Discussions](https://github.com/NerdySoftPaw/openpublictransport/discussions) instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched the existing issues and this is not a duplicate
+          required: true
+        - label: I am running the latest release of the integration
+          required: true
+        - label: I have read the relevant documentation
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: |
+        The departures sensor shows "unavailable" after every Home Assistant restart.
+        I expected it to recover automatically.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Provider
+      description: Which transit provider is affected?
+      options:
+        - AVV (Augsburg)
+        - BART (San Francisco, USA)
+        - BEG (Bavaria)
+        - BSVG (Braunschweig)
+        - BVG (Berlin / Brandenburg)
+        - DART (Des Moines, USA)
+        - DB (Germany, nationwide)
+        - DING (Ulm)
+        - Entur (Norway)
+        - HVV (Hamburg)
+        - Irish Rail (Ireland)
+        - KVV (Karlsruhe)
+        - mobilitéit.lu (Luxembourg)
+        - MVV (Munich)
+        - NS (Netherlands)
+        - NTA (Ireland)
+        - NVBW (Baden-Württemberg)
+        - NWL (Westfalen-Lippe)
+        - ÖBB (Austria)
+        - openpublictransport (Germany, GTFS.DE)
+        - OTP2 Custom (self-hosted)
+        - RMV (Frankfurt / Rhein-Main)
+        - RVV (Regensburg)
+        - SBB (Switzerland)
+        - TPG (Geneva)
+        - Trafiklab (Sweden)
+        - Transitous (worldwide)
+        - VAG (Freiburg)
+        - VBN OTP (Bremen / Niedersachsen)
+        - VBN TRIAS (Bremen / Niedersachsen)
+        - VGN (Nuremberg)
+        - VRN (Rhein-Neckar)
+        - VRR (Rhein-Ruhr, NRW)
+        - VVO (Dresden)
+        - VVS (Stuttgart)
+        - Multiple providers
+        - Not provider-specific
+    validations:
+      required: true
+
+  - type: input
+    id: stop
+    attributes:
+      label: Stop / station name
+      description: The exact name as configured in the integration. Leave empty if not applicable.
+      placeholder: Rastatt Bahnhof
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      multiple: true
+      options:
+        - Config flow / setup
+        - Reconfigure
+        - Departures sensor
+        - Delays binary sensor
+        - Calendar entity
+        - Event / disruptions entity
+        - Departure board camera
+        - Punctuality sensor
+        - Trip planner
+        - Actions (refresh, plan_trip, check_delays, announce_departure)
+        - Stop search
+        - Filters / favorites / walking time
+        - Translations
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version_integration
+    attributes:
+      label: Integration version
+      placeholder: v2026.7.8
+    validations:
+      required: true
+
+  - type: input
+    id: version_ha
+    attributes:
+      label: Home Assistant version
+      placeholder: 2026.7.2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_type
+    attributes:
+      label: Installation type
+      options:
+        - Home Assistant OS
+        - Home Assistant Supervised
+        - Home Assistant Container (Docker)
+        - Home Assistant Core (venv)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Diagnostics / logs
+      description: |
+        Enable debug logging, reproduce the problem, then paste the relevant log lines.
+
+        ```yaml
+        logger:
+          default: warning
+          logs:
+            custom_components.openpublictransport: debug
+        ```
+
+        **Please remove API keys, tokens and anything else private.**
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, YAML config, entity attributes — anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,25 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Question or setup help
+    url: https://github.com/NerdySoftPaw/openpublictransport/discussions/categories/q-a
+    about: Ask in Discussions — setup, API keys, filters, migration from vrr.
+
+  - name: 📖 Documentation
+    url: https://docs.openpublictransport.net/
+    about: Configuration, providers, sensors, actions and the trip planner.
+
+  - name: 🔀 Migration from VRRAPI-HACS / hacs-publictransport
+    url: https://docs.openpublictransport.net/latest/migration/
+    about: The domain changed from `vrr` to `openpublictransport` — start here.
+
+  - name: 🎴 Dashboard card issues
+    url: https://github.com/NerdySoftPaw/openpublictransport-card/issues
+    about: Problems with the Lovelace card belong in the card repository.
+
+  - name: 🖼️ Show your dashboard
+    url: https://github.com/NerdySoftPaw/openpublictransport/discussions/categories/show-and-tell
+    about: Share screenshots, automations and YAML with the community.
+
+  - name: ☕ Support the project
+    url: https://buymeacoffee.com/nerdysoftpaw
+    about: This is a spare-time project — donations are appreciated.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,48 @@
+name: 📖 Documentation
+description: Something in the docs is missing, wrong or unclear
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Docs live at [docs.openpublictransport.net](https://docs.openpublictransport.net/)
+        and are built from the `docs/` folder with MkDocs.
+        Small fixes are very welcome as a direct PR.
+
+  - type: input
+    id: page
+    attributes:
+      label: Which page?
+      placeholder: https://docs.openpublictransport.net/latest/trip-planner/
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Type of problem
+      options:
+        - Information is missing
+        - Information is outdated
+        - Information is wrong
+        - Confusing or hard to follow
+        - Broken link or rendering issue
+        - Typo / grammar
+        - Translation issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: What should change?
+      description: Quote the passage if possible and describe what would be clearer.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested wording
+      description: Optional — a draft replacement text.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,87 @@
+name: 💡 Feature Request
+description: Suggest a new feature or an improvement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea!
+
+        Want a **new transit provider** supported? Please use the
+        *🚉 Provider Request* template instead — it asks for the API details needed.
+
+        Still shaping the idea? [Discussions → Ideas](https://github.com/NerdySoftPaw/openpublictransport/discussions)
+        is a better place to talk it through first.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and discussions for this idea
+          required: true
+        - label: This is not a request for a new provider
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the situation you run into, not the solution yet.
+      placeholder: |
+        I commute with two lines from the same stop and only care about one of them
+        in the morning, the other in the evening. Right now I need two entities.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What should the integration do?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this touch?
+      multiple: true
+      options:
+        - Config flow / setup
+        - Entities (sensor, calendar, camera, ...)
+        - Actions / services
+        - Trip planner
+        - Departure board camera
+        - Filters, favorites, walking time
+        - Translations / i18n
+        - Dashboard card
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Template sensors, automations, other integrations — what did you try?
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example configuration or automation
+      description: If you can sketch how it would look in YAML, that helps a lot.
+      render: yaml
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you like to contribute this?
+      options:
+        - "No, just suggesting"
+        - "Maybe, with some guidance"
+        - "Yes, I'd like to open a PR"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/provider_data_issue.yml
+++ b/.github/ISSUE_TEMPLATE/provider_data_issue.yml
@@ -1,0 +1,98 @@
+name: 🚨 Wrong or Missing Departure Data
+description: A supported provider returns wrong, missing or stale departures
+title: "[Data]: "
+labels: ["provider", "data", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the integration *works* but the **data** is wrong —
+        missing departures, wrong delays, stops that cannot be found, odd platforms.
+
+        Please first compare against the provider's own app or website.
+        If their app is wrong too, it is an upstream data problem and there is
+        little this integration can do — but it is still worth documenting here.
+
+  - type: dropdown
+    id: symptom
+    attributes:
+      label: What is wrong?
+      multiple: true
+      options:
+        - Stop cannot be found in search
+        - Wrong stop matched
+        - No departures returned at all
+        - Departures missing (some lines absent)
+        - Wrong departure times
+        - Delays missing or incorrect
+        - Wrong or missing platform
+        - Wrong destination / line name
+        - Disruption notices missing
+        - Data is stale / not refreshing
+        - Trip planner returns no or wrong routes
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: provider
+    attributes:
+      label: Provider
+      placeholder: KVV
+    validations:
+      required: true
+
+  - type: input
+    id: stop
+    attributes:
+      label: Stop name (exactly as configured)
+      placeholder: Rastatt Bahnhof
+    validations:
+      required: true
+
+  - type: input
+    id: stop_id
+    attributes:
+      label: Stop ID
+      description: Visible in the entity attributes or diagnostics download.
+      placeholder: de:08216:14201
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What the provider's own app shows
+      description: A screenshot or a copy of the real departure board at the same moment.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What the integration shows
+      description: Entity state and attributes, or a screenshot of your card.
+    validations:
+      required: true
+
+  - type: input
+    id: when
+    attributes:
+      label: When did you observe this?
+      description: Date, time and timezone — departure data is very time-sensitive.
+      placeholder: 2026-08-02 07:42 CEST
+    validations:
+      required: true
+
+  - type: input
+    id: version_integration
+    attributes:
+      label: Integration version
+      placeholder: v2026.7.8
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debug log
+      description: Debug output for `custom_components.openpublictransport`. Remove any API keys.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/provider_request.yml
+++ b/.github/ISSUE_TEMPLATE/provider_request.yml
@@ -1,0 +1,105 @@
+name: 🚉 Provider Request
+description: Request support for a transit network that is not yet supported
+title: "[Provider]: "
+labels: ["provider", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A new provider is only feasible if there is a reachable API.
+        The more of the fields below you can fill in, the faster this can be built.
+
+        **Tip:** many networks are already covered indirectly by
+        **Transitous** (worldwide) or **DB** (Germany nationwide) — worth testing first.
+
+  - type: input
+    id: name
+    attributes:
+      label: Network name and abbreviation
+      placeholder: Verkehrsverbund Oberelbe (VVO)
+    validations:
+      required: true
+
+  - type: input
+    id: region
+    attributes:
+      label: Region and country
+      placeholder: Dresden, Germany
+    validations:
+      required: true
+
+  - type: input
+    id: website
+    attributes:
+      label: Official website
+      placeholder: https://www.vvo-online.de
+    validations:
+      required: true
+
+  - type: textarea
+    id: api
+    attributes:
+      label: API endpoint and documentation
+      description: |
+        Base URL, docs link, and anything you know about the interface.
+        Look for EFA / TRIAS / HAFAS / OTP2 / GTFS-RT / a public developer portal.
+      placeholder: |
+        Base URL: https://efa.example.org/standard/
+        Docs: https://example.org/opendata
+        Looks like an EFA/VDV instance, departureMonitor endpoint responds without auth.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api_type
+    attributes:
+      label: API type (if known)
+      options:
+        - EFA / VDV
+        - TRIAS
+        - HAFAS
+        - OTP2 / GraphQL
+        - GTFS + GTFS-Realtime
+        - REST (custom / proprietary)
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: auth
+    attributes:
+      label: Does the API require an API key?
+      options:
+        - "No, open access"
+        - "Yes, free after registration"
+        - "Yes, paid or approval required"
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: sample
+    attributes:
+      label: Sample request and response
+      description: |
+        A working request URL plus a trimmed JSON/XML response is the single most
+        useful thing you can provide. **Strip any API keys before pasting.**
+      render: json
+
+  - type: input
+    id: licence
+    attributes:
+      label: Data licence / terms of use
+      placeholder: CC-BY 4.0 — https://example.org/terms
+
+  - type: dropdown
+    id: testing
+    attributes:
+      label: Can you help test this?
+      description: A local tester in the region makes a huge difference.
+      options:
+        - "Yes, I live in the area and can test builds"
+        - "Yes, occasionally"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/translation.yml
+++ b/.github/ISSUE_TEMPLATE/translation.yml
@@ -1,0 +1,55 @@
+name: 🌍 Translation
+description: Fix a translation or offer a new language
+title: "[i18n]: "
+labels: ["translation", "good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Currently shipped: **DE, EN, FR, NL, PL, IT, SV**.
+
+        Translation files live in
+        `custom_components/openpublictransport/translations/`.
+        A new language is simply a copy of `en.json` with the values translated —
+        a perfect first contribution.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What would you like to do?
+      options:
+        - Report a wrong or awkward translation
+        - Report missing strings in an existing language
+        - Offer a new language
+    validations:
+      required: true
+
+  - type: input
+    id: language
+    attributes:
+      label: Language
+      description: Name and ISO code.
+      placeholder: Czech (cs)
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: |
+        For fixes: the key, the current text and your suggested replacement.
+        For new languages: just say hello and note whether you are a native speaker.
+      placeholder: |
+        Key: config.step.user.data.walking_time
+        Current (DE): "Laufzeit"
+        Suggested:    "Fußweg (Minuten)"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: pr
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a pull request with the translation file


### PR DESCRIPTION
This pull request introduces a comprehensive set of new GitHub issue templates for the repository, improving how users report bugs, request features, report provider data issues, request new providers, suggest documentation changes, and contribute translations. It also adds a configuration file to guide users toward discussions and documentation for common questions, and disables blank issues to ensure all reports follow a structured format.

**New and improved issue templates:**

* Added a detailed bug report template to standardize and streamline bug submissions, including preflight checklists, provider selection, affected areas, and log/context fields.
* Introduced a feature request template with a focus on describing the problem, proposed solution, affected area, and willingness to contribute.
* Added a provider data issue template to report wrong or missing departure data, with fields for provider, stop, expected/actual results, and debug logs.
* Added a provider request template to collect all necessary information for supporting new transit networks, including API details and tester availability.
* Added a documentation issue template for reporting missing, outdated, or unclear documentation, with fields to specify the page and type of problem.
* Added a translation template for reporting translation issues or offering new languages, with guidance for first-time contributors.

**Repository configuration enhancements:**

* Added a configuration file to disable blank issues and provide direct links for questions, documentation, migration help, dashboard sharing, and project support.…uests, provider data issues, provider requests, and translations