### PR TITLE
docs: turn the provider matrix into rows so all 38 are visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ All 18 tracked Bronze rules are done or exempt.
 
 ## Key Constraints / Do Not Break
 
-- **All 28 providers must keep working** — never remove a provider or change its
+- **All 38 providers must keep working** — never remove a provider or change its
   `provider_id` constant; existing config entries depend on these strings.
 - **Application Credentials integration** — API keys must stay in the AC store
   (`application_credentials.py`), not revert to `config_entry.data`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Real-time public transport departures for Home Assistant — 35 providers across
 
 ---
 
-## Supported Providers (35)
+## Supported Providers (38)
 
 | Provider | Region | API Key | Trip Planner |
 |----------|--------|---------|--------------|
@@ -37,17 +37,20 @@ Real-time public transport departures for Home Assistant — 35 providers across
 | **DING** | Ulm | No | Yes |
 | **Entur** | Norway (nationwide) | No | No |
 | **HVV** | Hamburg | No | Yes |
+| **HVV (Geofox GTI)** | Hamburg (official API) | Yes (free) | No |
 | **Irish Rail** | Ireland (nationwide) | No | No |
 | **KVV** | Karlsruhe | No | Yes |
 | **mobilitéit.lu** | Luxembourg (nationwide) | No | No |
 | **MVV** | Munich | No | Yes |
 | **NS** | Netherlands (nationwide) | No | No |
 | **NTA** | Ireland (nationwide) | Yes (free) | No |
