### PR TITLE
fix(trip): stop showing departed connections and rating walks as missed transfers

### DIFF
--- a/custom_components/openpublictransport/trip.py
+++ b/custom_components/openpublictransport/trip.py
@@ -78,6 +78,86 @@ _OTP_MODE_TO_PRODUCT = {
     "WALK": "walk",
 }
 
+# EFA models the walk to the platform (or between two nearby stations) as a leg
+# of the journey. Such a leg ends exactly when the connecting vehicle departs,
+# so rating it like a transfer marks every walk-in journey as "missed" — which
+# is what made the trip planner unusable in issue #72. Detected by product
+# class, with a name fallback for providers that omit the class.
+_NON_TRANSIT_PRODUCT_CLASSES = {98, 99, 100}
+_NON_TRANSIT_PRODUCT_NAMES = {
+    "footpath",
+    "fussweg",
+    "fußweg",
+    "walk",
+    "gesicherter anschluss",
+    "bicycle",
+    "fahrrad",
+}
+
+
+def _is_transit_product(product: Dict[str, Any]) -> bool:
+    """Return True when an EFA product describes an actual vehicle."""
+    if product.get("class") in _NON_TRANSIT_PRODUCT_CLASSES:
+        return False
+    return str(product.get("name") or "").strip().lower() not in _NON_TRANSIT_PRODUCT_NAMES
+
+
+def _rate_transfers(transit_legs: List[Dict[str, Any]]) -> tuple[bool, str, Optional[int]]:
+    """Rate a journey's transfers from the gaps between consecutive transit legs.
+
+    ``transit_legs`` must hold vehicle legs only, in travel order, each carrying
+    the internal ``_departure_s`` / ``_arrival_s`` epoch keys. Walking legs are
+    not transfers and must be filtered out by the caller.
+
+    Returns ``(connection_feasible, transfer_risk, min_transfer_time)``; the
+    minimum transfer time is ``None`` for a journey without a transfer.
+    """
+    feasible = True
+    risk = "low"
+    min_transfer: Optional[int] = None
+
+    for current, following in zip(transit_legs, transit_legs[1:]):
+        arrival = current.get("_arrival_s") or 0
+        departure = following.get("_departure_s") or 0
+        if not arrival or not departure:
+            continue
+        gap_min = int((departure - arrival) // 60)
+        if min_transfer is None or gap_min < min_transfer:
+            min_transfer = gap_min
+        if gap_min <= 0:
+            feasible = False
+            risk = "missed"
+        elif gap_min <= 3 and risk != "missed":
+            risk = "high"
+        elif gap_min <= 5 and risk not in ("missed", "high"):
+            risk = "medium"
+
+    return feasible, risk, min_transfer
+
+
+def _journey_bounds(legs: List[Dict[str, Any]]) -> tuple[Optional[str], Optional[str]]:
+    """Return a journey's start and end as local ISO-8601 timestamps.
+
+    The start is the first leg's departure — including an initial walk, because
+    that is when the traveller has to set off. Consumers need the full timestamp
+    (not just ``HH:MM``) to tell a connection that is still ahead from one that
+    has already left.
+    """
+    return (
+        _epoch_to_local_iso(legs[0].get("_departure_s") or 0),
+        _epoch_to_local_iso(legs[-1].get("_arrival_s") or 0),
+    )
+
+
+def _epoch_to_local_iso(epoch_s: float) -> Optional[str]:
+    """Format an epoch timestamp as a local ISO-8601 string (None if unknown)."""
+    if not epoch_s:
+        return None
+    try:
+        return dt_util.as_local(datetime.fromtimestamp(epoch_s, tz=timezone.utc)).isoformat()
+    except (ValueError, OSError, OverflowError):
+        return None
+
 
 async def async_plan_trip(
     hass: HomeAssistant,
@@ -285,16 +365,9 @@ def _parse_otp_itineraries(itineraries: List[Dict[str, Any]]) -> List[Dict[str, 
 
     for itin in itineraries:
         transit_legs: List[Dict[str, Any]] = []
-        # ms timestamps for transfer gap calculation
-        leg_arrival_ms: List[int] = []
-        leg_departure_ms: List[int] = []
 
         for leg in itin.get("legs", []):
             if not leg.get("transitLeg", False):
-                # Walking/transfer leg — capture its times for gap calc but skip display
-                if transit_legs:
-                    # The walk connects the previous transit leg to the next one
-                    leg_arrival_ms.append(leg.get("endTime", 0))
                 continue
 
             start_ms: int = leg.get("startTime", 0)
@@ -326,40 +399,22 @@ def _parse_otp_itineraries(itineraries: List[Dict[str, Any]]) -> List[Dict[str, 
                     "delay": delay_min,
                     "duration_minutes": round(leg.get("duration", 0) / 60),
                     "platform": "",
-                    # Internal ms values for transfer gap calculation
-                    "_arrival_ms": end_ms,
-                    "_departure_ms": start_ms,
+                    # Internal epoch seconds for transfer-gap calculation
+                    "_arrival_s": end_ms / 1000,
+                    "_departure_s": start_ms / 1000,
                 }
             )
-            leg_departure_ms.append(start_ms)
-            leg_arrival_ms.append(end_ms)
 
         if not transit_legs:
             continue
 
-        # Transfer risk from arrival of leg N to departure of leg N+1
-        connection_feasible = True
-        transfer_risk = "low"
-        min_transfer_time: Optional[int] = None
-
-        for i in range(len(transit_legs) - 1):
-            arr_ms = transit_legs[i]["_arrival_ms"]
-            dep_ms = transit_legs[i + 1]["_departure_ms"]
-            gap_min = (dep_ms - arr_ms) // 60000
-            if min_transfer_time is None or gap_min < min_transfer_time:
-                min_transfer_time = gap_min
-            if gap_min <= 0:
-                connection_feasible = False
-                transfer_risk = "missed"
-            elif gap_min <= 3 and transfer_risk != "missed":
-                transfer_risk = "high"
-            elif gap_min <= 5 and transfer_risk not in ("missed", "high"):
-                transfer_risk = "medium"
+        connection_feasible, transfer_risk, min_transfer_time = _rate_transfers(transit_legs)
+        departure_ts, arrival_ts = _journey_bounds(transit_legs)
 
         # Strip internal keys before returning
         for leg in transit_legs:
-            leg.pop("_arrival_ms", None)
-            leg.pop("_departure_ms", None)
+            leg.pop("_arrival_s", None)
+            leg.pop("_departure_s", None)
 
         first_dep = transit_legs[0].get("departure_estimated") or transit_legs[0].get("departure_planned", "")
         last_arr = transit_legs[-1].get("arrival_estimated") or transit_legs[-1].get("arrival_planned", "")
@@ -368,6 +423,8 @@ def _parse_otp_itineraries(itineraries: List[Dict[str, Any]]) -> List[Dict[str, 
             {
                 "departure": first_dep,
                 "arrival": last_arr,
+                "departure_timestamp": departure_ts,
+                "arrival_timestamp": arrival_ts,
                 "duration_minutes": round(itin.get("duration", 0) / 60),
                 "transfers": itin.get("numberOfTransfers", itin.get("transfers", len(transit_legs) - 1)),
                 "connection_feasible": connection_feasible,
@@ -489,21 +546,8 @@ def _parse_otp_plan_connection(nodes: List[Dict[str, Any]]) -> List[Dict[str, An
         if not transit_legs:
             continue
 
-        connection_feasible = True
-        transfer_risk = "low"
-        min_transfer_time: Optional[int] = None
-
-        for i in range(len(transit_legs) - 1):
-            gap_min = int((transit_legs[i + 1]["_departure_s"] - transit_legs[i]["_arrival_s"]) // 60)
-            if min_transfer_time is None or gap_min < min_transfer_time:
-                min_transfer_time = gap_min
-            if gap_min <= 0:
-                connection_feasible = False
-                transfer_risk = "missed"
-            elif gap_min <= 3 and transfer_risk != "missed":
-                transfer_risk = "high"
-            elif gap_min <= 5 and transfer_risk not in ("missed", "high"):
-                transfer_risk = "medium"
+        connection_feasible, transfer_risk, min_transfer_time = _rate_transfers(transit_legs)
+        departure_ts, arrival_ts = _journey_bounds(transit_legs)
 
         for leg in transit_legs:
             leg.pop("_arrival_s", None)
@@ -516,6 +560,8 @@ def _parse_otp_plan_connection(nodes: List[Dict[str, Any]]) -> List[Dict[str, An
             {
                 "departure": first_dep,
                 "arrival": last_arr,
+                "departure_timestamp": departure_ts,
+                "arrival_timestamp": arrival_ts,
                 "duration_minutes": round(_duration_to_seconds(node.get("duration")) / 60),
                 "transfers": node.get("numberOfTransfers", len(transit_legs) - 1),
                 "connection_feasible": connection_feasible,
@@ -534,14 +580,16 @@ def _parse_journeys(journeys: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
     for journey in journeys:
         legs = []
+        # Vehicle legs only — walking legs are not transfers (see _rate_transfers)
+        transit_legs: List[Dict[str, Any]] = []
         total_duration = 0
 
         for leg in journey.get("legs", []):
-            origin = leg.get("origin", {})
-            destination = leg.get("destination", {})
-            transport = leg.get("transportation", {})
-            product = transport.get("product", {})
-            interchange = leg.get("interchange", {})
+            origin = leg.get("origin") or {}
+            destination = leg.get("destination") or {}
+            transport = leg.get("transportation") or {}
+            product = transport.get("product") or {}
+            interchange = leg.get("interchange") or {}
 
             dep_planned = origin.get("departureTimePlanned", "")
             dep_estimated = origin.get("departureTimeEstimated", "")
@@ -573,7 +621,12 @@ def _parse_journeys(journeys: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "arrival_estimated": _format_time(arr_estimated),
                 "delay": dep_delay,
                 "duration_minutes": round(duration / 60) if duration else 0,
-                "platform": origin.get("platform", {}).get("name", ""),
+                "platform": (origin.get("platform") or {}).get("name", ""),
+                # Internal epoch seconds for transfer-gap calculation. Derived
+                # from the full timestamps rather than the HH:MM strings, so a
+                # transfer across midnight is no longer a negative gap.
+                "_departure_s": _iso_to_epoch(dep_estimated or dep_planned),
+                "_arrival_s": _iso_to_epoch(arr_estimated or arr_planned),
             }
 
             # Add transfer info if present
@@ -581,6 +634,8 @@ def _parse_journeys(journeys: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 leg_data["transfer"] = interchange.get("desc", "")
 
             legs.append(leg_data)
+            if _is_transit_product(product):
+                transit_legs.append(leg_data)
 
         if not legs:
             continue
@@ -589,37 +644,19 @@ def _parse_journeys(journeys: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         first_dep = legs[0].get("departure_estimated") or legs[0].get("departure_planned", "")
         last_arr = legs[-1].get("arrival_estimated") or legs[-1].get("arrival_planned", "")
 
-        # Connection feasibility
-        connection_feasible = True
-        transfer_risk = "low"
-        min_transfer_time = None
+        connection_feasible, transfer_risk, min_transfer_time = _rate_transfers(transit_legs)
+        departure_ts, arrival_ts = _journey_bounds(legs)
 
-        for i in range(len(legs) - 1):
-            arr = legs[i].get("arrival_estimated") or legs[i].get("arrival_planned", "")
-            dep = legs[i + 1].get("departure_estimated") or legs[i + 1].get("departure_planned", "")
-            if arr and dep:
-                try:
-                    arr_dt = dt_util.parse_datetime(f"2026-01-01T{arr}:00")
-                    dep_dt = dt_util.parse_datetime(f"2026-01-01T{dep}:00")
-                    if arr_dt and dep_dt:
-                        transfer_mins = int((dep_dt - arr_dt).total_seconds() / 60)
-                        if min_transfer_time is None or transfer_mins < min_transfer_time:
-                            min_transfer_time = transfer_mins
-                        if transfer_mins <= 0:
-                            connection_feasible = False
-                            transfer_risk = "missed"
-                        elif transfer_mins <= 3:
-                            transfer_risk = "high"
-                        elif transfer_mins <= 5:
-                            if transfer_risk != "high":
-                                transfer_risk = "medium"
-                except (ValueError, TypeError):
-                    pass
+        for leg_data in legs:
+            leg_data.pop("_departure_s", None)
+            leg_data.pop("_arrival_s", None)
 
         results.append(
             {
                 "departure": first_dep,
                 "arrival": last_arr,
+                "departure_timestamp": departure_ts,
+                "arrival_timestamp": arrival_ts,
                 "duration_minutes": round(total_duration / 60) if total_duration else 0,
                 "transfers": journey.get("interchanges", 0),
                 "connection_feasible": connection_feasible,

--- a/custom_components/openpublictransport/trip_sensor.py
+++ b/custom_components/openpublictransport/trip_sensor.py
@@ -24,7 +24,9 @@ from .const import (
     CONF_OTP_CUSTOM_API_KEY,
     CONF_SCAN_INTERVAL,
     CONF_VBN_API_KEY,
+    CONF_WALKING_TIME,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_WALKING_TIME,
     DOMAIN,
 )
 from .sensor import _RESTORE_SKIP_ATTRS
@@ -57,6 +59,7 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
         dest_id: Optional[str] = None,
         api_key: Optional[str] = None,
         custom_url: Optional[str] = None,
+        walking_time: int = DEFAULT_WALKING_TIME,
     ):
         """Initialize."""
         super().__init__(
@@ -74,12 +77,18 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
         self.dest_id = dest_id
         self.api_key = api_key
         self.custom_url = custom_url
+        self.walking_time = walking_time
         # Mirrors PublicTransportDataUpdateCoordinator so diagnostics can report
         # it for trip entries too (issue #58).
         self.last_update_success_time: Optional[datetime] = None
 
     async def _async_update_data(self) -> Optional[List[Dict[str, Any]]]:
         """Fetch trip data."""
+        # Ask for connections the traveller can still reach: with a walking time
+        # configured, the first one that counts leaves that many minutes from now.
+        # Without one, pass None so the provider anchors on its own clock.
+        earliest = dt_util.now() + timedelta(minutes=self.walking_time) if self.walking_time else None
+
         data = await async_plan_trip(
             self.hass,
             self.provider,
@@ -87,6 +96,7 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
             self.origin_city,
             self.destination,
             self.destination_city,
+            departure_time=earliest,
             origin_id=self.origin_id,
             dest_id=self.dest_id,
             api_key=self.api_key,
@@ -98,7 +108,34 @@ class TripDataUpdateCoordinator(DataUpdateCoordinator):
             # _parse_journeys returns [] for an empty board). Both leave
             # last_update_success True, so only the former must skip the stamp.
             self.last_update_success_time = dt_util.now()
+            data = self._drop_departed(data)
         return data
+
+    def _drop_departed(self, journeys: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Drop connections that have already left.
+
+        EFA anchors the requested time on the first *vehicle* departure and
+        back-dates the walk to the platform, so its first journey has regularly
+        already started — which is what put a past connection into the sensor
+        state in issue #72. A journey whose departure cannot be parsed is kept:
+        better an unrated connection than an empty sensor.
+        """
+        cutoff = dt_util.now() + timedelta(minutes=self.walking_time)
+        reachable = [
+            journey
+            for journey in journeys
+            if (departure := dt_util.parse_datetime(journey.get("departure_timestamp") or "")) is None
+            or departure >= cutoff
+        ]
+        if len(reachable) < len(journeys):
+            _LOGGER.debug(
+                "Trip %s → %s: dropped %s connection(s) departing before %s",
+                self.origin,
+                self.destination,
+                len(journeys) - len(reachable),
+                cutoff.isoformat(),
+            )
+        return reachable
 
 
 async def async_setup_trip_entry(
@@ -113,7 +150,13 @@ async def async_setup_trip_entry(
     destination_city = config_entry.data[CONF_TRIP_DESTINATION_CITY]
     origin_id = config_entry.data.get("trip_origin_id")
     dest_id = config_entry.data.get("trip_destination_id")
-    scan_interval = config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    # Options win over data — both are configurable after setup via the options flow
+    scan_interval = config_entry.options.get(
+        CONF_SCAN_INTERVAL, config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    )
+    walking_time = config_entry.options.get(
+        CONF_WALKING_TIME, config_entry.data.get(CONF_WALKING_TIME, DEFAULT_WALKING_TIME)
+    )
 
     # Resolve API key and custom URL based on provider
     if provider == "vbn_otp":
@@ -141,6 +184,7 @@ async def async_setup_trip_entry(
         dest_id=dest_id,
         api_key=api_key,
         custom_url=custom_url,
+        walking_time=walking_time,
     )
 
     config_entry.runtime_data = coordinator
@@ -200,6 +244,24 @@ class TripSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
             model="Trip Planner",
         )
 
+        # Listen to options updates — without this a changed walking time or
+        # scan interval only took effect after a restart.
+        self._config_entry.async_on_unload(self._config_entry.add_update_listener(self._async_update_listener))
+
+    async def _async_update_listener(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        """Handle options update."""
+        self.coordinator.walking_time = config_entry.options.get(
+            CONF_WALKING_TIME,
+            config_entry.data.get(CONF_WALKING_TIME, DEFAULT_WALKING_TIME),
+        )
+        scan_interval = config_entry.options.get(
+            CONF_SCAN_INTERVAL,
+            config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+        )
+        self.coordinator.update_interval = timedelta(seconds=scan_interval)
+
+        await self.coordinator.async_request_refresh()
+
     async def async_added_to_hass(self) -> None:
         """Restore the last trip so the sensor isn't blank right after a restart.
 
@@ -250,6 +312,9 @@ class TripSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
         attrs = {
             "departure": best.get("departure"),
             "arrival": best.get("arrival"),
+            "departure_timestamp": best.get("departure_timestamp"),
+            "arrival_timestamp": best.get("arrival_timestamp"),
+            "in_minutes": _minutes_until(best),
             "duration_minutes": best.get("duration_minutes"),
             "transfers": best.get("transfers"),
             "connection_feasible": best.get("connection_feasible"),
@@ -267,6 +332,9 @@ class TripSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
                 {
                     "departure": j.get("departure"),
                     "arrival": j.get("arrival"),
+                    "departure_timestamp": j.get("departure_timestamp"),
+                    "arrival_timestamp": j.get("arrival_timestamp"),
+                    "in_minutes": _minutes_until(j),
                     "duration_minutes": j.get("duration_minutes"),
                     "transfers": j.get("transfers"),
                     "transfer_risk": j.get("transfer_risk"),
@@ -275,3 +343,16 @@ class TripSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
             ]
 
         return attrs
+
+
+def _minutes_until(journey: Dict[str, Any]) -> Optional[int]:
+    """Minutes from now until a journey departs (None when it has no timestamp).
+
+    Counts down to the start of the journey — including an initial walk to the
+    platform, because that is when the traveller has to set off. Rounds down, so
+    a departure that has just passed reads as ``-1`` rather than a hopeful ``0``.
+    """
+    departure = dt_util.parse_datetime(journey.get("departure_timestamp") or "")
+    if departure is None:
+        return None
+    return int((departure - dt_util.now()).total_seconds() // 60)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **Trip Planner showed a connection that had already left, and rated every connection as
+  `missed`** ([#72](https://github.com/NerdySoftPaw/openpublictransport/issues/72)) — three
+  separate causes, all fixed:
+    - The walk to the platform was rated like a transfer. It ends exactly when the connecting
+      vehicle leaves, so every journey EFA prefixes with a footpath (all station-to-station
+      trips on HVV, KVV, VRR and the other EFA providers) came out as
+      `connection_feasible: false` / `transfer_risk: missed` / `min_transfer_time: 0`.
+      Only vehicle-to-vehicle transfers are rated now.
+    - Connections that had already departed stayed in the sensor. EFA anchors the requested
+      time on the first *vehicle* departure and back-dates the walk, so its first journey is
+      regularly already running — those are now dropped, and the next reachable connection is
+      the sensor state.
+    - **Walking time is now honoured by trip entries.** It shifts the query and filters
+      connections you could not reach in time; previously the option applied to departure
+      boards only. Changing it — or the scan interval — no longer needs a restart.
+- **Transfers across midnight** were reported as `missed`, because the gap was calculated from
+  `HH:MM` strings pinned to one fixed date. It is now derived from the full timestamps.
+
+### New Features
+
+- **Trip attributes carry full timestamps and a countdown** — `departure_timestamp`,
+  `arrival_timestamp` and `in_minutes`, on the connection itself and on every entry in
+  `next_journeys`. Cards and templates can tell a connection that is still ahead from one that
+  has left, which `HH:MM` alone did not allow.
+
+---
+
 ## v2026.8.0 — Platform data, filters, two entries per station, official HVV API
 
 Requires `python-openpublictransport` 0.1.16.

--- a/docs/trip-planner.md
+++ b/docs/trip-planner.md
@@ -61,7 +61,7 @@ The sensor will appear as `sensor.openpublictransport_trip_<origin>_to_<destinat
 
 ### Example Sensor State and Attributes
 
-**State:** `08:15 - U79 to Duisburg Meiderich`
+**State:** `08:15 → 08:42 (27 min, 1 transfers)`
 
 **Attributes:**
 
@@ -69,44 +69,70 @@ The sensor will appear as `sensor.openpublictransport_trip_<origin>_to_<destinat
 {
   "origin": "Holthausen, Dusseldorf",
   "destination": "Hauptbahnhof, Dusseldorf",
-  "departure_time": "2026-04-09T08:15:00+02:00",
-  "arrival_time": "2026-04-09T08:42:00+02:00",
+  "departure": "08:15",
+  "arrival": "08:42",
+  "departure_timestamp": "2026-04-09T08:15:00+02:00",
+  "arrival_timestamp": "2026-04-09T08:42:00+02:00",
+  "in_minutes": 6,
   "duration_minutes": 27,
   "transfers": 1,
   "connection_feasible": true,
   "transfer_risk": "low",
+  "min_transfer_time": 5,
   "legs": [
     {
+      "origin": "Holthausen",
+      "destination": "Dusseldorf Hbf",
       "line": "U79",
-      "direction": "Duisburg Meiderich",
-      "departure_stop": "Holthausen",
-      "departure_time": "08:15",
-      "arrival_stop": "Dusseldorf Hbf",
-      "arrival_time": "08:35",
+      "product": "U-Bahn",
+      "departure_planned": "08:15",
+      "departure_estimated": "08:17",
+      "arrival_planned": "08:35",
+      "arrival_estimated": "08:35",
       "delay": 2,
+      "duration_minutes": 20,
       "platform": "1"
     },
     {
+      "origin": "Dusseldorf Hbf",
+      "destination": "Hauptbahnhof",
       "line": "RE5",
-      "direction": "Koblenz Hbf",
-      "departure_stop": "Dusseldorf Hbf",
-      "departure_time": "08:40",
-      "arrival_stop": "Dusseldorf Hbf",
-      "arrival_time": "08:42",
+      "product": "Regional",
+      "departure_planned": "08:40",
+      "departure_estimated": "08:40",
+      "arrival_planned": "08:42",
+      "arrival_estimated": "08:42",
       "delay": 0,
+      "duration_minutes": 2,
       "platform": "3"
     }
   ],
-  "next_connections": [
+  "alternative_journeys": 3,
+  "next_journeys": [
     {
-      "departure_time": "08:30",
-      "arrival_time": "08:57",
+      "departure": "08:30",
+      "arrival": "08:57",
+      "departure_timestamp": "2026-04-09T08:30:00+02:00",
+      "arrival_timestamp": "2026-04-09T08:57:00+02:00",
+      "in_minutes": 21,
+      "duration_minutes": 27,
       "transfers": 1,
       "transfer_risk": "low"
     }
   ]
 }
 ```
+
+`departure` / `arrival` are `HH:MM` for display. Use `departure_timestamp` and `in_minutes` when
+you need to compare against the current time — a bare `HH:MM` cannot tell 23:50 tonight from
+23:50 tomorrow.
+
+Both `departure` and `in_minutes` refer to the **start of the journey**. On some providers that
+is a footpath to the platform, so the countdown is to when you have to set off, not to when the
+vehicle leaves.
+
+Connections that have already departed are not reported — the sensor always shows the next one
+you can still reach.
 
 ## Using the plan_trip Service
 
@@ -142,12 +168,22 @@ Every trip result includes transfer risk assessment:
 
 | Risk Level | Meaning |
 |------------|---------|
-| `low` | Comfortable transfer time (>5 min buffer) |
-| `medium` | Tight but feasible (2-5 min buffer) |
-| `high` | At risk due to delays (<2 min buffer) |
-| `missed` | Connection is no longer reachable |
+| `low` | Comfortable transfer time (more than 5 min), or no transfer at all |
+| `medium` | Tight but feasible (4-5 min) |
+| `high` | At risk due to delays (1-3 min) |
+| `missed` | Connection is no longer reachable (0 min or less) |
+
+The rating uses the gap between two **vehicles**, reported as `min_transfer_time` (`null` for a
+direct connection). A walk to the platform is not a transfer — it ends exactly when the
+connecting vehicle leaves, and rating it as one would mark every walk-in journey as `missed`.
 
 The `connection_feasible` attribute is `true` when all transfers can still be made, and `false` when any transfer is missed.
+
+## Walking Time
+
+The **walking time** option (**Configure** on the trip entry) is the time you need to reach the
+origin stop. It shifts the search and hides connections you could not reach in time, so a trip
+sensor with 10 minutes walking time never shows a connection leaving in 5 minutes.
 
 ## Example Automations
 

--- a/tests/test_trip.py
+++ b/tests/test_trip.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from custom_components.openpublictransport.trip import (
     _format_time,
@@ -175,6 +176,132 @@ def test_parse_journeys_platform_from_origin():
     ]
     result = _parse_journeys(journeys)
     assert result[0]["legs"][0]["platform"] == "3A"
+
+
+# ── _parse_journeys: walking legs are not transfers (issue #72) ───────────────
+
+def _hvv_walk_and_train(walk_start="23:07", walk_end="23:14", train_start="23:14", train_end="23:35"):
+    """The journey shape from issue #72: walk to the platform, then one S-Bahn.
+
+    HVV prepends a footpath for a station-to-station trip; it ends exactly when
+    the connecting train leaves, because the walk *is* the way to that platform.
+    """
+    day = "2026-08-01"
+    return {
+        "legs": [
+            {
+                "origin": {"name": "Hauptbahnhof/ZOB", "departureTimePlanned": f"{day}T{walk_start}:00+02:00"},
+                "destination": {"name": "Hamburg Hbf", "arrivalTimePlanned": f"{day}T{walk_end}:00+02:00"},
+                "transportation": {"product": {"class": 99, "name": "footpath"}},
+                "duration": 420,
+            },
+            {
+                "origin": {"name": "Hamburg Hbf", "departureTimePlanned": f"{day}T{train_start}:00+02:00"},
+                "destination": {"name": "Bergedorf", "arrivalTimePlanned": f"{day}T{train_end}:00+02:00"},
+                "transportation": {"number": "S2", "product": {"class": 1, "name": "S-Bahn"}},
+                "duration": 1260,
+            },
+        ],
+        "interchanges": 0,
+    }
+
+
+def test_parse_journeys_footpath_is_not_a_transfer():
+    """A walk to the platform must not be rated as a missed transfer (issue #72).
+
+    Before the fix every walk-in journey came out as connection_feasible=False /
+    transfer_risk='missed' / min_transfer_time=0, because the footpath leg was
+    fed into the transfer-gap loop.
+    """
+    result = _parse_journeys([_hvv_walk_and_train()])
+
+    assert len(result) == 1
+    assert result[0]["connection_feasible"] is True
+    assert result[0]["transfer_risk"] == "low"
+    assert result[0]["min_transfer_time"] is None  # no transfer at all
+    # The walk itself stays in the output — the traveller needs to see it
+    assert [leg["product"] for leg in result[0]["legs"]] == ["footpath", "S-Bahn"]
+
+
+def test_parse_journeys_footpath_detected_without_product_class():
+    """Providers that omit the product class are matched on the name."""
+    journey = _hvv_walk_and_train()
+    journey["legs"][0]["transportation"]["product"] = {"name": "Fußweg"}
+
+    result = _parse_journeys([journey])
+
+    assert result[0]["connection_feasible"] is True
+    assert result[0]["transfer_risk"] == "low"
+
+
+def test_parse_journeys_real_transfer_is_still_rated():
+    """Excluding walks must not stop actual vehicle-to-vehicle transfers being rated."""
+    journey = _hvv_walk_and_train()
+    journey["legs"].append(
+        {
+            "origin": {"name": "Bergedorf", "departureTimePlanned": "2026-08-01T23:37:00+02:00"},
+            "destination": {"name": "Lohbrügge", "arrivalTimePlanned": "2026-08-01T23:45:00+02:00"},
+            "transportation": {"number": "8", "product": {"class": 5, "name": "Bus"}},
+            "duration": 480,
+        }
+    )
+    journey["interchanges"] = 1
+
+    result = _parse_journeys([journey])
+
+    # 23:35 arrival → 23:37 departure = 2 min between the two vehicles
+    assert result[0]["min_transfer_time"] == 2
+    assert result[0]["transfer_risk"] == "high"
+    assert result[0]["connection_feasible"] is True
+
+
+def test_parse_journeys_transfer_across_midnight():
+    """A transfer past midnight is a positive gap, not a missed connection.
+
+    The old gap maths pinned both times to a fixed date, so 23:58 → 00:07 came
+    out as -1411 minutes and the journey was reported as missed.
+    """
+    journeys = [
+        {
+            "legs": [
+                {
+                    "origin": {"name": "A", "departureTimePlanned": "2026-08-01T23:30:00+02:00"},
+                    "destination": {"name": "B", "arrivalTimePlanned": "2026-08-01T23:58:00+02:00"},
+                    "transportation": {"number": "S1", "product": {"class": 1, "name": "S-Bahn"}},
+                    "duration": 1680,
+                },
+                {
+                    "origin": {"name": "B", "departureTimePlanned": "2026-08-02T00:07:00+02:00"},
+                    "destination": {"name": "C", "arrivalTimePlanned": "2026-08-02T00:20:00+02:00"},
+                    "transportation": {"number": "U1", "product": {"class": 2, "name": "U-Bahn"}},
+                    "duration": 780,
+                },
+            ],
+            "interchanges": 1,
+        }
+    ]
+
+    result = _parse_journeys(journeys)
+
+    assert result[0]["min_transfer_time"] == 9
+    assert result[0]["transfer_risk"] == "low"
+    assert result[0]["connection_feasible"] is True
+
+
+def test_parse_journeys_exposes_full_timestamps():
+    """Journeys carry full timestamps, so consumers can tell past from future."""
+    result = _parse_journeys([_hvv_walk_and_train()])
+
+    # Rendered in HA's local timezone, so compare instants rather than strings.
+    # Start of the journey = start of the walk, i.e. when to set off.
+    assert dt_util.parse_datetime(result[0]["departure_timestamp"]) == dt_util.parse_datetime(
+        "2026-08-01T23:07:00+02:00"
+    )
+    assert dt_util.parse_datetime(result[0]["arrival_timestamp"]) == dt_util.parse_datetime(
+        "2026-08-01T23:35:00+02:00"
+    )
+    # Internal gap-calculation keys must not leak into the attributes
+    assert not [key for leg in result[0]["legs"] for key in leg if key.startswith("_")]
 
 
 # ── _parse_otp_itineraries ────────────────────────────────────────────────────

--- a/tests/test_trip_sensor.py
+++ b/tests/test_trip_sensor.py
@@ -1,9 +1,11 @@
 """Tests for trip_sensor.py."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.openpublictransport.const import (
@@ -12,6 +14,7 @@ from custom_components.openpublictransport.const import (
     CONF_OTP_CUSTOM_API_KEY,
     CONF_SCAN_INTERVAL,
     CONF_VBN_API_KEY,
+    CONF_WALKING_TIME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -41,7 +44,7 @@ def _make_trip_coordinator(hass, provider="vrr"):
     )
 
 
-def _make_trip_entry(provider="vrr", is_trip=True, extra_data=None):
+def _make_trip_entry(provider="vrr", is_trip=True, extra_data=None, options=None):
     data = {
         CONF_TRIP_PROVIDER: provider,
         CONF_TRIP_ORIGIN: "Düsseldorf Hbf",
@@ -53,7 +56,7 @@ def _make_trip_entry(provider="vrr", is_trip=True, extra_data=None):
     }
     if extra_data:
         data.update(extra_data)
-    return MockConfigEntry(domain=DOMAIN, entry_id="trip_test", data=data)
+    return MockConfigEntry(domain=DOMAIN, entry_id="trip_test", data=data, options=options or {})
 
 
 # ── TripDataUpdateCoordinator ─────────────────────────────────────────────────
@@ -112,6 +115,88 @@ async def test_failed_lookup_does_not_stamp_a_success_time(hass: HomeAssistant):
 
     assert result is None
     assert coordinator.last_update_success_time is None
+
+
+# ── departed connections are dropped (issue #72) ──────────────────────────────
+
+def _journey_at(minutes_from_now, transfers=0):
+    """A journey departing `minutes_from_now` (negative = already gone)."""
+    departure = dt_util.now() + timedelta(minutes=minutes_from_now)
+    return {
+        "departure": departure.strftime("%H:%M"),
+        "arrival": (departure + timedelta(minutes=28)).strftime("%H:%M"),
+        "departure_timestamp": departure.isoformat(),
+        "arrival_timestamp": (departure + timedelta(minutes=28)).isoformat(),
+        "duration_minutes": 28,
+        "transfers": transfers,
+        "legs": [],
+    }
+
+
+async def test_coordinator_drops_already_departed_journeys(hass: HomeAssistant):
+    """Connections whose departure has passed never reach the sensor (issue #72).
+
+    EFA anchors the requested time on the first vehicle departure and back-dates
+    the walk to the platform, so its first journey is regularly already running.
+    """
+    coordinator = _make_trip_coordinator(hass)
+    journeys = [_journey_at(-8), _journey_at(-1), _journey_at(2), _journey_at(12)]
+
+    with patch(
+        "custom_components.openpublictransport.trip_sensor.async_plan_trip",
+        new_callable=AsyncMock, return_value=journeys,
+    ):
+        result = await coordinator._async_update_data()
+
+    assert [j["departure"] for j in result] == [journeys[2]["departure"], journeys[3]["departure"]]
+
+
+async def test_coordinator_keeps_journeys_without_timestamp(hass: HomeAssistant):
+    """A journey we cannot date is kept — better unrated than an empty sensor."""
+    coordinator = _make_trip_coordinator(hass)
+    journeys = [{"departure": "10:00", "arrival": "11:30", "duration_minutes": 90}]
+
+    with patch(
+        "custom_components.openpublictransport.trip_sensor.async_plan_trip",
+        new_callable=AsyncMock, return_value=journeys,
+    ):
+        result = await coordinator._async_update_data()
+
+    assert result == journeys
+
+
+async def test_walking_time_shifts_the_requested_departure(hass: HomeAssistant):
+    """With a walking time set, the query starts that many minutes from now.
+
+    The user in issue #72 raised the walking time to 30 min and nothing changed,
+    because the trip planner ignored the option entirely.
+    """
+    coordinator = _make_trip_coordinator(hass)
+    coordinator.walking_time = 30
+
+    with patch(
+        "custom_components.openpublictransport.trip_sensor.async_plan_trip",
+        new_callable=AsyncMock, return_value=[_journey_at(10), _journey_at(45)],
+    ) as mock_plan:
+        result = await coordinator._async_update_data()
+
+    requested = mock_plan.call_args.kwargs["departure_time"]
+    assert 29 <= (requested - dt_util.now()).total_seconds() / 60 <= 30
+    # A connection in 10 min is unreachable when the stop is a 30 min walk away
+    assert len(result) == 1
+
+
+async def test_without_walking_time_the_provider_keeps_its_own_clock(hass: HomeAssistant):
+    """No walking time → no pinned departure, so a live server anchors on now."""
+    coordinator = _make_trip_coordinator(hass)
+
+    with patch(
+        "custom_components.openpublictransport.trip_sensor.async_plan_trip",
+        new_callable=AsyncMock, return_value=[],
+    ) as mock_plan:
+        await coordinator._async_update_data()
+
+    assert mock_plan.call_args.kwargs["departure_time"] is None
 
 
 # ── async_setup_trip_entry ────────────────────────────────────────────────────
@@ -305,6 +390,51 @@ def test_trip_sensor_extra_attributes_multiple_journeys(hass: HomeAssistant):
     assert attrs["alternative_journeys"] == 2
     assert "next_journeys" in attrs
     assert len(attrs["next_journeys"]) == 2
+
+
+def test_trip_sensor_exposes_countdown_and_timestamps(hass: HomeAssistant):
+    """Attributes carry full timestamps and a countdown, for both best and alternatives.
+
+    A card can only tell a connection that is still ahead from one that has left
+    if it gets more than an HH:MM string (issue #72).
+    """
+    coordinator = _make_trip_coordinator(hass)
+    coordinator.data = [_journey_at(7), _journey_at(17)]
+    entry = _make_trip_entry()
+    sensor = TripSensor(coordinator, entry)
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["in_minutes"] == 6  # 6:5x remaining, truncated
+    assert dt_util.parse_datetime(attrs["departure_timestamp"]) is not None
+    assert dt_util.parse_datetime(attrs["arrival_timestamp"]) is not None
+    assert attrs["next_journeys"][0]["in_minutes"] == 16
+    assert attrs["next_journeys"][0]["departure_timestamp"] is not None
+
+
+def test_trip_sensor_countdown_is_none_without_timestamp(hass: HomeAssistant):
+    """A journey without a timestamp reports no countdown instead of guessing."""
+    coordinator = _make_trip_coordinator(hass)
+    coordinator.data = [{"departure": "10:00", "arrival": "11:30", "duration_minutes": 90, "transfers": 0}]
+    entry = _make_trip_entry()
+    sensor = TripSensor(coordinator, entry)
+
+    assert sensor.extra_state_attributes["in_minutes"] is None
+
+
+async def test_options_update_applies_walking_time_and_interval(hass: HomeAssistant):
+    """Changing the options takes effect without a restart (issue #72)."""
+    coordinator = _mock_trip_coordinator(data=[])
+    coordinator.async_request_refresh = AsyncMock()
+    entry = _make_trip_entry()
+    sensor = TripSensor(coordinator, entry)
+
+    updated_entry = _make_trip_entry(options={CONF_WALKING_TIME: 30, CONF_SCAN_INTERVAL: 300})
+
+    await sensor._async_update_listener(hass, updated_entry)
+
+    assert coordinator.walking_time == 30
+    assert coordinator.update_interval == timedelta(seconds=300)
+    coordinator.async_request_refresh.assert_awaited_once()
 
 
 # ── restore state across restart ──────────────────────────────────────────────


### PR DESCRIPTION
## What does this change?

Fixes #72 — the Trip Planner only ever showed connections that had already left, every one of them flagged `transfer_risk: missed`. Three separate causes, all reproduced against the live HVV EFA endpoint with the reporter's route:

- **The walk to the platform was rated like a transfer.** EFA prepends a footpath leg for station-to-station trips; it ends exactly when the connecting vehicle departs, so the gap is zero by definition. Every walk-in journey therefore came out as `connection_feasible: false` / `transfer_risk: missed` / `min_transfer_time: 0` — on every EFA provider, which is why the reporter saw identical behaviour on HVV, KVV and VRR. Only vehicle-to-vehicle transfers are rated now; walking legs stay in `legs` for display.
- **Departed connections stayed in the sensor.** EFA anchors the requested time on the first *vehicle* departure and back-dates the walk, so its first journey is regularly already running — that is what filled the state and detail view while the usable connections sat in `next_journeys`. They are dropped now.
- **Walking time was ignored by trip entries**, which is why the reporter's 30 minutes changed nothing. It now shifts the query and filters connections that cannot be reached in time. Trip entries also had no options-update listener, so a changed walking time or scan interval no longer needs a restart.

Also fixed: transfer gaps were computed from `HH:MM` strings pinned to a fixed date, so 23:58 → 00:07 came out as -1411 minutes and was reported as missed. They come from the full timestamps now.

New attributes `departure_timestamp`, `arrival_timestamp` and `in_minutes` — on the connection and on every `next_journeys` entry — because a bare `HH:MM` cannot tell a connection that is still ahead from one that has left. Purely additive; the card renders unchanged and stops showing "min 0 min" and the not-feasible warning on direct connections.

The three transfer-rating code paths (EFA, OTP REST, OTP2 GraphQL) now share one implementation, and a dead ms-collection loop in the OTP REST parser is gone. No change needed in `python-openpublictransport` — trip planning lives entirely in the integration.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] New provider
- [ ] Translation
- [x] Documentation
- [ ] Refactor / maintenance
- [ ] Breaking change

## How was it tested?

Against the **live HVV EFA endpoint** (`hvv.efa.de/efa/XML_TRIP_REQUEST2`) with the reporter's route, Hamburg Hauptbahnhof/ZOB (`de:02000:10002`) → Hamburg Bergedorf (`de:02000:25950`), which reproduces the report exactly. Same payload through the parser before and after:

```
before: 12:37 → 13:05  interchanges=0  feasible=False  risk=missed  min_transfer=0
after:  12:37 → 13:05  interchanges=0  feasible=True   risk=low     min_transfer=None
```

12 new unit tests: walk-is-not-a-transfer (with and without a product class), a real vehicle-to-vehicle transfer still being rated, transfer across midnight, the exposed timestamps, dropping departed connections, keeping undatable ones, the walking-time offset and filter, and the options listener. Full suite: 562 passed on Python 3.14.

Not yet exercised on a running Home Assistant instance — see the checklist below.

## Checklist

- [x] `pytest tests/ -v` passes — 562 passed
- [ ] `pre-commit run --all-files` passes — **it already fails on `origin/main`**: black would reformat 27 files, isort and flake8 fail, and mypy reports the same 7 errors in 5 files there as on this branch. This PR neither adds to nor fixes that. `black`, `flake8` and `mypy` are clean on the two modules it touches.
- [x] No API keys, tokens or personal stop data left in the diff
- [ ] Tested against a real Home Assistant instance, not only unit tests — verified against the live provider API and unit tests; a run on a real instance is still outstanding, and the reporter has been asked to confirm on their HVV/KVV/VRR entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)