### PR TITLE
docs: give the provider table the room it needs on desktop

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # Providers Overview
 
 The integration supports 38 transit providers across Europe and the USA. Each has its own API and data format; the integration normalizes all of them into the same entities and attributes.
@@ -8,7 +13,7 @@ All 38 providers, one row each. The code below each name is the provider ID — 
 pick in the config flow and what the `plan_trip` action expects.
 
 | Provider | Region | API | Key | RT | Platform | Alerts | Trip | Search |
-|----------|--------|-----|-----|----|----------|--------|------|--------|
+|----------|--------|-----|-----|:--:|:--------:|:------:|:----:|:------:|
 | [VRR](vrr.md)<br>`vrr` | Rhein-Ruhr | EFA | – | ✅ | ✅ | ✅ | ✅ | Auto |
 | [KVV](kvv.md)<br>`kvv` | Karlsruhe | EFA | – | ✅ | ✅ | ✅ | ✅ | Auto |
 | [HVV](hvv.md)<br>`hvv` | Hamburg | EFA | – | ✅ | ✅ | ✅ | ✅ | Auto |

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -115,3 +115,25 @@
   height: 28px;
   width: 28px;
 }
+
+/* ===================== TABLES ===================== */
+/* The provider comparison is nine columns wide. Material's default content
+   column (61rem, shared with the table of contents) plus the theme's generous
+   cell padding pushed it into horizontal scrolling even on a desktop. */
+.md-grid {
+  max-width: 78rem;
+}
+
+.md-typeset table:not([class]) {
+  font-size: 0.68rem;
+}
+
+.md-typeset table:not([class]) th,
+.md-typeset table:not([class]) td {
+  padding: 0.35em 0.5em;
+}
+
+/* Provider IDs and other inline code must not wrap mid-token. */
+.md-typeset table:not([class]) code {
+  white-space: nowrap;
+}


### PR DESCRIPTION
Follow-up to #85 — that PR was merged while this last commit was still in flight, so the table on `main` is compact but still runs off the right edge.

Shorter cells were not the whole story. On a 1280 px window Material spends ~250 px on the left nav and ~210 px on the table of contents, leaving the table about **765 px**. Nine columns do not fit that no matter how short the text is.

- **`hide: toc` on the providers overview.** It is the one page whose value *is* the table, and the left nav still lists every provider.
- Content grid widened to 78rem, table font to 0.68rem, cell padding from 0.6em/0.8em down to 0.35em/0.5em.
- Symbol columns centred through the markdown alignment row.

Verified against a real render — headless Chrome against the built site, not by eye: all nine columns visible at 1280 px, and at 1100 px, where the left nav collapses, with room to spare.

`pytest tests/test_docs_providers.py` → 8 passed. `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)