+| **National Rail** | Great Britain (nationwide) | Yes (free) | No |
 | **NVBW** | Baden-Württemberg | No | No |
 | **NWL** | Westfalen-Lippe | No | Yes |
 | **ÖBB** | Austria (nationwide) | No | No |
 | **openpublictransport** | Germany (nationwide, GTFS.DE + GTFS-RT, community OTP2) | Yes ([request](https://openpublictransport.net/api-key)) | Yes |
 | **OTP2 Custom** | Any OTP2 instance (self-hosted) | Optional | Yes |
+| **Rejseplanen** | Denmark (nationwide) | Yes (free) | No |
 | **RMV** | Frankfurt / Rhein-Main | Yes (free) | No |
 | **RVV** | Regensburg | No | Yes |
 | **SBB** | Switzerland (nationwide) | No | No |

--- a/docs/providers/db.md
+++ b/docs/providers/db.md
@@ -1,0 +1,78 @@
+# DB (Deutsche Bahn)
+
+Nationwide departures for Germany, from long-distance ICE services down to local
+buses, through the community-run `v6.db.transport.rest` API.
+
+!!! note "Community proxy, not an official DB service"
+    `v6.db.transport.rest` is maintained by [derhuerst](https://github.com/derhuerst)
+    and is free and open, but it is not operated or supported by Deutsche Bahn.
+    Availability is not guaranteed — occasional downtime is normal. For a
+    nationwide provider with an availability promise, use
+    [openpublictransport](openpublictransport.md).
+
+## Coverage Area
+
+- All DB long-distance services (ICE, IC, EC)
+- Regional and suburban rail nationwide (RE, RB, S-Bahn)
+- Local transport wherever the underlying HAFAS data carries it (U-Bahn, tram, bus, ferry)
+
+## API Details
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | `https://v6.db.transport.rest` |
+| **API Type** | FPTF REST |
+| **API Key** | Not required |
+| **Timezone** | Europe/Berlin |
+
+## Transport Types
+
+DB uses FPTF (Friendly Public Transport Format) product types:
+
+| Product | Type | Description |
+|---------|------|-------------|
+| nationalExpress | train | ICE |
+| national | train | IC / EC |
+| regionalExpress | train | RE |
+| regional | train | RB |
+| suburban | train | S-Bahn |
+| subway | subway | U-Bahn |
+| tram | tram | Tram / Straßenbahn |
+| bus | bus | Bus services |
+| ferry | ferry | Ferry |
+| taxi | taxi | Rufbus / Anruf-Sammeltaxi |
+
+## Configuration
+
+### Setup Steps
+
+1. Select **DB** as provider
+2. Search for your stop (e.g., "Köln Hbf")
+3. Select the stop from the list
+4. Choose transport types and the number of departures
+
+### Example Stops
+
+- `Berlin Hbf`
+- `München Hbf`
+- `Hamburg Dammtor`
+- `Köln Messe/Deutz`
+
+## Special Features
+
+### Real-Time Data
+
+Departures carry the planned time plus the live estimate, so delays and platform
+changes come through the same as on the regional providers.
+
+### Notices
+
+Service messages are read from the FPTF `remarks` list — disruptions, cancellations
+and operator notes appear in the departure attributes.
+
+## Limitations
+
+- Trip planning is not available for this provider; use an EFA provider or
+  [openpublictransport](openpublictransport.md) for A-to-B routing.
+- The proxy applies its own rate limits. The integration's default scan interval of
+  60 seconds is well within them.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -1,92 +1,110 @@
 # Providers Overview
 
-The Public Transport Integration supports multiple transit providers across Europe, plus Norway and the USA. Each provider has its own API and data format, but the integration normalizes all data into a consistent format.
+The integration supports 38 transit providers across Europe and the USA. Each has its own API and data format; the integration normalizes all of them into the same entities and attributes.
 
 ## Provider Comparison
 
-| Feature | VRR | KVV | HVV | MVV | VVS | VGN | VAG Freiburg | BVG | RMV | VBN OTP | VBN TRIAS | VRN | VVO | DING | AVV | RVV | BSVG | NWL | NVBW | BEG | SBB | ÖBB | Trafiklab | NTA | Transitous | openpublictransport | OTP2 Custom |
-|---------|-----|-----|-----|-----|-----|-----|--------------|-----|-----|---------|-----------|-----|-----|------|-----|-----|------|-----|------|-----|-----|-----|-----------|-----|-----------|---------------------|-------------|
-| **Region** | NRW | Karlsruhe | Hamburg | Munich | Stuttgart | Nuremberg | Freiburg | Berlin | Frankfurt | Bremen/Niedersachsen | Bremen/Niedersachsen | Rhein-Neckar | Dresden | Ulm | Augsburg | Regensburg | Braunschweig | Westfalen-Lippe | Baden-Württemberg | Bayern | Switzerland | Austria | Sweden | Ireland | Worldwide | Germany (all) | Any OTP2 |
-| **API Type** | EFA | EFA | EFA | EFA | EFA | EFA | EFA | FPTF REST | HAFAS REST | OTP REST | TRIAS XML | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | EFA | REST | HAFAS Scotty | REST | GTFS-RT | MOTIS2 | OTP2 GraphQL | OTP2 GraphQL |
-| **API Key** | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | Yes (free) | No | No | No | No | No | No | No | No | No | No | No | Yes (free) | Yes (free) | No | Yes (free²) | Optional |
-| **Real-time Data** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available | Yes (GTFS-RT) | Depends on server |
-| **Delay Information** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | When available | Yes | Depends on server |
-| **Platform Info** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Limited | When available | No | No |
-| **Agency/Operator** | No | No | No | No | No | No | No | Yes | Yes | Yes | No | No | No | No | No | No | No | No | No | No | No | Yes | Yes | No | When available | No | No |
-| **Alerts/Notices** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | No | Yes | When available | No | No |
-| **Trip Planner** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | No | No | No | No | No | Yes | Yes |
-| **Stop Search** | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Geocoded¹ | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Autocomplete | Stop ID | Autocomplete | GraphQL + prefix | GraphQL + prefix |
+All 38 providers, one row each. The **ID** is what you pick in the config flow and
+what the `plan_trip` action expects.
+
+| Provider | ID | Region | API Type | API Key | Real-time | Platform | Alerts | Trip Planner | Stop Search |
+|----------|----|--------|----------|---------|-----------|----------|--------|--------------|-------------|
+| [VRR](vrr.md) | `vrr` | Rhein-Ruhr (NRW) | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [KVV](kvv.md) | `kvv` | Karlsruhe | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [HVV](hvv.md) | `hvv` | Hamburg | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [HVV Geofox GTI](hvv-gti.md) | `hvv_gti` | Hamburg (official API) | GTI (signed JSON) | Yes (free)³ | Yes (explicit delay) | Yes, incl. changes | Cancellations, attributes | No | Autocomplete |
+| [BVG](bvg.md) | `bvg` | Berlin / Brandenburg | FPTF REST | No | Yes | Yes | Yes | No | Autocomplete |
+| [MVV](mvv.md) | `mvv` | Munich | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [VVS](vvs.md) | `vvs` | Stuttgart | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [VGN](vgn.md) | `vgn` | Nuremberg | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [VAG](vagfr.md) | `vagfr` | Freiburg | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [RMV](rmv.md) | `rmv` | Frankfurt / Rhein-Main | HAFAS REST | Yes (free) | Yes | Yes | Yes | No | Autocomplete |
+| [VRN](vrn.md) | `vrn` | Rhein-Neckar | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [VVO](vvo.md) | `vvo` | Dresden | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [DING](ding.md) | `ding` | Ulm / Donau-Iller | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [AVV](avv.md) | `avv_augsburg` | Augsburg | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [RVV](rvv.md) | `rvv` | Regensburg | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [BSVG](bsvg.md) | `bsvg` | Braunschweig | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [NWL](nwl.md) | `nwl` | Westfalen-Lippe | EFA | No | Yes | Yes | Yes | Yes | Autocomplete |
+| [NVBW](nvbw.md) | `nvbw` | Baden-Württemberg | EFA | No | Yes | Yes | Yes | No | Autocomplete |
+| [BEG](beg.md) | `beg` | Bavaria | EFA | No | Yes | Yes | Yes | No | Autocomplete |
+| [DB](db.md) | `db` | Germany (nationwide) | FPTF REST | No | Yes | Yes | Yes | No | Autocomplete |
+| [VBN OTP](vbn.md) | `vbn_otp` | Bremen / Niedersachsen | OTP REST | Yes (free) | Yes | No | Yes | Yes | Geocoded¹ |
+| [VBN TRIAS](vbn.md) | `vbn_trias` | Bremen / Niedersachsen | TRIAS XML | Yes (free) | Yes | Yes | No | No | Autocomplete |
+| [openpublictransport](openpublictransport.md) | `openpublictransport` | Germany (nationwide) | OTP2 GraphQL | Yes (free)² | Yes (GTFS-RT) | No | No | Yes | GraphQL + prefix |
+| [SBB](sbb.md) | `sbb` | Switzerland | REST | No | Yes | Yes | No | No | Autocomplete |
+| [TPG](tpg.md) | `tpg_ch` | Geneva | HAFAS mgate | No | Yes | Yes | Cancellations | No | Autocomplete |
+| [ÖBB](oebb.md) | `oebb` | Austria | HAFAS Scotty | No | Yes | Yes | Yes (HIM) | No | Autocomplete |
+| [NS](ns.md) | `ns_nl` | Netherlands | HAFAS Scotty | No | Yes | Yes | Yes (HIM) | No | Autocomplete |
+| [mobilitéit.lu](mobiliteit_lu.md) | `mobiliteit_lu` | Luxembourg | HAFAS Scotty | No | Yes | Yes | Yes (HIM) | No | Autocomplete |
+| [Rejseplanen](rejseplanen.md) | `rejseplanen` | Denmark | HAFAS REST | Yes (free) | Yes | Yes, incl. changes | Cancellations | No | Autocomplete |
+| [Entur](entur.md) | `entur_no` | Norway | OTP transmodel GraphQL | No | Yes | Yes (quay) | Cancellations | No | Geocoder |
+| [Trafiklab](trafiklab.md) | `trafiklab_se` | Sweden | REST | Yes (free) | Yes | Yes | No | No | Autocomplete |
+| [NTA](nta.md) | `nta_ie` | Ireland | GTFS-RT | Yes (free) | Yes | Limited | Yes | No | Stop ID |
+| [Irish Rail](irishrail.md) | `irishrail_ie` | Ireland | HAFAS mgate | No | Yes | Yes | Cancellations | No | Autocomplete |
+| [National Rail](national_rail.md) | `national_rail` | Great Britain | OpenLDBWS (SOAP) | Yes (free) | Yes | Yes | Cancellations + reasons | No | Autocomplete |
+| [BART](bart.md) | `bart_us` | San Francisco, USA | HAFAS mgate | No | Yes | Yes | Cancellations | No | Autocomplete |
+| [DART](dart.md) | `dart_us` | Des Moines, USA | HAFAS mgate | No | Yes | Limited | Cancellations | No | Autocomplete |
+| [Transitous](transitous.md) | `transitous` | Worldwide | MOTIS2 | No | When available | When available | When available | No | Autocomplete |
+| [OTP2 Custom](otp-custom.md) | `otp_custom` | Any OTP2 instance | OTP2 GraphQL | Optional | Depends on server | No | No | Yes | GraphQL + prefix |
+
+Delay information is available wherever real-time data is — the two always come from the same
+response, so there is no separate column. Agency/operator names are exposed by BVG, RMV, VBN OTP,
+ÖBB and Trafiklab; the EFA providers do not report them.
 
 ¹ VBN OTP has no native name-based stop search. The integration geocodes your search term via Nominatim (OpenStreetMap) and finds stops within 500 m of the resolved coordinates.
 
 ² API key for the community server is free — [request it here](https://openpublictransport.net/api-key).
 
-### Providers added in 0.1.14
-
-These use the HAFAS "Scotty", HAFAS `mgate.exe`, or Entur transmodel interfaces. None require an API key.
-
-| Provider | Region | API Type | Real-time | Platform | Notices | Stop Search |
-|----------|--------|----------|-----------|----------|---------|-------------|
-| **NS** | Netherlands | HAFAS Scotty | Yes | Yes | Yes (HIM) | Autocomplete |
-| **mobilitéit.lu** | Luxembourg | HAFAS Scotty | Yes | Yes | Yes (HIM) | Autocomplete |
-| **Entur** | Norway | OTP transmodel GraphQL | Yes | Yes (quay) | Cancellations | Geocoder |
-| **BART** | San Francisco, USA | HAFAS mgate | Yes | Yes | Cancellations | Autocomplete |
-| **DART** | Des Moines, USA | HAFAS mgate | Yes | Limited | Cancellations | Autocomplete |
-| **Irish Rail** | Ireland | HAFAS mgate | Yes | Yes | Cancellations | Autocomplete |
-| **TPG** | Geneva, Switzerland | HAFAS mgate | Yes | Yes | Cancellations | Autocomplete |
-
-### Providers added in 0.1.16
-
-| Provider | Region | API Type | Real-time | Platform | Notices | Stop Search |
-|----------|--------|----------|-----------|----------|---------|-------------|
-| **[HVV Geofox GTI](hvv-gti.md)** | Hamburg, Germany | GTI (HMAC-signed JSON) | Yes (explicit delay) | Yes, incl. changes | Cancellations, attributes | Autocomplete |
-
-HOCHBAHN's official API on behalf of the HVV. Free credentials, requested by email at
-api@hochbahn.de. It exposes delays, cancellations and platform changes that the keyless
-[HVV](hvv.md) EFA provider does not — both providers remain available.
-Trip planning is not supported on GTI yet; use the EFA `hvv` provider for trip entries.
+³ HVV Geofox GTI is HOCHBAHN's official API on behalf of the HVV. Credentials are free and
+requested by email at api@hochbahn.de. It exposes delays, cancellations and platform changes that
+the keyless [HVV](hvv.md) EFA provider does not — both providers stay available, and trip planning
+runs through the EFA `hvv` provider.
 
 ## Timezone Handling
 
 Each provider uses its local timezone for departure times:
 
-| Provider | Timezone |
-|----------|----------|
-| VRR | Europe/Berlin |
-| KVV | Europe/Berlin |
-| HVV | Europe/Berlin |
-| HVV Geofox GTI | Europe/Berlin |
-| MVV | Europe/Berlin |
-| VVS | Europe/Berlin |
-| VGN | Europe/Berlin |
-| VAG Freiburg | Europe/Berlin |
-| BVG | Europe/Berlin |
-| RMV | Europe/Berlin |
-| VBN OTP | Europe/Berlin |
-| VBN TRIAS | Europe/Berlin |
-| VRN | Europe/Berlin |
-| VVO | Europe/Berlin |
-| DING | Europe/Berlin |
-| AVV | Europe/Berlin |
-| RVV | Europe/Berlin |
-| BSVG | Europe/Berlin |
-| NWL | Europe/Berlin |
-| NVBW | Europe/Berlin |
-| BEG | Europe/Berlin |
-| SBB | Europe/Zurich |
-| TPG | Europe/Zurich |
-| ÖBB | Europe/Vienna |
-| NS | Europe/Amsterdam |
-| mobilitéit.lu | Europe/Luxembourg |
-| Entur | Europe/Oslo |
-| Irish Rail | Europe/Dublin |
-| BART | America/Los_Angeles |
-| DART | America/Chicago |
-| Trafiklab | Europe/Stockholm |
-| NTA | Europe/Dublin |
-| Transitous | Per-stop (automatic) |
-| openpublictransport | Europe/Berlin |
-| OTP2 Custom | Europe/Berlin (or per OTP2 config) |
+| Provider | ID | Timezone |
+|----------|----|----------|
+| VRR | `vrr` | Europe/Berlin |
+| KVV | `kvv` | Europe/Berlin |
+| HVV | `hvv` | Europe/Berlin |
+| HVV Geofox GTI | `hvv_gti` | Europe/Berlin |
+| BVG | `bvg` | Europe/Berlin |
+| MVV | `mvv` | Europe/Berlin |
+| VVS | `vvs` | Europe/Berlin |
+| VGN | `vgn` | Europe/Berlin |
+| VAG | `vagfr` | Europe/Berlin |
+| RMV | `rmv` | Europe/Berlin |
+| VRN | `vrn` | Europe/Berlin |
+| VVO | `vvo` | Europe/Berlin |
+| DING | `ding` | Europe/Berlin |
+| AVV | `avv_augsburg` | Europe/Berlin |
+| RVV | `rvv` | Europe/Berlin |
+| BSVG | `bsvg` | Europe/Berlin |
+| NWL | `nwl` | Europe/Berlin |
+| NVBW | `nvbw` | Europe/Berlin |
+| BEG | `beg` | Europe/Berlin |
+| DB | `db` | Europe/Berlin |
+| VBN OTP | `vbn_otp` | Europe/Berlin |
+| VBN TRIAS | `vbn_trias` | Europe/Berlin |
+| openpublictransport | `openpublictransport` | Europe/Berlin |
+| SBB | `sbb` | Europe/Zurich |
+| TPG | `tpg_ch` | Europe/Zurich |
+| ÖBB | `oebb` | Europe/Vienna |
+| NS | `ns_nl` | Europe/Amsterdam |
+| mobilitéit.lu | `mobiliteit_lu` | Europe/Luxembourg |
+| Rejseplanen | `rejseplanen` | Europe/Copenhagen |
+| Entur | `entur_no` | Europe/Oslo |
+| Trafiklab | `trafiklab_se` | Europe/Stockholm |
+| NTA | `nta_ie` | Europe/Dublin |
+| Irish Rail | `irishrail_ie` | Europe/Dublin |
+| National Rail | `national_rail` | Europe/London |
+| BART | `bart_us` | America/Los_Angeles |
+| DART | `dart_us` | America/Chicago |
+| Transitous | `transitous` | Per-stop (automatic) |
+| OTP2 Custom | `otp_custom` | Europe/Berlin (or per OTP2 config) |
 
 ## Transport Type Mapping
 

--- a/docs/providers/rejseplanen.md
+++ b/docs/providers/rejseplanen.md
@@ -1,0 +1,81 @@
+# Rejseplanen (Denmark)
+
+Rejseplanen is the national journey planner for Denmark. It covers every operator
+in the country — DSB, Arriva, the Copenhagen Metro, regional buses and ferries —
+through a HAFAS REST API.
+
+## Coverage Area
+
+- All of Denmark, nationwide
+- National and regional rail (DSB, Arriva)
+- Copenhagen Metro and S-tog
+- Regional and city buses
+- Domestic ferries
+
+## API Details
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | `https://www.rejseplanen.dk/api` |
+| **API Type** | HAFAS REST |
+| **API Key** | Required (free) |
+| **Timezone** | Europe/Copenhagen |
+
+## Getting an API Key
+
+1. Register at [labs.rejseplanen.dk](https://labs.rejseplanen.dk/).
+2. Request access to the Rejseplanen API.
+3. You receive an access ID, which the integration sends as `accessId`.
+
+The free tier allows **50,000 calls per month** and is limited to non-commercial
+use. At the default scan interval of 60 seconds, one departure sensor uses roughly
+44,000 calls per month — so plan on one sensor per key, or raise the scan interval
+when you configure several.
+
+## Transport Types
+
+Rejseplanen reports the product category (`catOut`), which maps as follows:
+
+| Category | Type | Description |
+|----------|------|-------------|
+| IC, LYN | train | InterCity and InterCityLyn long-distance trains |
+| RE, REG, TOG | train | Regional trains |
+| S | train | S-tog (Copenhagen suburban rail) |
+| M | subway | Copenhagen Metro |
+| BUS, EXB, NB, TB | bus | City, express, night and rail-replacement buses |
+| T | tram | Aarhus and Odense light rail |
+| F | ferry | Ferries |
+
+## Configuration
+
+### Setup Steps
+
+1. Select **Rejseplanen** as provider
+2. Enter your API key
+3. Search for your stop (e.g., "København H")
+4. Select the stop from the list
+5. Choose transport types and the number of departures
+
+### Example Stops
+
+- `København H`
+- `Aarhus H`
+- `Odense St.`
+- `Nørreport St.`
+
+## Special Features
+
+### Real-Time Data
+
+Departures carry both the planned and the live time, so delays show up directly.
+Platform changes are detected by comparing the real-time track against the
+scheduled one.
+
+### Cancellations
+
+Cancelled departures are flagged and reported in the departure attributes.
+
+## Limitations
+
+- Trip planning is not available for this provider.
+- The API key is personal — keep it out of shared dashboards and screenshots.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: openpublictransport
-site_description: Multi-Provider Public Transport Home Assistant Integration for 28 transit networks across Germany, Switzerland, Austria, Sweden, Ireland, and worldwide
+site_description: Home Assistant integration for real-time public transport departures from 38 transit networks across Germany, Switzerland, Austria, the Netherlands, Luxembourg, Denmark, Norway, Sweden, Ireland, the UK, the USA, and worldwide
 site_url: https://docs.openpublictransport.net
 repo_url: https://github.com/NerdySoftPaw/openpublictransport
 repo_name: NerdySoftPaw/openpublictransport
@@ -76,11 +76,14 @@ nav:
       - NWL (Westfalen-Lippe): providers/nwl.md
       - NVBW (Baden-Württemberg): providers/nvbw.md
       - BEG (Bayern): providers/beg.md
+      - DB (Deutschlandweit): providers/db.md
+      - VBN (Bremen / Niedersachsen): providers/vbn.md
       - SBB (Schweiz): providers/sbb.md
       - TPG (Genève): providers/tpg.md
       - ÖBB (Österreich): providers/oebb.md
       - NS (Nederland): providers/ns.md
       - mobilitéit.lu (Luxembourg): providers/mobiliteit_lu.md
+      - Rejseplanen (Danmark): providers/rejseplanen.md
       - Entur (Norway): providers/entur.md
       - Trafiklab (Sweden): providers/trafiklab.md
       - NTA (Ireland): providers/nta.md

--- a/tests/test_docs_providers.py
+++ b/tests/test_docs_providers.py
@@ -1,0 +1,117 @@
+"""The provider docs must describe exactly what the code ships.
+
+`docs/providers/index.md` carries the provider comparison and the timezone
+table. Both drifted before — the comparison showed providers as columns and
+stopped at 35 of 38, and `db`, `rejseplanen` and `national_rail` appeared
+nowhere on the page at all. These tests pin the four columns that have a source
+of truth in code; the rest (platform info, alerts, stop search style) is a
+documentation claim with nothing to check it against.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+from openpublictransport.providers import get_provider_class
+
+from custom_components.openpublictransport.const import PROVIDERS
+from custom_components.openpublictransport.trip import TRIP_CAPABLE_PROVIDERS
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_PROVIDERS = REPO_ROOT / "docs" / "providers"
+INDEX = DOCS_PROVIDERS / "index.md"
+MKDOCS = REPO_ROOT / "mkdocs.yml"
+
+# Row shape: | [Name](page.md) | `id` | Region | API Type | API Key | Real-time | … |
+_MATRIX_ROW = re.compile(r"^\| \[([^\]]+)\]\(([^)]+)\) \| `([a-z0-9_]+)` \|(.+)\|\s*$", re.M)
+# Row shape: | Name | `id` | Timezone |
+_TIMEZONE_ROW = re.compile(r"^\| ([^|]+?) \| `([a-z0-9_]+)` \| ([^|]+?) \|\s*$", re.M)
+
+# Documented values the code cannot express.
+#   otp_custom: the class reports no key requirement, but a self-hosted instance
+#   may well be protected — the docs say "Optional" on purpose.
+API_KEY_EXCEPTIONS = {"otp_custom": "Optional"}
+#   These two have no single fixed zone.
+TIMEZONE_EXCEPTIONS = {
+    "transitous": "Per-stop (automatic)",
+    "otp_custom": "Europe/Berlin (or per OTP2 config)",
+}
+
+
+def _matrix_rows():
+    """Return {provider_id: (name, page, [cells…])} from the comparison table."""
+    rows = {}
+    for name, page, provider_id, rest in _MATRIX_ROW.findall(INDEX.read_text(encoding="utf-8")):
+        rows[provider_id] = (name, page, [cell.strip() for cell in rest.split("|")])
+    return rows
+
+
+def _timezone_rows():
+    """Return {provider_id: timezone} from the timezone table."""
+    section = INDEX.read_text(encoding="utf-8").split("## Timezone Handling", 1)[1]
+    section = section.split("## Transport Type Mapping", 1)[0]
+    return {provider_id: tz.strip() for _, provider_id, tz in _TIMEZONE_ROW.findall(section)}
+
+
+def test_comparison_lists_every_provider():
+    assert set(_matrix_rows()) == set(PROVIDERS)
+
+
+def test_timezone_table_lists_every_provider():
+    assert set(_timezone_rows()) == set(PROVIDERS)
+
+
+def test_api_key_column_matches_the_providers():
+    """"Yes" in the docs must mean the provider class demands a key."""
+    mismatches = []
+    for provider_id, (_, _, cells) in _matrix_rows().items():
+        documented = cells[2]
+        if API_KEY_EXCEPTIONS.get(provider_id) == documented:
+            continue
+        required = get_provider_class(provider_id)(None).requires_api_key
+        if documented.startswith("Yes") is not required:
+            mismatches.append(f"{provider_id}: docs say {documented!r}, code says {required}")
+    assert not mismatches, mismatches
+
+
+def test_trip_planner_column_matches_the_capability_set():
+    documented = {pid for pid, (_, _, cells) in _matrix_rows().items() if cells[6] == "Yes"}
+    assert documented == set(TRIP_CAPABLE_PROVIDERS)
+
+
+def test_timezones_match_the_providers():
+    mismatches = []
+    for provider_id, documented in _timezone_rows().items():
+        if TIMEZONE_EXCEPTIONS.get(provider_id) == documented:
+            continue
+        actual = get_provider_class(provider_id)(None).get_timezone()
+        if documented != actual:
+            mismatches.append(f"{provider_id}: docs say {documented!r}, code says {actual!r}")
+    assert not mismatches, mismatches
+
+
+def test_every_provider_links_to_an_existing_page():
+    missing = [
+        f"{provider_id} -> {page}"
+        for provider_id, (_, page, _) in _matrix_rows().items()
+        if not (DOCS_PROVIDERS / page).is_file()
+    ]
+    assert not missing, missing
+
+
+def test_every_provider_page_is_in_the_nav():
+    """An unreferenced page still builds, just unreachable — catches orphans."""
+    # mkdocs.yml uses !!python/name: tags for some extensions; ignore what we can't load.
+    nav_text = MKDOCS.read_text(encoding="utf-8")
+    referenced = set(re.findall(r"providers/([a-z0-9_-]+\.md)", nav_text)) - {"index.md"}
+    on_disk = {path.name for path in DOCS_PROVIDERS.glob("*.md")} - {"index.md"}
+    assert on_disk - referenced == set(), sorted(on_disk - referenced)
+    assert referenced - on_disk == set(), sorted(referenced - on_disk)
+
+
+def test_nav_is_valid_yaml():
+    """Guard against a broken nav block after hand-editing."""
+    text = MKDOCS.read_text(encoding="utf-8")
+    text = re.sub(r"!!python/name:\S+", "null", text)
+    config = yaml.safe_load(text)
+    assert any("Providers" in entry for entry in config["nav"] if isinstance(entry, dict))


### PR DESCRIPTION
The comparison table in `docs/providers/index.md` had providers as **columns** — 27 of them — plus two "Providers added in 0.1.14 / 0.1.16" tables carrying another 8. That is 35 of 38, and `db`, `rejseplanen` and `national_rail` appeared nowhere on the page, not even in prose. Adding eleven more columns was not an option: the table already only worked by scrolling sideways.

## The table

One table, one row per provider:

```
| Provider | ID | Region | API Type | API Key | Real-time | Platform | Alerts | Trip Planner | Stop Search |
```

- The provider name links to its detail page — previously exactly **one** row on the whole page was a link.
- The **ID** column is the string users pick in the config flow and pass to `plan_trip`, and it is what the new test parses (same shape as the tables in `docs/trip-planner.md`).
- Delay information lost its column: it was identical to real-time in all 27 rows and now says so in one sentence. Agency/operator moved to the same sentence — only five providers report it.
- The two "providers added in …" sections are gone; their rows and the HVV Geofox GTI prose live with the table now.

## Also in this PR

- **Timezone table** covers all 38 and carries IDs (was 35 rows, name-only).
- **New pages** `docs/providers/db.md` and `docs/providers/rejseplanen.md` — the only two providers without one.
- **`docs/providers/vbn.md` is in the nav.** It existed but was referenced nowhere, so it built as an orphan page.
- **Stale counts**: `mkdocs.yml` said 28 providers, `README.md` said 35 (and was missing HVV Geofox GTI, National Rail and Rejseplanen), `CLAUDE.md` said "All 28 providers must keep working".

## Keeping it honest

`tests/test_docs_providers.py` pins the four columns that have a source of truth in code:

| Docs | Code |
|---|---|
| ID column | `const.PROVIDERS` |
| API Key column | `provider_class(None).requires_api_key` |
| Trip Planner column | `trip.TRIP_CAPABLE_PROVIDERS` |
| Timezone table | `provider_class(None).get_timezone()` |

Plus: every linked page exists, and every page on disk is reachable from the nav. Two documented values are exempt on purpose — `otp_custom`'s "Optional" key (the class reports `False`, but a self-hosted instance may well be protected) and the two providers without a fixed timezone.

Verified by breaking two cells on purpose: the API-key and timezone tests failed, then passed again after reverting. The remaining columns (platform, alerts, stop-search style, API type) have nothing in code to check against — noted in the test's docstring rather than faked.

`pytest tests/ -v` → 583 passed. `mkdocs build --strict` → clean, and the orphan warning for `vbn.md` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)