### PR TITLE
chore(release): 2026.8.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,17 @@ jobs:
           cd custom_components/openpublictransport
           zip -r ../../openpublictransport.zip .
 
+      # Immutable releases reject asset uploads after publication ("HTTP 422:
+      # Cannot upload assets to an immutable release"), so the zip has to be
+      # attached while the release is still a draft. When it already is, skip
+      # instead of failing the run.
       - name: Upload release asset
-        run: gh release upload "${{ github.event.release.tag_name }}" openpublictransport.zip
+        run: |
+          if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -qx openpublictransport.zip; then
+            echo "openpublictransport.zip is already attached to $TAG — nothing to upload."
+            exit 0
+          fi
+          gh release upload "$TAG" openpublictransport.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}

--- a/custom_components/openpublictransport/manifest.json
+++ b/custom_components/openpublictransport/manifest.json
@@ -18,5 +18,5 @@
     "aiofiles",
     "gtfs-realtime-bindings>=1.0.0"
   ],
-  "version": "2026.8.1"
+  "version": "2026.8.2"
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2026.8.1 — Trip Planner: reachable connections, correct transfer rating
+## v2026.8.2 — Trip Planner: reachable connections, correct transfer rating
 
 Requires `python-openpublictransport` 0.1.16.
 


### PR DESCRIPTION
## What does this change?

Release prep for **v2026.8.2**, containing the Trip Planner fixes from #75 (fixes #72). Bumps `manifest.json` and retitles the changelog section.

**Why 2026.8.2 and not 2026.8.1:** v2026.8.1 was published, but the release workflow could not attach `openpublictransport.zip` — immutable releases reject asset uploads after publication (`HTTP 422: Cannot upload assets to an immutable release`). Without that asset HACS cannot install the release. The tag name is unusable from then on: GitHub keeps a tag reserved once an immutable release has used it, even after the release and the tag ref are deleted. No 2026.8.1 artefact ever reached users, so the number is simply skipped.

This also makes the workflow's upload step idempotent, since the zip now has to be attached while the release is still a draft — otherwise the post-publish run fails on every future release.

Library pin stays at `python-openpublictransport==0.1.16`; no PyPI release in this chain.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New provider
- [ ] Translation
- [x] Documentation
- [x] Refactor / maintenance
- [ ] Breaking change

## How was it tested?

`release.yaml` parses as valid YAML with its three steps intact. The skip condition matches the asset name exactly (`grep -qx`), so a run whose asset is missing still uploads and a run whose asset is present exits 0 instead of failing. Version metadata is unchanged code-wise — `manifest.json` stays valid JSON and remains the single source of the version. Full suite: 562 passed.

## Checklist

- [x] `pytest tests/ -v` passes — 562 passed
- [ ] `pre-commit run --all-files` passes — pre-existing failure on `main`, unrelated to this diff (see #75)
- [x] No API keys, tokens or personal stop data left in the diff
- [x] Tested against a real Home Assistant instance, not only unit tests — n/a, version metadata and CI only

🤖 Generated with [Claude Code](https://claude.com/claude-code)