### PR TITLE
chore(release): 2026.8.1

### DIFF
--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.8.0"
+  "version": "2026.8.1"
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## v2026.8.1 — Trip Planner: reachable connections, correct transfer rating
+
+Requires `python-openpublictransport` 0.1.16.
 
 ### Fixes
 


### PR DESCRIPTION
## What does this change?

Release prep for **v2026.8.1**: bumps `manifest.json` to `2026.8.1` and promotes the `Unreleased` changelog section to the released heading. Content of the release is #75 (fixes #72).

Library pin stays at `python-openpublictransport==0.1.16` — the Trip Planner fix is entirely in the integration, so no PyPI release is needed in this chain.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New provider
- [ ] Translation
- [x] Documentation
- [x] Refactor / maintenance
- [ ] Breaking change

## How was it tested?

Version-only change, no code paths touched. `manifest.json` stays valid JSON and is the single source of the version (`sensor.py` reads `INTEGRATION_VERSION` from it). Full suite still green: 562 passed.

## Checklist

- [x] `pytest tests/ -v` passes — 562 passed
- [ ] `pre-commit run --all-files` passes — pre-existing failure on `main`, unrelated to this diff (see #75)
- [x] No API keys, tokens or personal stop data left in the diff
- [x] Tested against a real Home Assistant instance, not only unit tests — n/a, version metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)